### PR TITLE
feat: add static shell and settings mocks

### DIFF
--- a/docs/ui-previews/settings-shell/settings-mock.svg
+++ b/docs/ui-previews/settings-shell/settings-mock.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="600">
+  <rect width="100%" height="100%" fill="#f0f0f0" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#555">
+    SettingsMock preview
+  </text>
+</svg>

--- a/docs/ui-previews/settings-shell/shell-mock.svg
+++ b/docs/ui-previews/settings-shell/shell-mock.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="600">
+  <rect width="100%" height="100%" fill="#f0f0f0" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#555">
+    ShellMock preview
+  </text>
+</svg>

--- a/src/components/settings/ProfileCard.tsx
+++ b/src/components/settings/ProfileCard.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { View, Text, StyleSheet, useColorScheme } from 'react-native';
+
+interface Props {
+  name: string;
+  handle: string;
+}
+
+const ProfileCard = ({ name, handle }: Props) => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.card, shadowColor: colors.shadow }]}> 
+      <View style={[styles.avatar, { backgroundColor: colors.avatar }]} />
+      <View style={styles.info}>
+        <Text style={[styles.name, { color: colors.text }]}>{name}</Text>
+        <Text style={[styles.handle, { color: colors.subtext }]}>{handle}</Text>
+      </View>
+      <Text style={[styles.qr, { color: colors.subtext }]}>QR</Text>
+    </View>
+  );
+};
+
+const lightColors = { card: '#ffffff', text: '#000000', subtext: '#555555', avatar: '#cccccc', shadow: '#000000' };
+const darkColors = { card: '#222222', text: '#ffffff', subtext: '#aaaaaa', avatar: '#444444', shadow: '#000000' };
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    margin: 16,
+    borderRadius: 8,
+    elevation: 2,
+    shadowOpacity: 0.2,
+    shadowOffset: { width: 0, height: 1 },
+    shadowRadius: 2,
+  },
+  avatar: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+  },
+  info: {
+    flex: 1,
+    marginLeft: 16,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  handle: {
+    marginTop: 4,
+    fontSize: 14,
+  },
+  qr: {
+    fontSize: 16,
+  },
+});
+
+export default ProfileCard;

--- a/src/components/settings/SectionHeader.tsx
+++ b/src/components/settings/SectionHeader.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Text, StyleSheet, useColorScheme } from 'react-native';
+
+interface Props {
+  title: string;
+}
+
+const SectionHeader = ({ title }: Props) => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+
+  return <Text style={[styles.header, { color: colors.subtext }]}>{title}</Text>;
+};
+
+const lightColors = { subtext: '#555555' };
+const darkColors = { subtext: '#aaaaaa' };
+
+const styles = StyleSheet.create({
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});
+
+export default SectionHeader;

--- a/src/components/settings/SettingsListItem.tsx
+++ b/src/components/settings/SettingsListItem.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, useColorScheme } from 'react-native';
+
+interface Props {
+  label: string;
+  onPress?: () => void;
+}
+
+const SettingsListItem = ({ label, onPress }: Props) => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+
+  return (
+    <TouchableOpacity accessibilityRole="button" accessibilityLabel={label} onPress={onPress}>
+      <View style={[styles.container, { borderBottomColor: colors.border, backgroundColor: colors.card }]}> 
+        <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
+        <Text style={[styles.chevron, { color: colors.subtext }]}>›</Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+const lightColors = { card: '#ffffff', text: '#000000', subtext: '#777777', border: '#e0e0e0' };
+const darkColors = { card: '#1c1c1c', text: '#ffffff', subtext: '#aaaaaa', border: '#333333' };
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  label: {
+    flex: 1,
+    fontSize: 16,
+  },
+  chevron: {
+    fontSize: 18,
+    marginLeft: 4,
+  },
+});
+
+export default SettingsListItem;

--- a/src/components/settings/SettingsListItem.tsx
+++ b/src/components/settings/SettingsListItem.tsx
@@ -4,14 +4,20 @@ import { View, Text, StyleSheet, TouchableOpacity, useColorScheme } from 'react-
 interface Props {
   label: string;
   onPress?: () => void;
+  accessibilityHint?: string;
 }
 
