### PR TITLE
refactor message ui to use tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "eslint-plugin-react-native": "^5.0.0",
     "husky": "^9.0.10",
     "lint-staged": "^15.2.0"
-  },
+  }
 }

--- a/packages/message-ui/DemoScreen.tsx
+++ b/packages/message-ui/DemoScreen.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
+import { spacing, useTheme } from '@mchat/ui-tokens';
 import MessageListItem from './MessageListItem';
 
 const DemoScreen: React.FC = () => {
+  const { colors } = useTheme();
   const messages = [
     { id: 1, sender: 'them', text: 'Hello!', timestamp: '09:41' },
     { id: 2, sender: 'me', text: 'Hi there!', timestamp: '09:42', status: 'sent' },
@@ -19,13 +21,15 @@ const DemoScreen: React.FC = () => {
       sender: 'them',
       text: 'Doing well, thanks!',
       timestamp: '09:44',
-      status: '',
       isReply: true,
     },
   ];
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={styles.content}
+    >
       {messages.map((msg) => (
         <MessageListItem key={msg.id} {...msg} />
       ))}
@@ -36,10 +40,9 @@ const DemoScreen: React.FC = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#e5ddd5',
   },
   content: {
-    paddingVertical: 16,
+    paddingVertical: spacing.md,
   },
 });
 

--- a/packages/message-ui/MessageBubble.tsx
+++ b/packages/message-ui/MessageBubble.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { spacing, typography, useTheme } from '@mchat/ui-tokens';
 
 export type MessageBubbleProps = {
   sender: 'me' | 'them';
   text: string;
   timestamp: string;
-  status: 'sent' | 'delivered' | 'read' | '';
+  status?: 'sent' | 'delivered' | 'read';
   isReply?: boolean;
   isSelected?: boolean;
 };
@@ -19,19 +20,31 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
   isSelected,
 }) => {
   const isMe = sender === 'me';
+  const { colors } = useTheme();
+
   return (
     <View
       style={[
         styles.container,
         isMe ? styles.meContainer : styles.themContainer,
+        { backgroundColor: isMe ? colors.primary : colors.background },
         isSelected && styles.selected,
+        isSelected && { borderColor: colors.primary },
       ]}
     >
-      {isReply && <Text style={styles.reply}>Reply</Text>}
-      <Text style={styles.text}>{text}</Text>
+      {isReply && (
+        <Text style={[styles.reply, { color: colors.text, opacity: 0.6 }]}>Reply</Text>
+      )}
+      <Text style={[styles.text, { color: colors.text }]}>{text}</Text>
       <View style={styles.metaRow}>
-        <Text style={styles.timestamp}>{timestamp}</Text>
-        {isMe && <Text style={styles.status}>{status}</Text>}
+        <Text style={[styles.timestamp, { color: colors.text, opacity: 0.6 }]}>
+          {timestamp}
+        </Text>
+        {isMe && status && (
+          <Text style={[styles.status, { color: colors.text, opacity: 0.6 }]}>
+            {status}
+          </Text>
+        )}
       </View>
     </View>
   );
@@ -40,46 +53,40 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
 const styles = StyleSheet.create({
   container: {
     maxWidth: '80%',
-    marginVertical: 4,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 16,
+    marginVertical: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: spacing.md,
   },
   meContainer: {
     alignSelf: 'flex-end',
-    backgroundColor: '#dcf8c6',
   },
   themContainer: {
     alignSelf: 'flex-start',
-    backgroundColor: '#fff',
   },
   selected: {
-    borderColor: '#007AFF',
-    borderWidth: 2,
+    borderWidth: spacing.xs / 2,
   },
   reply: {
-    fontSize: 12,
-    color: '#555',
-    marginBottom: 4,
+    fontSize: typography.fontSize.xs,
+    marginBottom: spacing.xs,
   },
   text: {
-    fontSize: 16,
-    color: '#000',
+    fontSize: typography.fontSize.md,
   },
   metaRow: {
     flexDirection: 'row',
     justifyContent: 'flex-end',
-    marginTop: 4,
+    marginTop: spacing.xs,
   },
   timestamp: {
-    fontSize: 10,
-    color: '#555',
+    fontSize: typography.fontSize.xs,
   },
   status: {
-    fontSize: 10,
-    color: '#555',
-    marginLeft: 4,
+    fontSize: typography.fontSize.xs,
+    marginLeft: spacing.xs,
   },
 });
 
 export default MessageBubble;
+

--- a/packages/message-ui/MessageListItem.tsx
+++ b/packages/message-ui/MessageListItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
+import { spacing } from '@mchat/ui-tokens';
 import MessageBubble, { MessageBubbleProps } from './MessageBubble';
 
 export type MessageListItemProps = MessageBubbleProps;
@@ -12,8 +13,8 @@ const MessageListItem: React.FC<MessageListItemProps> = (props) => (
 
 const styles = StyleSheet.create({
   row: {
-    paddingHorizontal: 8,
-    paddingVertical: 2,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs / 2,
   },
 });
 

--- a/packages/message-ui/package.json
+++ b/packages/message-ui/package.json
@@ -1,9 +1,7 @@
 {
   "name": "@mchat/message-ui",
   "version": "0.1.0",
-  "dependencies": {
-    "@mchat/ui-tokens": "*"
-  }
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/message-ui/package.json
+++ b/packages/message-ui/package.json
@@ -3,5 +3,8 @@
   "version": "0.1.0",
   "main": "index.ts",
   "types": "index.ts",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "@mchat/ui-tokens": "*"
+  }
 }


### PR DESCRIPTION
## Summary
- refactor MessageBubble to use theme tokens and optional status prop
- adjust MessageListItem padding with spacing tokens
- demo screen now uses theme colors and spacing tokens

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*


------
https://chatgpt.com/codex/tasks/task_e_68a7447cf338832f87c4524facbb8825