### PR TITLE
feat: add ui tokens package

### DIFF
--- a/packages/ui-tokens/dist/ThemeProvider.d.ts
+++ b/packages/ui-tokens/dist/ThemeProvider.d.ts
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+import { Colors } from './colors';
+import { Spacing } from './spacing';
+import { Typography } from './typography';
+export type Theme = {
+    colors: Colors;
+    spacing: Spacing;
+    typography: Typography;
+};
+export type ThemeProviderProps = {
+    children: ReactNode;
+    mode?: 'light' | 'dark';
+};
+export declare const ThemeProvider: ({ children, mode }: ThemeProviderProps) => any;
+export declare const useTheme: () => any;

--- a/packages/ui-tokens/dist/ThemeProvider.js
+++ b/packages/ui-tokens/dist/ThemeProvider.js
@@ -1,0 +1,56 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.useTheme = exports.ThemeProvider = void 0;
+const react_1 = __importStar(require("react"));
+const colors_1 = require("./colors");
+const spacing_1 = require("./spacing");
+const typography_1 = require("./typography");
+const ThemeContext = (0, react_1.createContext)({
+    colors: colors_1.lightColors,
+    spacing: spacing_1.spacing,
+    typography: typography_1.typography,
+});
+const ThemeProvider = ({ children, mode = 'light' }) => {
+    const value = {
+        colors: mode === 'light' ? colors_1.lightColors : colors_1.darkColors,
+        spacing: spacing_1.spacing,
+        typography: typography_1.typography,
+    };
+    return react_1.default.createElement(ThemeContext.Provider, { value: value }, children);
+};
+exports.ThemeProvider = ThemeProvider;
+const useTheme = () => (0, react_1.useContext)(ThemeContext);
+exports.useTheme = useTheme;

--- a/packages/ui-tokens/dist/ThemedText.d.ts
+++ b/packages/ui-tokens/dist/ThemedText.d.ts
@@ -1,0 +1,3 @@
+import React from 'react';
+import { TextProps } from 'react-native';
+export declare const ThemedText: React.FC<TextProps>;

--- a/packages/ui-tokens/dist/ThemedText.js
+++ b/packages/ui-tokens/dist/ThemedText.js
@@ -1,0 +1,14 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ThemedText = void 0;
+const react_1 = __importDefault(require("react"));
+const react_native_1 = require("react-native");
+const ThemeProvider_1 = require("./ThemeProvider");
+const ThemedText = ({ style, ...rest }) => {
+    const { colors, typography } = (0, ThemeProvider_1.useTheme)();
+    return (react_1.default.createElement(react_native_1.Text, { ...rest, style: [{ color: colors.text, fontSize: typography.fontSize.md }, style] }));
+};
+exports.ThemedText = ThemedText;

--- a/packages/ui-tokens/dist/colors.d.ts
+++ b/packages/ui-tokens/dist/colors.d.ts
@@ -1,0 +1,13 @@
+export declare const lightColors: {
+    background: string;
+    text: string;
+    primary: string;
+    secondary: string;
+};
+export declare const darkColors: {
+    background: string;
+    text: string;
+    primary: string;
+    secondary: string;
+};
+export type Colors = typeof lightColors;

--- a/packages/ui-tokens/dist/colors.js
+++ b/packages/ui-tokens/dist/colors.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.darkColors = exports.lightColors = void 0;
+exports.lightColors = {
+    background: '#FFFFFF',
+    text: '#000000',
+    primary: '#1E90FF',
+    secondary: '#FF4081',
+};
+exports.darkColors = {
+    background: '#000000',
+    text: '#FFFFFF',
+    primary: '#1E90FF',
+    secondary: '#FF4081',
+};

--- a/packages/ui-tokens/dist/index.d.ts
+++ b/packages/ui-tokens/dist/index.d.ts
@@ -1,0 +1,5 @@
+export * from './colors';
+export * from './spacing';
+export * from './typography';
+export { ThemeProvider, useTheme } from './ThemeProvider';
+export { ThemedText } from './ThemedText';

--- a/packages/ui-tokens/dist/index.js
+++ b/packages/ui-tokens/dist/index.js
@@ -1,0 +1,25 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ThemedText = exports.useTheme = exports.ThemeProvider = void 0;
+__exportStar(require("./colors"), exports);
+__exportStar(require("./spacing"), exports);
+__exportStar(require("./typography"), exports);
+var ThemeProvider_1 = require("./ThemeProvider");
+Object.defineProperty(exports, "ThemeProvider", { enumerable: true, get: function () { return ThemeProvider_1.ThemeProvider; } });
+Object.defineProperty(exports, "useTheme", { enumerable: true, get: function () { return ThemeProvider_1.useTheme; } });
+var ThemedText_1 = require("./ThemedText");
+Object.defineProperty(exports, "ThemedText", { enumerable: true, get: function () { return ThemedText_1.ThemedText; } });

