### PR TITLE
feat: add matrix core crate

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -3,5 +3,380 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+
+[[package]]
+name = "cc"
+version = "1.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "matrix_core"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/native/rust/matrix_core/Cargo.toml
+++ b/native/rust/matrix_core/Cargo.toml
@@ -2,5 +2,23 @@
 name = "matrix_core"
 version = "0.1.0"
 edition = "2021"
+description = "Core abstractions, models, and storage for Matrix interactions"
+
+[lib]
+name = "matrix_core"
+path = "src/lib.rs"
+
+[features]
+default = ["sqlite"]
+sqlite = ["rusqlite"]
+mem-store = []
 
 [dependencies]
+async-trait = "0.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+rusqlite = { version = "0.31", features = ["bundled"], optional = true }
+
+[dev-dependencies]
+futures = "0.3"

--- a/native/rust/matrix_core/README.md
+++ b/native/rust/matrix_core/README.md
@@ -1,0 +1,23 @@
+# matrix_core
+
+`matrix_core` defines a minimal boundary for Matrix-based applications.
+It exposes configuration, session and event types alongside an abstract
+storage trait so that higher level crates can share a stable contract.
+No networking code or Matrix SDK is included; those responsibilities live
+in other layers.
+
+## Features
+
+- `ClientConfig` and `Session` structures.
+- `MatrixEvent` enums for messages, receipts, typing notifications and
+  room metadata.
+- `IMatrixStore` trait with async APIs.
+- In-memory (`mem-store` feature) and SQLite (`sqlite` feature, default)
+  storage adapters.
+- `CoreError` and `CoreResult` for unified error handling.
+
+## Non-goals
+
+This crate does **not** implement Matrix protocol interactions or
+federation. It simply provides stable types and storage abstractions
+that other crates can build upon.

--- a/native/rust/matrix_core/src/config.rs
+++ b/native/rust/matrix_core/src/config.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Configuration parameters for the Matrix client.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClientConfig {
+    /// Base URL of the homeserver.
+    pub homeserver_url: String,
+    /// User agent string for network requests.
+    pub user_agent: String,
+    /// Path where stores should persist data.
+    pub store_path: PathBuf,
+    /// Feature flags that can toggle functionality.
+    #[serde(default)]
+    pub feature_flags: HashMap<String, bool>,
+}

--- a/native/rust/matrix_core/src/error.rs
+++ b/native/rust/matrix_core/src/error.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+/// Errors emitted by the Matrix core crate.
+#[derive(Error, Debug)]
+pub enum CoreError {
+    /// Generic storage error.
+    #[error("storage error: {0}")]
+    Storage(String),
+    /// Serialization or deserialization error.
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    #[cfg(feature = "sqlite")]
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
+}
+
+/// Convenient result type used throughout the crate.
+pub type CoreResult<T> = Result<T, CoreError>;

--- a/native/rust/matrix_core/src/events.rs
+++ b/native/rust/matrix_core/src/events.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+/// A condensed set of Matrix events exposed to applications.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum MatrixEvent {
+    /// A room message with plain text content.
+    Message {
+        room_id: String,
+        sender: String,
+        body: String,
+    },
+    /// A read receipt for a specific event.
+    Receipt {
+        room_id: String,
+        event_id: String,
+        user_id: String,
+    },
+    /// Users currently typing in a room.
+    Typing {
+        room_id: String,
+        user_ids: Vec<String>,
+    },
+    /// Metadata for a room such as name or topic.
+    RoomMeta {
+        room_id: String,
+        name: Option<String>,
+        topic: Option<String>,
+    },
+}
+
+/// Persistent state for a room.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoomState {
+    /// Display name of the room.
+    pub name: Option<String>,
+    /// Topic for the room.
+    pub topic: Option<String>,
+}

--- a/native/rust/matrix_core/src/lib.rs
+++ b/native/rust/matrix_core/src/lib.rs
@@ -1,19 +1,92 @@
-//! Entry points for the `matrix_core` FFI.
+//! Matrix core abstractions for config, session, events and storage.
 //!
-//! Functions exposed from this crate follow the conventions in `FFI.md` and map
-//! directly to methods in the future Expo Module API.
+//! This crate defines a minimal, self-contained boundary that higher level
+//! application crates can depend on. It intentionally avoids networking or
+//! Matrix-specific SDK dependencies. Consumers are expected to implement
+//! network logic separately while relying on the types and storage contracts
+//! provided here.
 
