### PR TITLE
feat: add chats list mock screen

### DIFF
--- a/apps/mobile/src/components/chats/Avatar.tsx
+++ b/apps/mobile/src/components/chats/Avatar.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Image, Text, View, StyleSheet } from 'react-native';
+
+interface Props {
+  title: string;
+  avatarUri?: string;
+  size?: number;
+}
+
+export default function Avatar({ title, avatarUri, size = 48 }: Props) {
+  const initials = title
+    .split(' ')
+    .map((p) => p[0])
+    .join('')
+    .toUpperCase();
+
+  if (avatarUri) {
+    return (
+      <Image
+        source={{ uri: avatarUri }}
+        style={[
+          styles.image,
+          { width: size, height: size, borderRadius: size / 2 },
+        ]}
+      />
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.placeholder,
+        { width: size, height: size, borderRadius: size / 2 },
+      ]}
+    >
+      <Text style={styles.initials}>{initials}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  image: {
+    resizeMode: 'cover',
+  },
+  placeholder: {
+    backgroundColor: '#ccc',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  initials: {
+    color: '#555',
+    fontWeight: 'bold',
+  },
+});

--- a/apps/mobile/src/components/chats/Avatar.tsx
+++ b/apps/mobile/src/components/chats/Avatar.tsx
@@ -8,11 +8,15 @@ interface Props {
 }
 
 export default function Avatar({ title, avatarUri, size = 48 }: Props) {
-  const initials = title
-    .split(' ')
-    .map((p) => p[0])
-    .join('')
-    .toUpperCase();
+  const initials =
+    !title || !title.trim()
+      ? ''
+      : title
+          .split(' ')
+          .filter((p) => p.trim().length > 0)
+          .map((p) => p[0])
+          .join('')
+          .toUpperCase();
 
   if (avatarUri) {
     return (

--- a/apps/mobile/src/components/chats/ChatListItem.tsx
+++ b/apps/mobile/src/components/chats/ChatListItem.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ViewStyle,
+} from 'react-native';
+import Avatar from './Avatar';
+import UnreadBadge from './UnreadBadge';
+
+export interface ChatListItemProps {
+  title: string;
+  preview: string;
+  time: string;
+  unreadCount?: number;
+  muted?: boolean;
+  pinned?: boolean;
+  avatarUri?: string;
+  style?: ViewStyle;
+}
+
+export default function ChatListItem({
+  title,
+  preview,
+  time,
+  unreadCount,
+  muted,
+  pinned,
+  avatarUri,
+  style,
+}: ChatListItemProps) {
+  const accessibility = `Chat with ${title}${
+    unreadCount ? `, ${unreadCount} unread messages` : ''
+  }`;
+
+  return (
+    <TouchableOpacity
+      style={[styles.container, style]}
+      accessibilityRole="button"
+      accessibilityLabel={accessibility}
+    >
+      {pinned && <Text style={styles.pin}>📌</Text>}
+      <Avatar title={title} avatarUri={avatarUri} />
+      <View style={styles.content}>
+        <View style={styles.rowTop}>
+          <Text style={styles.title} numberOfLines={1}>
+            {title}
+          </Text>
+          <Text style={styles.time}>{time}</Text>
+        </View>
+        <View style={styles.rowBottom}>
+          <Text style={styles.preview} numberOfLines={1}>
+            {preview}
+          </Text>
+          <View style={styles.rightIcons}>
+            {muted && <Text style={styles.muted}>🔇</Text>}
+            {typeof unreadCount === 'number' && unreadCount > 0 && (
+              <UnreadBadge count={unreadCount} />
+            )}
+          </View>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const ROW_HEIGHT = 72;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    height: ROW_HEIGHT,
+    backgroundColor: 'transparent',
+  },
+  pin: {
+    marginRight: 4,
+    fontSize: 16,
+  },
+  content: {
+    flex: 1,
+    marginLeft: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#ccc',
+    height: '100%',
+    justifyContent: 'center',
+  },
+  rowTop: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  rowBottom: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  title: {
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  preview: {
+    color: '#666',
+    flex: 1,
+    marginRight: 8,
+  },
+  time: {
+    color: '#666',
+    fontSize: 12,
+  },
+  rightIcons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  muted: {
+    marginRight: 4,
+  },
+});
+
+export const getItemLayout = (_: unknown, index: number) => ({
+  length: ROW_HEIGHT,
+  offset: ROW_HEIGHT * index,
+  index,
+});

--- a/apps/mobile/src/components/chats/UnreadBadge.tsx
+++ b/apps/mobile/src/components/chats/UnreadBadge.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+
+interface Props {
+  count: number;
+}
+
+export default function UnreadBadge({ count }: Props) {
+  const display = count > 99 ? '99+' : String(count);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>{display}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#25d366',
+    borderRadius: 10,
+    paddingHorizontal: 6,
+    minWidth: 20,
+    height: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+});

--- a/apps/mobile/src/screens/ChatsListMock.tsx
+++ b/apps/mobile/src/screens/ChatsListMock.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import {
+  SafeAreaView,
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  RefreshControl,
+  useColorScheme,
+} from 'react-native';
+import ChatListItem, {
+  getItemLayout,
+  ChatListItemProps,
+} from '../components/chats/ChatListItem';
+
+const mockChats: (ChatListItemProps & { id: string })[] = [
+  {
+    id: '1',
+    title: 'Alice',
+    preview: 'Hey, are we still on for tonight?',
+    time: '09:41',
+    unreadCount: 3,
+  },
+  {
+    id: '2',
+    title: 'Bob',
+    preview: 'Sure, see you there!',
+    time: '08:22',
+    muted: true,
+  },
+  {
+    id: '3',
+    title: 'Charlie Group',
+    preview: 'Charlie: Shared a photo',
+    time: 'Yesterday',
+    unreadCount: 12,
+    pinned: true,
+  },
+  {
+    id: '4',
+    title: 'Dora',
+    preview: 'Let me know.',
+    time: 'Yesterday',
+  },
+  {
+    id: '5',
+    title: 'Eve',
+    preview: 'This is a very long message preview that should be truncated.',
+    time: 'Mon',
+  },
+  {
+    id: '6',
+    title: 'Frank',
+    preview: '👍',
+    time: 'Sun',
+    unreadCount: 1,
+  },
+  {
+    id: '7',
+    title: 'Grace',
+    preview: 'Typing...',
+    time: 'Sat',
+    muted: true,
+    unreadCount: 2,
+  },
+  {
+    id: '8',
+    title: 'Heidi',
+    preview: 'Check this out!',
+    time: 'Fri',
+  },
+  {
+    id: '9',
+    title: 'Ivan',
+    preview: 'Ok',
+    time: 'Fri',
+  },
+  {
+    id: '10',
+    title: 'Judy',
+    preview: "Let's catch up soon",
+    time: 'Thu',
+    unreadCount: 99,
+  },
+];
+
+export default function ChatsListMock() {
+  const scheme = useColorScheme();
+  const isDark = scheme === 'dark';
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: isDark ? '#000' : '#fff',
+    },
+    header: {
+      height: 56,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 16,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: isDark ? '#333' : '#ccc',
+    },
+    headerTitle: {
+      fontSize: 20,
+      fontWeight: 'bold',
+      color: isDark ? '#fff' : '#000',
+    },
+    headerIcon: {
+      fontSize: 18,
+      color: isDark ? '#fff' : '#000',
+    },
+    tabs: {
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: isDark ? '#333' : '#ccc',
+    },
+    tab: {
+      paddingVertical: 8,
+      color: isDark ? '#fff' : '#000',
+    },
+  });
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>mChat</Text>
+        <Text style={styles.headerIcon}>🔍</Text>
+      </View>
+      <View style={styles.tabs}>
+        {['All', 'Unread', 'Groups'].map((tab) => (
+          <Text key={tab} style={styles.tab}>
+            {tab}
+          </Text>
+        ))}
+      </View>
+      <FlatList
+        data={mockChats}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <ChatListItem {...item} />}
+        getItemLayout={getItemLayout}
+        refreshControl={
+          <RefreshControl refreshing={false} onRefresh={() => {}} />
+        }
+      />
+    </SafeAreaView>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "typecheck": "tsc -p packages/chat-types/tsconfig.json"
+    "typecheck": "tsc -p packages/chat-types/tsconfig.json",
     "lint": "eslint '**/*.{ts,tsx,js}'",
     "format": "prettier --write '**/*.{ts,tsx,js,json,md}'",
     "prepare": "husky install",
@@ -45,6 +45,6 @@
     "eslint-plugin-react-native": "^5.0.0",
     "husky": "^9.0.10",
     "lint-staged": "^15.2.0",
-    "prettier": "^3.3.2">>>>>> main
+    "prettier": "^3.3.2"
   }
 }

--- a/packages/message-ui/package.json
+++ b/packages/message-ui/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@mchat/message-ui",
   "version": "0.1.0",
-  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- create mock chats list screen with hardcoded data and basic header/tabs
- add Avatar, UnreadBadge, and ChatListItem components for chat rows
- remove placeholder screenshot and fix package manifests for valid npm scripts

## Testing
- `npm test`
- `npm run lint` *(fails: formatting issues in existing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a980429d8c832f9cbc8a4cd2c0d28e