### PR TITLE
Add portable Rust cross-compilation scripts

### DIFF
--- a/native/rust/build-scripts/Makefile
+++ b/native/rust/build-scripts/Makefile
@@ -1,0 +1,16 @@
+# Simple wrapper Makefile for cross-compiling the Rust workspace.
+
+# Override these variables when invoking make, e.g.:
+#   make android ANDROID_ARCH=x86_64
+#   make ios IOS_TARGET=x86_64-apple-ios
+
+ANDROID_ARCH ?= arm64-v8a
+IOS_TARGET ?= aarch64-apple-ios
+
+.PHONY: android ios
+
+android:
+	./build-android.sh $(ANDROID_ARCH)
+
+ios:
+	./build-ios.sh $(IOS_TARGET)

--- a/native/rust/build-scripts/build-android.sh
+++ b/native/rust/build-scripts/build-android.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the Rust workspace for a given Android architecture.
+# Usage: ./build-android.sh [arch]
+# Example: ./build-android.sh arm64-v8a
+# Defaults to arm64-v8a if no argument is provided.
+
+ARCH=${1:-arm64-v8a}
+
+# Determine script and workspace directories
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORKSPACE_DIR="$SCRIPT_DIR/.."
+OUTPUT_DIR="$WORKSPACE_DIR/target/android/$ARCH"
+
+# Ensure required tools are available
+command -v cargo >/dev/null 2>&1 || { echo "cargo is required but not installed."; exit 1; }
+command -v rustup >/dev/null 2>&1 || { echo "rustup is required but not installed."; exit 1; }
+command -v cargo-ndk >/dev/null 2>&1 || { echo "cargo-ndk is required. Install with 'cargo install cargo-ndk'."; exit 1; }
+
+# Map common Android architectures to Rust target triples
+case "$ARCH" in
+  arm64-v8a) TARGET_TRIPLE=aarch64-linux-android ;;
+  armeabi-v7a) TARGET_TRIPLE=armv7-linux-androideabi ;;
+  x86_64) TARGET_TRIPLE=x86_64-linux-android ;;
+  *) echo "Unsupported Android architecture: $ARCH"; exit 1 ;;
+esac
+
+# Verify the Rust target is installed
+if ! rustup target list --installed | grep -q "$TARGET_TRIPLE"; then
+  echo "Rust target $TARGET_TRIPLE is not installed. Install it with: rustup target add $TARGET_TRIPLE"
+  exit 1
+fi
+
+# Run the build
+cd "$WORKSPACE_DIR"
+echo "Building for Android architecture $ARCH ($TARGET_TRIPLE)..."
+cargo ndk --target "$ARCH" --output-dir "$OUTPUT_DIR" build --release
+
+echo "Build artifacts are located in $OUTPUT_DIR"

--- a/native/rust/build-scripts/build-android.sh
+++ b/native/rust/build-scripts/build-android.sh
@@ -23,6 +23,7 @@ case "$ARCH" in
   arm64-v8a) TARGET_TRIPLE=aarch64-linux-android ;;
   armeabi-v7a) TARGET_TRIPLE=armv7-linux-androideabi ;;
   x86_64) TARGET_TRIPLE=x86_64-linux-android ;;
+  x86) TARGET_TRIPLE=i686-linux-android ;;
   *) echo "Unsupported Android architecture: $ARCH"; exit 1 ;;
 esac
 

--- a/native/rust/build-scripts/build-ios.sh
+++ b/native/rust/build-scripts/build-ios.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the Rust workspace for a given iOS target.
+# Usage: ./build-ios.sh [target]
+# Example: ./build-ios.sh aarch64-apple-ios
+# Defaults to aarch64-apple-ios if no argument is provided.
+
+TARGET=${1:-aarch64-apple-ios}
+
+# Determine script and workspace directories
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORKSPACE_DIR="$SCRIPT_DIR/.."
+OUTPUT_DIR="$WORKSPACE_DIR/target/ios/$TARGET"
+
+# Ensure required tools are available
+command -v cargo >/dev/null 2>&1 || { echo "cargo is required but not installed."; exit 1; }
+command -v rustup >/dev/null 2>&1 || { echo "rustup is required but not installed."; exit 1; }
+command -v xcodebuild >/dev/null 2>&1 || { echo "xcodebuild is required. Install Xcode command-line tools."; exit 1; }
+
+# Verify the Rust target is installed
+if ! rustup target list --installed | grep -q "$TARGET"; then
+  echo "Rust target $TARGET is not installed. Install it with: rustup target add $TARGET"
+  exit 1
+fi
+
+# Run the build
+cd "$WORKSPACE_DIR"
+echo "Building for iOS target $TARGET..."
+cargo build --release --target "$TARGET" --target-dir "$OUTPUT_DIR"
+
+echo "Build artifacts are located in $OUTPUT_DIR"

--- a/native/rust/build-scripts/build-ios.sh
+++ b/native/rust/build-scripts/build-ios.sh
@@ -29,4 +29,4 @@ cd "$WORKSPACE_DIR"
 echo "Building for iOS target $TARGET..."
 cargo build --release --target "$TARGET" --target-dir "$OUTPUT_DIR"
 
-echo "Build artifacts are located in $OUTPUT_DIR"
+echo "Build artifacts are located in $OUTPUT_DIR/$TARGET"


### PR DESCRIPTION
## Summary
- add Android build script with target/arch selection and sanity checks
- add iOS build script with target selection and tooling checks
- include Makefile wrapper to invoke scripts with configurable targets

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68a744e9f5e8832f9855d2e7d185a49c