### PR TITLE
chore: scaffold Rust mobile build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ web-build/
 target/
 **/target/
 native/rust/target/
+native/rust/out/

--- a/native/rust/build-scripts/Makefile
+++ b/native/rust/build-scripts/Makefile
@@ -1,0 +1,11 @@
+SHELL := /bin/bash
+
+.PHONY: android ios all
+
+android:
+	./build-android.sh
+
+ios:
+	./build-ios.sh
+
+all: android ios

--- a/native/rust/build-scripts/build-android.sh
+++ b/native/rust/build-scripts/build-android.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+CRATE_DIR="$SCRIPT_DIR/.."
+OUT_DIR="$CRATE_DIR/out/android"
+
+mkdir -p "$OUT_DIR"
+
+if command -v cargo >/dev/null 2>&1 && cargo ndk --version >/dev/null 2>&1; then
+  echo "Building Android library for arm64-v8a"
+  cargo ndk -t arm64-v8a -o "$OUT_DIR" build --release --manifest-path "$CRATE_DIR/Cargo.toml" --package matrix_core
+else
+  echo "cargo-ndk not installed; skipping Android build."
+  echo "Output directory prepared at $OUT_DIR"
+fi

--- a/native/rust/build-scripts/build-ios.sh
+++ b/native/rust/build-scripts/build-ios.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+CRATE_DIR="$SCRIPT_DIR/.."
+OUT_DIR="$CRATE_DIR/out/ios"
+
+mkdir -p "$OUT_DIR"
+
+echo "Building iOS xcframework (placeholder)"
+if command -v cargo >/dev/null 2>&1; then
+  echo "Rust toolchain detected"
+  # TODO: Add real build commands for aarch64-apple-ios and x86_64-apple-ios
+  # Example:
+  # cargo build --target aarch64-apple-ios --release --manifest-path "$CRATE_DIR/Cargo.toml" --package matrix_core
+  # cargo build --target x86_64-apple-ios --release --manifest-path "$CRATE_DIR/Cargo.toml" --package matrix_core
+  # xcodebuild -create-xcframework -library <path to libs> -output "$OUT_DIR/matrix_core.xcframework"
+else
+  echo "Rust toolchain not installed; skipping iOS build"
+fi
+
+touch "$OUT_DIR/.placeholder"


### PR DESCRIPTION
## Summary
- add Android build script using cargo-ndk
- scaffold iOS xcframework build script
- wire scripts into Makefile and ignore generated output

## Testing
- `bash native/rust/build-scripts/build-android.sh`
- `bash native/rust/build-scripts/build-ios.sh`
- `make -C native/rust/build-scripts android`
- `make -C native/rust/build-scripts ios`


------
https://chatgpt.com/codex/tasks/task_e_68a57358c23c832f88e4436777805839