### PR TITLE
chore: stub matrix core Expo config plugin

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,0 +1,17 @@
+import { ExpoConfig, ConfigContext } from '@expo/config';
+
+const withMatrixCorePlugin = './plugins/with-matrix-core';
+
+export default ({ config }: ConfigContext): ExpoConfig => {
+  const withMatrixCore = process.env.WITH_MATRIX_CORE === 'true';
+
+  return {
+    ...config,
+    name: config.name ?? 'mchat',
+    slug: config.slug ?? 'mchat',
+    plugins: [
+      ...(config.plugins ?? []),
+      ...(withMatrixCore ? [withMatrixCorePlugin] : []),
+    ],
+  };
+};

--- a/apps/mobile/plugins/with-matrix-core.ts
+++ b/apps/mobile/plugins/with-matrix-core.ts
@@ -15,7 +15,16 @@ const withMatrixCore: ConfigPlugin = (config) => {
     return c;
   }]);
 import { ConfigPlugin } from '@expo/config-plugins';
+import { ConfigPlugin } from '@expo/config-plugins';
 
+/**
+ * Stub Expo config plugin for future Matrix core integration.
+ * Currently logs intended changes without modifying native projects.
+ */
+const withMatrixCore: ConfigPlugin = (config) => {
+  // Placeholder: log intended changes for iOS and Android
+  console.log('with-matrix-core: iOS configuration placeholder');
+  console.log('with-matrix-core: Android configuration placeholder');
 /**
  * Stub Expo config plugin for future Matrix core integration.
  * Currently logs intended changes without modifying native projects.

--- a/apps/mobile/plugins/with-matrix-core.ts
+++ b/apps/mobile/plugins/with-matrix-core.ts
@@ -1,0 +1,21 @@
+import { ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
+
+/**
+ * Stub Expo config plugin for future Matrix core integration.
+ * Currently logs intended changes without modifying native projects.
+ */
+const withMatrixCore: ConfigPlugin = (config) => {
+  config = withDangerousMod(config, ['ios', async (c) => {
+    console.log('with-matrix-core: iOS configuration placeholder');
+    return c;
+  }]);
+
+  config = withDangerousMod(config, ['android', async (c) => {
+    console.log('with-matrix-core: Android configuration placeholder');
+    return c;
+  }]);
+
+  return config;
+};
+
+export default withMatrixCore;

--- a/apps/mobile/plugins/with-matrix-core.ts
+++ b/apps/mobile/plugins/with-matrix-core.ts
@@ -14,7 +14,15 @@ const withMatrixCore: ConfigPlugin = (config) => {
     console.log('with-matrix-core: Android configuration placeholder');
     return c;
   }]);
+import { ConfigPlugin } from '@expo/config-plugins';
 
+/**
+ * Stub Expo config plugin for future Matrix core integration.
+ * Currently logs intended changes without modifying native projects.
+ */
+const withMatrixCore: ConfigPlugin = (config) => {
+  console.log('with-matrix-core: iOS configuration placeholder');
+  console.log('with-matrix-core: Android configuration placeholder');
   return config;
 };
 


### PR DESCRIPTION
## Summary
- add stub Expo config plugin for Matrix core integration
- wire plugin into app config behind `WITH_MATRIX_CORE` flag

## Testing
- `npx expo prebuild --non-interactive` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo)*
- `WITH_MATRIX_CORE=true npx expo prebuild --non-interactive` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo)*

------
https://chatgpt.com/codex/tasks/task_e_68a5686cee5c832f9e12df3ea0ae99bc