### PR TITLE
Add accessibility checklist and utility helpers

### DIFF
--- a/docs/a11y-checklist.md
+++ b/docs/a11y-checklist.md
@@ -1,0 +1,7 @@
+# Accessibility Baseline Checklist
+
+- **Color contrast:** Ensure text and interactive elements meet at least a 4.5:1 contrast ratio (3:1 for large text) and verify in both light and dark themes.
+- **Dynamic type:** Respect system font-size settings. Use scalable units and avoid fixed font sizes so content adapts to user preferences.
+- **Screen reader labels:** Every interactive element provides a descriptive `accessibilityLabel` and, where helpful, an `accessibilityHint` without duplicating visible text.
+- **Hit areas:** Touch targets are at least 44\u00d744 dp. Use `hitSlop` to expand smaller elements' touch areas when layout constraints exist.
+- **Haptics:** Critical actions trigger appropriate haptic feedback and respect the user's global haptics/ vibration settings.

--- a/packages/a11y-utils/index.ts
+++ b/packages/a11y-utils/index.ts
@@ -1,0 +1,27 @@
+export function accessibleLabel(text: string, extras?: string | string[]): string {
+  if (!extras) {
+    return text;
+  }
+  const parts = Array.isArray(extras) ? extras : [extras];
+  const extra = parts.filter(Boolean).join(', ');
+  return extra ? `${text}, ${extra}` : text;
+}
+
+export interface HitSlop {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+export function hitSlop(area: number | Partial<HitSlop>): HitSlop {
+  if (typeof area === 'number') {
+    return { top: area, bottom: area, left: area, right: area };
+  }
+  return {
+    top: area.top ?? 0,
+    bottom: area.bottom ?? 0,
+    left: area.left ?? 0,
+    right: area.right ?? 0,
+  };
+}

--- a/packages/a11y-utils/package.json
+++ b/packages/a11y-utils/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@mchat/a11y-utils",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/a11y-utils/tsconfig.json
+++ b/packages/a11y-utils/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary
- document baseline accessibility requirements including color contrast, dynamic type, screen reader labels, hit areas and haptics
- add `accessibleLabel` and `hitSlop` helpers to centralize accessibility utilities

## Testing
- `tsc -p packages/a11y-utils/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a5688d8654832f83f5493dc29789d0