-const SettingsListItem = ({ label, onPress }: Props) => {
+const SettingsListItem = ({ label, onPress, accessibilityHint }: Props) => {
   const scheme = useColorScheme();
   const colors = scheme === 'dark' ? darkColors : lightColors;
 
   return (
-    <TouchableOpacity accessibilityRole="button" accessibilityLabel={label} onPress={onPress}>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityHint={accessibilityHint || `Activates ${label}`}
+      onPress={onPress}
+    >
       <View style={[styles.container, { borderBottomColor: colors.border, backgroundColor: colors.card }]}> 
         <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
         <Text style={[styles.chevron, { color: colors.subtext }]}>›</Text>

--- a/src/components/shell/TabBarMock.tsx
+++ b/src/components/shell/TabBarMock.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View, Text, StyleSheet, useColorScheme } from 'react-native';
+
+const TabBarMock = () => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+
+  const tabs = [
+    { label: 'Chats', icon: '💬' },
+    { label: 'Calls', icon: '📞' },
+    { label: 'Settings', icon: '⚙️' },
+  ];
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.card, borderTopColor: colors.border }]}> 
+      {tabs.map((tab) => (
+        <View key={tab.label} style={styles.tab}>
+          <Text style={styles.icon}>{tab.icon}</Text>
+          <Text style={[styles.label, { color: colors.text }]}>{tab.label}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const lightColors = { card: '#ffffff', text: '#222222', border: '#e0e0e0' };
+const darkColors = { card: '#1c1c1c', text: '#f2f2f2', border: '#333333' };
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  icon: {
+    fontSize: 20,
+    marginBottom: 2,
+  },
+  label: {
+    fontSize: 12,
+  },
+});
+
+export default TabBarMock;

--- a/src/screens/SettingsMock.tsx
+++ b/src/screens/SettingsMock.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { ScrollView, View, Text, StyleSheet, useColorScheme } from 'react-native';
+import ProfileCard from '../components/settings/ProfileCard';
+import SectionHeader from '../components/settings/SectionHeader';
+import SettingsListItem from '../components/settings/SettingsListItem';
+
+const SettingsMock = () => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+
+  return (
+    <ScrollView style={[styles.screen, { backgroundColor: colors.background }]}> 
+      <ProfileCard name="Jane Doe" handle="@jane" />
+      <View style={styles.section}>
+        <SectionHeader title="Account" />
+        <SettingsListItem label="Phone Number" />
+        <SettingsListItem label="Privacy" />
+        <SettingsListItem label="Security" />
+        <SettingsListItem label="Two-Step Verify" />
+      </View>
+      <View style={styles.section}>
+        <SectionHeader title="Appearance" />
+        <SettingsListItem label="Theme" />
+        <SettingsListItem label="Wallpapers" />
+      </View>
+      <View style={styles.section}>
+        <SectionHeader title="Notifications" />
+        <SettingsListItem label="Message tones" />
+        <SettingsListItem label="Vibrate" />
+      </View>
+      <View style={styles.section}>
+        <SectionHeader title="Data & Storage" />
+        <SettingsListItem label="Media auto-download" />
+      </View>
+      <View style={styles.section}>
+        <SectionHeader title="Help" />
+        <SettingsListItem label="FAQ" />
+        <SettingsListItem label="Report a problem" />
+      </View>
+      <View style={styles.footer}>
+        <Text style={[styles.version, { color: colors.subtext }]}>v0.0.0</Text>
+        <Text style={[styles.license, { color: colors.subtext }]}>Open source, no telemetry</Text>
+      </View>
+    </ScrollView>
+  );
+};
+
+const lightColors = { background: '#f5f5f5', subtext: '#777777' };
+const darkColors = { background: '#000000', subtext: '#aaaaaa' };
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+  section: {
+    marginTop: 8,
+  },
+  footer: {
+    alignItems: 'center',
+    paddingVertical: 32,
+  },
+  version: {
+    fontSize: 12,
+  },
+  license: {
+    fontSize: 12,
+    marginTop: 4,
+  },
+});
+
+export default SettingsMock;

--- a/src/screens/ShellMock.tsx
+++ b/src/screens/ShellMock.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, useColorScheme, Animated, ScrollView } from 'react-native';
+import TabBarMock from '../components/shell/TabBarMock';
+
+const ShellMock = () => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+  const shimmer = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(shimmer, { toValue: 1, duration: 1000, useNativeDriver: true }),
+        Animated.timing(shimmer, { toValue: 0.3, duration: 1000, useNativeDriver: true }),
+      ]),
+    ).start();
+  }, [shimmer]);
+
+  return (
+    <View style={[styles.screen, { backgroundColor: colors.background }]}> 
+      <View style={[styles.topBar, { backgroundColor: colors.card, borderBottomColor: colors.border }]}> 
+        <Text style={[styles.title, { color: colors.text }]}>mChat</Text>
+        <View style={styles.topIcons}>
+          <Text style={[styles.topIcon, { color: colors.subtext }]}>🔍</Text>
+          <Text style={[styles.topIcon, { color: colors.subtext }]}>📷</Text>
+        </View>
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={[styles.card, { backgroundColor: colors.card, shadowColor: colors.shadow }]}> 
+          <Text style={[styles.cardText, { color: colors.text }]}>This is the shell</Text>
+        </View>
+        {[0, 1, 2, 3].map((i) => (
+          <Animated.View
+            key={i}
+            style={[styles.placeholder, { backgroundColor: colors.placeholder, opacity: shimmer }]}
+          />
+        ))}
+      </ScrollView>
+      <TabBarMock />
+    </View>
+  );
+};
+
+const lightColors = {
+  background: '#f5f5f5',
+  card: '#ffffff',
+  text: '#000000',
+  subtext: '#777777',
+  border: '#e0e0e0',
+  placeholder: '#e0e0e0',
+  shadow: '#000000',
+};
+const darkColors = {
+  background: '#000000',
+  card: '#1c1c1c',
+  text: '#ffffff',
+  subtext: '#aaaaaa',
+  border: '#333333',
+  placeholder: '#333333',
+  shadow: '#000000',
+};
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+  topBar: {
+    height: 56,
+    paddingHorizontal: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    justifyContent: 'space-between',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  topIcons: {
+    flexDirection: 'row',
+  },
+  topIcon: {
+    marginLeft: 16,
+    fontSize: 18,
+  },
+  content: {
+    padding: 16,
+  },
+  card: {
+    padding: 24,
+    borderRadius: 8,
+    marginBottom: 24,
+    elevation: 2,
+    shadowOpacity: 0.2,
+    shadowOffset: { width: 0, height: 1 },
+    shadowRadius: 2,
+  },
+  cardText: {
+    fontSize: 16,
+  },
+  placeholder: {
+    height: 40,
+    borderRadius: 4,
+    marginBottom: 12,
+  },
+});
+
+export default ShellMock;


### PR DESCRIPTION
## Summary
- add mock shell screen with placeholder content and tab bar
- add mock settings/profile screen with sections and profile card
- include UI preview placeholders

## Testing
- `npm test` *(fails: Invalid package.json: JSONParseError)*
- `npm run lint` *(fails: Invalid package.json: JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_68a98092d788832fb7e891b5dfccceb6