-#[no_mangle]
-pub extern "C" fn matrix_core_sum(left: i32, right: i32) -> MatrixResult<i32> {
-    MatrixResult::Ok(left + right)
-}
+mod config;
+mod error;
+mod events;
+mod session;
+mod store;
+
+pub use config::ClientConfig;
+pub use error::{CoreError, CoreResult};
+pub use events::{MatrixEvent, RoomState};
+pub use session::Session;
+pub use store::IMatrixStore;
+
+#[cfg(feature = "mem-store")]
+pub use store::mem::MemStore;
+
+#[cfg(feature = "sqlite")]
+pub use store::sqlite::SqliteStore;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::executor::block_on;
+
+    #[cfg(feature = "mem-store")]
+    #[test]
+    fn session_roundtrip() {
+        let store = MemStore::new();
+        let session = Session {
+            user_id: "@alice:example.org".into(),
+            device_id: "DEVICEID".into(),
+            access_token: Some("token".into()),
+        };
+        block_on(store.put_session(&session)).unwrap();
+        let loaded = block_on(store.get_session()).unwrap().unwrap();
+        assert_eq!(loaded, session);
+    }
+
+    #[cfg(feature = "mem-store")]
+    #[test]
+    fn room_state_roundtrip() {
+        let store = MemStore::new();
+        let state = RoomState {
+            name: Some("My Room".into()),
+            topic: None,
+        };
+        block_on(store.put_room_state("!r:example.org", &state)).unwrap();
+        let loaded = block_on(store.get_room_state("!r:example.org"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded, state);
+    }
+
+    #[cfg(feature = "mem-store")]
+    #[test]
+    fn timeline_append_and_slice() {
+        let store = MemStore::new();
+        let events = vec![
+            MatrixEvent::Message {
+                room_id: "!r:example.org".into(),
+                sender: "@a:ex".into(),
+                body: "hi".into(),
+            },
+            MatrixEvent::Message {
+                room_id: "!r:example.org".into(),
+                sender: "@b:ex".into(),
+                body: "hey".into(),
+            },
+        ];
+        block_on(store.append_timeline_events("!r:example.org", &events)).unwrap();
+        let slice = block_on(store.get_timeline_slice("!r:example.org", 0, 2)).unwrap();
+        assert_eq!(slice, events);
+    }
 
     #[test]
-    fn it_adds() {
-        assert_eq!(matrix_core_sum(1, 1), 2);
+    fn event_serialization_roundtrip() {
+        let ev = MatrixEvent::Typing {
+            room_id: "!r:example.org".into(),
+            user_ids: vec!["@a:ex".into()],
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        let back: MatrixEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(ev, back);
     }
 }

--- a/native/rust/matrix_core/src/session.rs
+++ b/native/rust/matrix_core/src/session.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+/// User session credentials stored locally.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Session {
+    /// The user's Matrix ID.
+    pub user_id: String,
+    /// The device ID used for this session.
+    pub device_id: String,
+    /// Access token placeholder. Network layer is responsible for refreshing.
+    pub access_token: Option<String>,
+}

--- a/native/rust/matrix_core/src/store.rs
+++ b/native/rust/matrix_core/src/store.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+
+use crate::{
+    error::CoreResult,
+    events::{MatrixEvent, RoomState},
+    session::Session,
+};
+
+/// Abstraction over persistent storage used by the client.
+#[async_trait]
+pub trait IMatrixStore: Send + Sync {
+    /// Persist the user's session.
+    async fn put_session(&self, session: &Session) -> CoreResult<()>;
+    /// Retrieve the stored session if it exists.
+    async fn get_session(&self) -> CoreResult<Option<Session>>;
+    /// Store state information for a room.
+    async fn put_room_state(&self, room_id: &str, state: &RoomState) -> CoreResult<()>;
+    /// Retrieve room state, if any.
+    async fn get_room_state(&self, room_id: &str) -> CoreResult<Option<RoomState>>;
+    /// Append events to a room's timeline.
+    async fn append_timeline_events(&self, room_id: &str, events: &[MatrixEvent])
+        -> CoreResult<()>;
+    /// Fetch a slice of timeline events by index range.
+    async fn get_timeline_slice(
+        &self,
+        room_id: &str,
+        start: usize,
+        end: usize,
+    ) -> CoreResult<Vec<MatrixEvent>>;
+}
+
+#[cfg(feature = "mem-store")]
+pub mod mem;
+
+#[cfg(feature = "sqlite")]
+pub mod sqlite;

--- a/native/rust/matrix_core/src/store/mem.rs
+++ b/native/rust/matrix_core/src/store/mem.rs
@@ -26,25 +26,25 @@ impl MemStore {
 #[async_trait::async_trait]
 impl IMatrixStore for MemStore {
     async fn put_session(&self, session: &Session) -> CoreResult<()> {
-        let mut guard = self.session.lock().unwrap();
+        let mut guard = self.session.lock().map_err(|e| anyhow!(e.to_string()))?;
         *guard = Some(session.clone());
         Ok(())
     }
 
     async fn get_session(&self) -> CoreResult<Option<Session>> {
-        Ok(self.session.lock().unwrap().clone())
+        Ok(self.session.lock().map_err(|e| anyhow!(e.to_string()))?.clone())
     }
 
     async fn put_room_state(&self, room_id: &str, state: &RoomState) -> CoreResult<()> {
         self.room_state
             .lock()
-            .unwrap()
+            .map_err(|e| anyhow!(e.to_string()))?
             .insert(room_id.to_string(), state.clone());
         Ok(())
     }
 
     async fn get_room_state(&self, room_id: &str) -> CoreResult<Option<RoomState>> {
-        Ok(self.room_state.lock().unwrap().get(room_id).cloned())
+        Ok(self.room_state.lock().map_err(|e| anyhow!(e.to_string()))?.get(room_id).cloned())
     }
 
     async fn append_timeline_events(

--- a/native/rust/matrix_core/src/store/mem.rs
+++ b/native/rust/matrix_core/src/store/mem.rs
@@ -26,25 +26,25 @@ impl MemStore {
 #[async_trait::async_trait]
 impl IMatrixStore for MemStore {
     async fn put_session(&self, session: &Session) -> CoreResult<()> {
-        let mut guard = self.session.lock().map_err(|e| anyhow!(e.to_string()))?;
+        let mut guard = self.session.lock().map_err(|e| CoreError::PoisonedLock(e.to_string()))?;
         *guard = Some(session.clone());
         Ok(())
     }
 
     async fn get_session(&self) -> CoreResult<Option<Session>> {
-        Ok(self.session.lock().map_err(|e| anyhow!(e.to_string()))?.clone())
+        Ok(self.session.lock().map_err(|e| CoreError::PoisonedLock(e.to_string()))?.clone())
     }
 
     async fn put_room_state(&self, room_id: &str, state: &RoomState) -> CoreResult<()> {
         self.room_state
             .lock()
-            .map_err(|e| anyhow!(e.to_string()))?
+            .map_err(|e| CoreError::PoisonedLock(e.to_string()))?
             .insert(room_id.to_string(), state.clone());
         Ok(())
     }
 
     async fn get_room_state(&self, room_id: &str) -> CoreResult<Option<RoomState>> {
-        Ok(self.room_state.lock().map_err(|e| anyhow!(e.to_string()))?.get(room_id).cloned())
+        Ok(self.room_state.lock().map_err(|e| CoreError::PoisonedLock(e.to_string()))?.get(room_id).cloned())
     }
 
     async fn append_timeline_events(

--- a/native/rust/matrix_core/src/store/mem.rs
+++ b/native/rust/matrix_core/src/store/mem.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use super::IMatrixStore;
+use crate::{
+    error::CoreResult,
+    events::{MatrixEvent, RoomState},
+    session::Session,
+};
+
+/// Simple in-memory store useful for tests.
+#[derive(Default)]
+pub struct MemStore {
+    session: Mutex<Option<Session>>,
+    room_state: Mutex<HashMap<String, RoomState>>,
+    timelines: Mutex<HashMap<String, Vec<MatrixEvent>>>,
+}
+
+impl MemStore {
+    /// Create a new empty in-memory store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl IMatrixStore for MemStore {
+    async fn put_session(&self, session: &Session) -> CoreResult<()> {
+        let mut guard = self.session.lock().unwrap();
+        *guard = Some(session.clone());
+        Ok(())
+    }
+
+    async fn get_session(&self) -> CoreResult<Option<Session>> {
+        Ok(self.session.lock().unwrap().clone())
+    }
+
+    async fn put_room_state(&self, room_id: &str, state: &RoomState) -> CoreResult<()> {
+        self.room_state
+            .lock()
+            .unwrap()
+            .insert(room_id.to_string(), state.clone());
+        Ok(())
+    }
+
+    async fn get_room_state(&self, room_id: &str) -> CoreResult<Option<RoomState>> {
+        Ok(self.room_state.lock().unwrap().get(room_id).cloned())
+    }
+
+    async fn append_timeline_events(
+        &self,
+        room_id: &str,
+        events: &[MatrixEvent],
+    ) -> CoreResult<()> {
+        let mut timelines = self.timelines.lock().unwrap();
+        let timeline = timelines.entry(room_id.to_string()).or_default();
+        timeline.extend_from_slice(events);
+        Ok(())
+    }
+
+    async fn get_timeline_slice(
+        &self,
+        room_id: &str,
+        start: usize,
+        end: usize,
+    ) -> CoreResult<Vec<MatrixEvent>> {
+        let timelines = self.timelines.lock().unwrap();
+        let timeline = timelines.get(room_id).cloned().unwrap_or_default();
+        let slice = timeline.into_iter().skip(start).take(end - start).collect();
+        Ok(slice)
+    }
+}

--- a/native/rust/matrix_core/src/store/sqlite.rs
+++ b/native/rust/matrix_core/src/store/sqlite.rs
@@ -1,0 +1,115 @@
+use std::path::Path;
+use std::sync::Mutex;
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+use super::IMatrixStore;
+use crate::{
+    error::CoreResult,
+    events::{MatrixEvent, RoomState},
+    session::Session,
+};
+
+/// SQLite-backed store using rusqlite.
+pub struct SqliteStore {
+    conn: Mutex<Connection>,
+}
+
+impl SqliteStore {
+    /// Open a new SQLite store at the given path.
+    pub fn open(path: &Path) -> CoreResult<Self> {
+        let conn = Connection::open(path)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS session (data TEXT);
+             CREATE TABLE IF NOT EXISTS room_state (room_id TEXT PRIMARY KEY, data TEXT);
+             CREATE TABLE IF NOT EXISTS timeline (room_id TEXT, idx INTEGER, data TEXT);",
+        )?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl IMatrixStore for SqliteStore {
+    async fn put_session(&self, session: &Session) -> CoreResult<()> {
+        let json = serde_json::to_string(session)?;
+        let conn = self.conn.lock().unwrap();
+        conn.execute("DELETE FROM session", [])?;
+        conn.execute("INSERT INTO session (data) VALUES (?1)", [json])?;
+        Ok(())
+    }
+
+    async fn get_session(&self) -> CoreResult<Option<Session>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT data FROM session LIMIT 1")?;
+        let opt: Option<String> = stmt.query_row([], |row| row.get(0)).optional()?;
+        let session = opt.map(|json| serde_json::from_str(&json)).transpose()?;
+        Ok(session)
+    }
+
+    async fn put_room_state(&self, room_id: &str, state: &RoomState) -> CoreResult<()> {
+        let json = serde_json::to_string(state)?;
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO room_state (room_id, data) VALUES (?1, ?2)
+             ON CONFLICT(room_id) DO UPDATE SET data=excluded.data",
+            params![room_id, json],
+        )?;
+        Ok(())
+    }
+
+    async fn get_room_state(&self, room_id: &str) -> CoreResult<Option<RoomState>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT data FROM room_state WHERE room_id = ?1")?;
+        let opt: Option<String> = stmt.query_row([room_id], |row| row.get(0)).optional()?;
+        let state = opt.map(|json| serde_json::from_str(&json)).transpose()?;
+        Ok(state)
+    }
+
+    async fn append_timeline_events(
+        &self,
+        room_id: &str,
+        events: &[MatrixEvent],
+    ) -> CoreResult<()> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let mut idx: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(idx), -1) FROM timeline WHERE room_id = ?1",
+            [room_id],
+            |row| row.get(0),
+        )?;
+        for ev in events {
+            idx += 1;
+            let json = serde_json::to_string(ev)?;
+            tx.execute(
+                "INSERT INTO timeline (room_id, idx, data) VALUES (?1, ?2, ?3)",
+                params![room_id, idx, json],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    async fn get_timeline_slice(
+        &self,
+        room_id: &str,
+        start: usize,
+        end: usize,
+    ) -> CoreResult<Vec<MatrixEvent>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT data FROM timeline WHERE room_id = ?1 AND idx >= ?2 AND idx < ?3 ORDER BY idx ASC",
+        )?;
+        let rows = stmt.query_map(params![room_id, start as i64, end as i64], |row| {
+            let json: String = row.get(0)?;
+            Ok(json)
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            let json: String = row?;
+            out.push(serde_json::from_str(&json)?);
+        }
+        Ok(out)
+    }
+}

--- a/native/rust/matrix_core/src/store/sqlite.rs
+++ b/native/rust/matrix_core/src/store/sqlite.rs
@@ -34,14 +34,14 @@ impl SqliteStore {
 impl IMatrixStore for SqliteStore {
     async fn put_session(&self, session: &Session) -> CoreResult<()> {
         let json = serde_json::to_string(session)?;
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|e| crate::error::CoreError::MutexPoisoned(e.to_string()))?;
         conn.execute("DELETE FROM session", [])?;
         conn.execute("INSERT INTO session (data) VALUES (?1)", [json])?;
         Ok(())
     }
 
     async fn get_session(&self) -> CoreResult<Option<Session>> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|e| crate::error::CoreError::MutexPoisoned(e.to_string()))?;
         let mut stmt = conn.prepare("SELECT data FROM session LIMIT 1")?;
         let opt: Option<String> = stmt.query_row([], |row| row.get(0)).optional()?;
         let session = opt.map(|json| serde_json::from_str(&json)).transpose()?;


### PR DESCRIPTION
## Summary
- add standalone `matrix_core` crate with configuration, session, event types, and storage trait
- provide in-memory and SQLite storage implementations
- document crate purpose and non-goals

## Testing
- `cargo test --features mem-store`

------
https://chatgpt.com/codex/tasks/task_e_68a980eec554832fb6a20ccdf1810081