### PR TITLE
refactor lightning payment detection utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "eslint-plugin-react-native": "^5.0.0",
     "husky": "^9.0.10",
     "lint-staged": "^15.2.0"
-  },
+  }
 }

--- a/packages/lightning-utils/detect.test.ts
+++ b/packages/lightning-utils/detect.test.ts
@@ -1,4 +1,4 @@
-import { detectPaymentStrings, normalizeInvoice } from './detect';
+import { detectPaymentStrings, normalizeInvoice } from '.';
 
 describe('detectPaymentStrings positives', () => {
   const positives = [

--- a/packages/lightning-utils/detect.ts
+++ b/packages/lightning-utils/detect.ts
@@ -1,18 +1,29 @@
+/**
+ * Types of payment strings that can be detected.
+ */
 export type PaymentStringType = 'bolt11' | 'bolt12' | 'lnurl' | 'lightning';
 
+/**
+ * Result of detecting a payment string in a piece of text.
+ */
+export interface PaymentString {
+  type: PaymentStringType;
+  value: string;
+}
+
+// Character class for Bech32 encodings used by Lightning payment strings.
 const BECH32_CHARS = '[02-9ac-hj-np-z]';
 
-const bolt11Regex = new RegExp(`^ln(?!url|o|r|i)[a-z0-9]+1${BECH32_CHARS}+$`, 'i');
-const bolt12Regex = new RegExp(`^ln(o|r|i)[a-z0-9]*1${BECH32_CHARS}+$`, 'i');
-const lnurlRegex = new RegExp(`^lnurl1${BECH32_CHARS}{10,}$`, 'i');
-// Extracted regex pattern strings for consistency
-const BOLT11_PATTERN_STR = `ln(?!url|o|r|i)[a-z0-9]+1${BECH32_CHARS}+`;
-const BOLT12_PATTERN_STR = `ln(o|r|i)[a-z0-9]*1${BECH32_CHARS}+`;
-const LNURL_PATTERN_STR = `lnurl1${BECH32_CHARS}{10,}`;
+// Base patterns without anchors. These are reused for validation and extraction.
+const BOLT11_PATTERN = `ln(?!url|o|r|i)[a-z0-9]+1${BECH32_CHARS}+`;
+const BOLT12_PATTERN = `ln(?:o|r|i)[a-z0-9]*1${BECH32_CHARS}+`;
+const LNURL_PATTERN = `lnurl1${BECH32_CHARS}{10,}`;
 
-const bolt11Regex = new RegExp(`^${BOLT11_PATTERN_STR}$`, 'i');
-const bolt12Regex = new RegExp(`^${BOLT12_PATTERN_STR}$`, 'i');
-const lnurlRegex = new RegExp(`^${LNURL_PATTERN_STR}$`, 'i');
+// Compiled regexes for strict validation of individual strings.
+const bolt11Regex = new RegExp(`^${BOLT11_PATTERN}$`, 'i');
+const bolt12Regex = new RegExp(`^${BOLT12_PATTERN}$`, 'i');
+const lnurlRegex = new RegExp(`^${LNURL_PATTERN}$`, 'i');
+
 function isBolt11(str: string): boolean {
   return bolt11Regex.test(str);
 }
@@ -25,14 +36,25 @@ function isLnurl(str: string): boolean {
   return lnurlRegex.test(str);
 }
 
+/**
+ * Normalise a lightning invoice by removing any `lightning:` prefix,
+ * trimming surrounding whitespace and lowercasing the result.
+ */
 export function normalizeInvoice(str: string): string {
   return str.trim().replace(/^lightning:/i, '').toLowerCase();
 }
 
-export function detectPaymentStrings(text: string): { type: PaymentStringType; value: string }[] {
-  const results: { type: PaymentStringType; value: string }[] = [];
+/**
+ * Detect Lightning payment strings in arbitrary text.
+ *
+ * Matches bare BOLT11, BOLT12 and LNURL strings as well as `lightning:` URIs.
+ * Returns an array describing each match with its detected type and original
+ * value as it appeared in the text.
+ */
+export function detectPaymentStrings(text: string): PaymentString[] {
+  const results: PaymentString[] = [];
 
-  // Detect lightning: URIs first
+  // Detect `lightning:` URIs first.
   const lightningPattern = /lightning:([^\s]+)/gi;
   let match: RegExpExecArray | null;
   while ((match = lightningPattern.exec(text))) {
@@ -42,33 +64,25 @@ export function detectPaymentStrings(text: string): { type: PaymentStringType; v
     }
   }
 
-  // Remove lightning: URIs to avoid duplicate detection
+  // Remove `lightning:` URIs to avoid duplicate detection in later regexes.
   const sanitized = text.replace(/lightning:\s*[^\s]+/gi, ' ');
 
-  const bolt11Pattern = /\bln(?!url|o|r|i)[a-z0-9]+1[02-9ac-hj-np-z]+\b/gi;
+  // Detect bare payment strings.
+  const bolt11Pattern = new RegExp(`\\b${BOLT11_PATTERN}\\b`, 'gi');
   while ((match = bolt11Pattern.exec(sanitized))) {
     results.push({ type: 'bolt11', value: match[0] });
   }
 
-  const bolt12Pattern = /\bln(o|r|i)[a-z0-9]*1[02-9ac-hj-np-z]+\b/gi;
+  const bolt12Pattern = new RegExp(`\\b${BOLT12_PATTERN}\\b`, 'gi');
   while ((match = bolt12Pattern.exec(sanitized))) {
     results.push({ type: 'bolt12', value: match[0] });
   }
 
-  const bolt11Pattern = new RegExp(`\\b${BOLT11_REGEX_STR}\\b`, 'gi');
-  while ((match = bolt11Pattern.exec(sanitized))) {
-    results.push({ type: 'bolt11', value: match[0] });
-  }
-
-  const bolt12Pattern = new RegExp(`\\b${BOLT12_REGEX_STR}\\b`, 'gi');
-  while ((match = bolt12Pattern.exec(sanitized))) {
-    results.push({ type: 'bolt12', value: match[0] });
-  }
-
-  const lnurlPattern = new RegExp(`\\b${LNURL_REGEX_STR}\\b`, 'gi');
+  const lnurlPattern = new RegExp(`\\b${LNURL_PATTERN}\\b`, 'gi');
   while ((match = lnurlPattern.exec(sanitized))) {
     results.push({ type: 'lnurl', value: match[0] });
   }
 
   return results;
 }
+

--- a/packages/lightning-utils/index.ts
+++ b/packages/lightning-utils/index.ts
@@ -1,1 +1,3 @@
-export { detectPaymentStrings, normalizeInvoice, PaymentStringType } from './detect';
+export { detectPaymentStrings, normalizeInvoice } from './detect';
+export type { PaymentString, PaymentStringType } from './detect';
+


### PR DESCRIPTION
## Summary
- simplify lightning payment detection utility and document regex patterns
- expose typed detectPaymentStrings/normalizeInvoice API from barrel
- fix root package.json formatting for tooling

## Testing
- `npm test packages/lightning-utils/detect.test.ts` *(fails: jest: not found)*
- `npm install jest ts-jest typescript @types/jest --no-save --legacy-peer-deps` *(fails: No matching version found for @types/react-native@^0.73.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a744ac10a4832fb3344c845ad05bf0