### PR TITLE
Add security and privacy policy stubs

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,9 @@
+# Privacy Policy
+
+We value your privacy and are committed to protecting it.
+
+- No analytics or tracking libraries are included in this project.
+- Crash reports are optional and disabled by default.
+- Lightning payments are designed with privacy in mind; we do not log payment details on our servers.
+
+If you have any privacy questions or concerns, contact privacy@example.com.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -6,4 +6,4 @@ We value your privacy and are committed to protecting it.
 - Crash reports are optional and disabled by default.
 - Lightning payments are designed with privacy in mind; we do not log payment details on our servers.
 
-If you have any privacy questions or concerns, contact privacy@example.com.
+If you have any privacy questions or concerns, contact privacy@yourprojectdomain.com.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+We take the security of this project seriously. If you discover a vulnerability, please contact us at security@example.com.
+
+We will acknowledge your report within 3 working days and aim to provide a remediation plan within 7 working days.
+
+Please allow us a reasonable time to address the issue before any public disclosure.
+
+Thank you for helping make this project safer for everyone.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-We take the security of this project seriously. If you discover a vulnerability, please contact us at security@example.com.
+We take the security of this project seriously. If you discover a vulnerability, please contact us at security@yourdomain.com.
 
 We will acknowledge your report within 3 working days and aim to provide a remediation plan within 7 working days.
 


### PR DESCRIPTION
## Summary
- add coordinated disclosure policy with contact email
- define initial privacy policy: no analytics, opt-in crash reports, privacy-focused payments

## Testing
- `npm test` (fails: Could not read package.json)
- `cargo test` (fails: could not find `Cargo.toml`)


------
https://chatgpt.com/codex/tasks/task_e_68a5687c1980832f8c9fd895c382cd2c