### PR TITLE
fix: correct license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "AGPL-3.0-only",
   "type": "commonjs",
   "lint-staged": {
     "*.{ts,tsx,js,json,md}": [


### PR DESCRIPTION
## Summary
- update package.json license to AGPL-3.0-only to match repository license

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9f13ece08832fb32f4331a1f03c03