--- a/packages/ui-tokens/dist/spacing.d.ts
+++ b/packages/ui-tokens/dist/spacing.d.ts
@@ -1,0 +1,8 @@
+export declare const spacing: {
+    xs: number;
+    sm: number;
+    md: number;
+    lg: number;
+    xl: number;
+};
+export type Spacing = typeof spacing;

--- a/packages/ui-tokens/dist/spacing.js
+++ b/packages/ui-tokens/dist/spacing.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.spacing = void 0;
+exports.spacing = {
+    xs: 4,
+    sm: 8,
+    md: 16,
+    lg: 24,
+    xl: 32,
+};

--- a/packages/ui-tokens/dist/typography.d.ts
+++ b/packages/ui-tokens/dist/typography.d.ts
@@ -1,0 +1,16 @@
+export declare const typography: {
+    fontFamily: string;
+    fontSize: {
+        xs: number;
+        sm: number;
+        md: number;
+        lg: number;
+        xl: number;
+    };
+    fontWeight: {
+        regular: string;
+        medium: string;
+        bold: string;
+    };
+};
+export type Typography = typeof typography;

--- a/packages/ui-tokens/dist/typography.js
+++ b/packages/ui-tokens/dist/typography.js
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.typography = void 0;
+exports.typography = {
+    fontFamily: 'System',
+    fontSize: {
+        xs: 12,
+        sm: 14,
+        md: 16,
+        lg: 20,
+        xl: 24,
+    },
+    fontWeight: {
+        regular: '400',
+        medium: '500',
+        bold: '700',
+    },
+};

--- a/packages/ui-tokens/package.json
+++ b/packages/ui-tokens/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@mchat/ui-tokens",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-native": "^0.73.0"
+  }
+}

--- a/packages/ui-tokens/src/ThemeProvider.tsx
+++ b/packages/ui-tokens/src/ThemeProvider.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, ReactNode } from 'react';
+import { lightColors, darkColors, Colors } from './colors';
+import { spacing, Spacing } from './spacing';
+import { typography, Typography } from './typography';
+
+export type Theme = {
+  colors: Colors;
+  spacing: Spacing;
+  typography: Typography;
+};
+
+const ThemeContext = createContext<Theme>({
+  colors: lightColors,
+  spacing,
+  typography,
+});
+
+export type ThemeProviderProps = {
+  children: ReactNode;
+  mode?: 'light' | 'dark';
+};
+
+export const ThemeProvider = ({ children, mode = 'light' }: ThemeProviderProps) => {
+  const value: Theme = {
+    colors: mode === 'light' ? lightColors : darkColors,
+    spacing,
+    typography,
+  };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/packages/ui-tokens/src/ThemedText.tsx
+++ b/packages/ui-tokens/src/ThemedText.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Text, TextProps } from 'react-native';
+import { useTheme } from './ThemeProvider';
+
+export const ThemedText: React.FC<TextProps> = ({ style, ...rest }) => {
+  const { colors, typography } = useTheme();
+  return (
+    <Text
+      {...rest}
+      style={[{ color: colors.text, fontSize: typography.fontSize.md }, style]}
+    />
+  );
+};

--- a/packages/ui-tokens/src/colors.ts
+++ b/packages/ui-tokens/src/colors.ts
@@ -1,0 +1,15 @@
+export const lightColors = {
+  background: '#FFFFFF',
+  text: '#000000',
+  primary: '#1E90FF',
+  secondary: '#FF4081',
+};
+
+export const darkColors = {
+  background: '#000000',
+  text: '#FFFFFF',
+  primary: '#1E90FF',
+  secondary: '#FF4081',
+};
+
+export type Colors = typeof lightColors;

--- a/packages/ui-tokens/src/index.ts
+++ b/packages/ui-tokens/src/index.ts
@@ -1,0 +1,5 @@
+export * from './colors';
+export * from './spacing';
+export * from './typography';
+export { ThemeProvider, useTheme } from './ThemeProvider';
+export { ThemedText } from './ThemedText';

--- a/packages/ui-tokens/src/spacing.ts
+++ b/packages/ui-tokens/src/spacing.ts
@@ -1,0 +1,9 @@
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+};
+
+export type Spacing = typeof spacing;

--- a/packages/ui-tokens/src/typography.ts
+++ b/packages/ui-tokens/src/typography.ts
@@ -1,0 +1,17 @@
+export const typography = {
+  fontFamily: 'System',
+  fontSize: {
+    xs: 12,
+    sm: 14,
+    md: 16,
+    lg: 20,
+    xl: 24,
+  },
+  fontWeight: {
+    regular: '400',
+    medium: '500',
+    bold: '700',
+  },
+};
+
+export type Typography = typeof typography;

--- a/packages/ui-tokens/tsconfig.json
+++ b/packages/ui-tokens/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "jsx": "react",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add color, spacing, and typography tokens
- provide ThemeProvider with light/dark modes and useTheme hook
- include ThemedText example component

## Testing
- `npm install` (fail: 403 Forbidden)
- `npm run build` (fail: Cannot find module 'react')

------
https://chatgpt.com/codex/tasks/task_e_68a56851cc94832f9d9396b6136244b2