### PR TITLE
chore: unify TypeScript configuration

### DIFF
--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,6 +1,8 @@
 {
-  "extends": "expo/tsconfig.base",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "strict": true
+    "jsx": "react-native",
+    "types": ["react", "react-native"],
+    "noEmit": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "eslint-plugin-react-native": "^5.0.0",
     "husky": "^9.0.10",
     "lint-staged": "^15.2.0"
-  },
+  }
 }

--- a/packages/a11y-utils/package.json
+++ b/packages/a11y-utils/package.json
@@ -4,6 +4,12 @@
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json"
   }

--- a/packages/a11y-utils/tsconfig.json
+++ b/packages/a11y-utils/tsconfig.json
@@ -1,14 +1,9 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2019",
     "module": "ESNext",
     "declaration": true,
-    "outDir": "dist",
-    "strict": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
-    "skipLibCheck": true
+    "outDir": "dist"
   },
   "include": ["index.ts"]
 }

--- a/packages/lightning-utils/package.json
+++ b/packages/lightning-utils/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@mchat/lightning-utils",
   "version": "0.1.0",
-  "main": "index.ts",
-  "types": "index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
   "dependencies": {}
 }

--- a/packages/lightning-utils/tsconfig.json
+++ b/packages/lightning-utils/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "./tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "declaration": true,
     "outDir": "dist"
   },
-  "include": ["packages/**/*"]
+  "include": ["**/*.ts"]
 }

--- a/packages/message-ui/package.json
+++ b/packages/message-ui/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@mchat/message-ui",
   "version": "0.1.0",
-  "main": "index.ts",
-  "types": "index.ts",
-  "private": true
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
 }

--- a/packages/message-ui/tsconfig.json
+++ b/packages/message-ui/tsconfig.json
@@ -1,15 +1,11 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "ESNext",
     "jsx": "react-native",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "types": ["react", "react-native"],
-    "noEmit": true
+    "declaration": true,
+    "outDir": "dist"
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/packages/push-contract/package.json
+++ b/packages/push-contract/package.json
@@ -3,6 +3,12 @@
   "version": "0.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc"
   },

--- a/packages/push-contract/tsconfig.json
+++ b/packages/push-contract/tsconfig.json
@@ -1,10 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2019",
-    "module": "commonjs",
     "declaration": true,
-    "outDir": "dist",
-    "strict": true
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/packages/ui-tokens/package.json
+++ b/packages/ui-tokens/package.json
@@ -3,6 +3,12 @@
   "version": "0.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/packages/ui-tokens/tsconfig.json
+++ b/packages/ui-tokens/tsconfig.json
@@ -1,12 +1,7 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "commonjs",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "declaration": true,
-    "jsx": "react",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,11 +2,16 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "commonjs",
+    "moduleResolution": "node",
     "strict": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@mchat/*": ["packages/*/src"]
+    }
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- centralize strict TypeScript settings and path aliases in `tsconfig.base.json`
- have all packages and apps extend the base config
- align package exports and types with compiled `dist` output

## Testing
- `npm install --legacy-peer-deps` *(fails: No matching version found for @types/react-native@^0.73.2)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a743bdcb38832fa4d6e63330f548a9