### PR TITLE
docs: add initial architecture decision records

### DIFF
--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,15 @@
+# 0001: Record architecture decisions
+
+- Status: Accepted
+- Date: 2025-08-20
+
+## Context
+Software projects benefit from documenting significant architectural decisions. These records help future contributors understand why certain paths were taken.
+
+## Decision
+Adopt Architecture Decision Records (ADRs) to capture important architectural choices. Each ADR will reside in this folder and follow the format described in the README.
+
+## Consequences
+- Provides a history of the project's key decisions.
+- Facilitates informed discussions when revisiting or revising past decisions.
+- Requires contributors to maintain ADRs as the architecture evolves.

--- a/docs/adr/0002-react-native-expo-dev-client.md
+++ b/docs/adr/0002-react-native-expo-dev-client.md
@@ -1,0 +1,16 @@
+# 0002: Use React Native with Expo Dev Client for UI
+
+- Status: Accepted
+- Date: 2025-08-20
+
+## Context
+The project targets iOS and Android with a single codebase while maintaining a native feel. Expo Dev Client provides a customizable runtime for React Native apps and streamlines development.
+
+## Decision
+Build the mobile interface using React Native and Expo Dev Client. This choice allows rapid iteration with JavaScript and TypeScript while keeping the option to add native modules when necessary.
+
+## Consequences
+- Single codebase for multiple platforms.
+- Faster development and hot-reload during the prototyping phase.
+- Dependency on the Expo ecosystem and React Native updates.
+- Potential performance trade-offs compared to fully native implementations.

--- a/docs/adr/0003-rust-core.md
+++ b/docs/adr/0003-rust-core.md
@@ -1,0 +1,16 @@
+# 0003: Implement core logic in Rust
+
+- Status: Accepted
+- Date: 2025-08-20
+
+## Context
+End-to-end encryption and protocol handling require performance and safety. Rust offers memory safety without a garbage collector and has an existing Matrix SDK.
+
+## Decision
+Develop the application's core using Rust, leveraging `matrix-rust-sdk`, and expose functionality to the React Native layer through a native module.
+
+## Consequences
+- High-performance, memory-safe core.
+- Shared logic across platforms.
+- Requires a bridging layer to connect Rust and JavaScript.
+- Builds become more complex with native code compilation.

--- a/docs/adr/0004-lightning-deep-link-first.md
+++ b/docs/adr/0004-lightning-deep-link-first.md
@@ -1,0 +1,16 @@
+# 0004: Lightning payments via deep-link first
+
+- Status: Accepted
+- Date: 2025-08-20
+
+## Context
+Supporting Lightning Network payments is a project goal. Embedding a wallet is complex and may delay core messaging features.
+
+## Decision
+Initial Lightning support will use deep-links to existing wallet apps. Users can send and receive payments through their preferred wallet without embedding wallet code in the app.
+
+## Consequences
+- Enables Lightning payments early in the project.
+- Reduces security and maintenance burden by relying on established wallets.
+- Requires users to have a compatible Lightning wallet installed.
+- Later work needed to embed wallet functionality directly.

--- a/docs/adr/0005-matrix-federation.md
+++ b/docs/adr/0005-matrix-federation.md
@@ -1,0 +1,16 @@
+# 0005: Federation via Matrix protocol
+
+- Status: Accepted
+- Date: 2025-08-20
+
+## Context
+The project aims to avoid walled gardens and interoperate with other messaging systems. Matrix provides an open standard for secure, decentralized communication.
+
+## Decision
+Adopt the Matrix protocol for federation. Servers and clients will communicate using Matrix APIs, enabling interoperability with the wider Matrix ecosystem.
+
+## Consequences
+- Aligns the project with a well-supported open protocol.
+- Allows communication with existing Matrix users and servers.
+- Requires handling Matrix-specific concepts such as rooms and events.
+- Server infrastructure must support Matrix federation requirements.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records
+
+This folder stores Architecture Decision Records (ADRs) for the project.
+
+## How to add a new ADR
+1. Choose the next sequential number and create a file named `NNNN-your-title.md`.
+2. Use the following sections:
+   - **Status**: `Accepted`, `Proposed`, etc.
+   - **Date**: When the decision was made.
+   - **Context**: The forces at play.
+   - **Decision**: What choice was made.
+   - **Consequences**: Results of the decision.
+3. Commit the ADR and open a pull request.
+
+ADRs are permanent. When decisions change, add a new ADR and link it to the superseded one.


### PR DESCRIPTION
## Summary
- add ADR folder with instructions for creating new records
- record initial architecture decisions for React Native with Expo Dev Client, Rust core, Lightning deep-linking, and Matrix federation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_68a568850b28832f97dcc67e57c7d129