### PR TITLE
feat: add mock lightning core expo module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ packages/*/dist/
 .expo-shared/
 android/
 ios/
+!native/ln-core/android/
+!native/ln-core/android/**
+!native/ln-core/ios/
+!native/ln-core/ios/**
 web-build/
 *.jks
 *.keystore

--- a/native/ln-core/README.md
+++ b/native/ln-core/README.md
@@ -1,0 +1,27 @@
+# Ln Core Expo Module (Mock)
+
+This directory contains a mock implementation of a Lightning node core for use in Expo/React Native apps.
+It exposes a stable TypeScript API and deterministic native shims so the module can be called from JavaScript
+without connecting to real Lightning nodes or handling funds.
+
+## Features
+
+- `init` / `isReady` lifecycle helpers
+- fixed `nodeInfo`
+- mock invoice creation returning a dummy BOLT11 string
+- mock payment that resolves after a short delay and emits `PaymentUpdated` events
+- in-memory payment list and fee estimation helpers
+
+**NO REAL FUNDS:** this mock does not open channels or broadcast payments. It should never be used
+in production as-is. Replace the native shims with a Breez SDK or LDK backed implementation for real
+Lightning support.
+
+## Replacing the Mock
+
+To swap in a real implementation:
+
+1. Add native dependencies for your chosen Lightning library (Breez SDK, LDK, etc.)
+2. Extend the Swift/Kotlin shims in `ios/` and `android/` to call into that library
+3. Implement secure storage of node keys and channel state in the `init` options
+4. Update the Expo config plugin `with-ln-core.ts` with any required native build steps or binaries
+

--- a/native/ln-core/android/build.gradle
+++ b/native/ln-core/android/build.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'com.android.library'
+
+android {
+  compileSdkVersion 33
+  defaultConfig {
+    minSdkVersion 23
+    targetSdkVersion 33
+  }
+  sourceSets {
+    main {
+      java.srcDirs = ['src/main/java']
+      manifest.srcFile 'src/main/AndroidManifest.xml'
+    }
+  }
+}
+
+dependencies {
+  implementation 'com.facebook.react:react-native:+'
+}

--- a/native/ln-core/android/src/main/AndroidManifest.xml
+++ b/native/ln-core/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.mchat.lncore">
+</manifest>

--- a/native/ln-core/android/src/main/java/com/mchat/lncore/LnCoreModule.kt
+++ b/native/ln-core/android/src/main/java/com/mchat/lncore/LnCoreModule.kt
@@ -1,0 +1,70 @@
+package com.mchat.lncore
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import kotlinx.coroutines.delay
+import java.util.UUID
+
+class LnCoreModule : Module() {
+  private val payments = mutableListOf<MutableMap<String, Any>>()
+  private var network: String = "testnet"
+
+  override fun definition() = ModuleDefinition {
+    Name("LnCore")
+    Events("PaymentUpdated")
+
+    AsyncFunction("init") { opts: Map<String, Any>? ->
+      opts?.get("network")?.let { network = it as String }
+      mapOf("ok" to true)
+    }
+
+    AsyncFunction("isReady") { true }
+
+    AsyncFunction("nodeInfo") {
+      mapOf(
+        "pubkey" to "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "alias" to "MockNode",
+        "connected" to false
+      )
+    }
+
+    AsyncFunction("createInvoice") { params: Map<String, Any> ->
+      val amount = (params["amountSats"] as? Number)?.toLong() ?: 0L
+      val memo = params["memo"] as? String
+      val id = UUID.randomUUID().toString()
+      val prefix = when (network) {
+        "mainnet" -> "lnbc"
+        "signet" -> "lntbs"
+        else -> "lntb"
+      }
+      val bolt11 = "${prefix}1mock${id.take(8)}"
+      val payment = mutableMapOf<String, Any>(
+        "id" to id,
+        "bolt11" to bolt11,
+        "status" to "pending",
+        "amountSats" to amount,
+        "timestamp" to System.currentTimeMillis() / 1000
+      )
+      payments.add(payment)
+      mutableMapOf<String, Any>("bolt11" to bolt11, "amountSats" to amount).apply {
+        memo?.let { put("memo", it) }
+      }
+    }
+
+    AsyncFunction("payInvoice") { bolt11: String ->
+      val payment = payments.find { it["bolt11"] == bolt11 }
+      val id = payment?.get("id") as? String ?: UUID.randomUUID().toString()
+      sendEvent("PaymentUpdated", mapOf("id" to id, "status" to "pending"))
+      delay((300..800).random().toLong())
+      payment?.set("status", "succeeded")
+      sendEvent("PaymentUpdated", mapOf("id" to id, "status" to "succeeded"))
+      mapOf("preimage" to "a".repeat(64), "feesSats" to 1)
+    }
+
+    AsyncFunction("estimateFees") { _: String ->
+      mapOf("maxFeesSats" to 1)
+    }
+
+    AsyncFunction("listPayments") { payments.toList() }
+  }
+}

--- a/native/ln-core/index.ts
+++ b/native/ln-core/index.ts
@@ -1,0 +1,34 @@
+import { EventEmitter, Subscription, requireNativeModule } from 'expo-modules-core';
+
+export type LnInitOptions = { dataDir?: string; network?: 'mainnet' | 'testnet' | 'signet' };
+export type LnInvoice = { bolt11: string; amountSats?: number; memo?: string };
+export type Payment = { id: string; bolt11: string; status: 'pending' | 'succeeded' | 'failed'; amountSats: number; timestamp: number };
+export type PaymentUpdatedEvent = { id: string; status: 'pending' | 'succeeded' | 'failed' };
+
+export interface LnCore {
+  init(opts: LnInitOptions): Promise<{ ok: true }>;
+  isReady(): Promise<boolean>;
+  nodeInfo(): Promise<{ pubkey: string; alias: string; connected: boolean }>;
+  createInvoice(params: { amountSats: number; memo?: string }): Promise<LnInvoice>;
+  payInvoice(bolt11: string): Promise<{ preimage: string; feesSats: number }>;
+  estimateFees(bolt11: string): Promise<{ maxFeesSats: number }>;
+  listPayments(): Promise<Payment[]>;
+}
+
+const LnCoreModule = requireNativeModule<LnCore>('LnCore');
+const emitter = new EventEmitter(LnCoreModule);
+
+export function addPaymentUpdatedListener(listener: (event: PaymentUpdatedEvent) => void): Subscription {
+  return emitter.addListener('PaymentUpdated', listener);
+}
+
+export default {
+  init: (opts: LnInitOptions) => LnCoreModule.init(opts),
+  isReady: () => LnCoreModule.isReady(),
+  nodeInfo: () => LnCoreModule.nodeInfo(),
+  createInvoice: (params: { amountSats: number; memo?: string }) => LnCoreModule.createInvoice(params),
+  payInvoice: (bolt11: string) => LnCoreModule.payInvoice(bolt11),
+  estimateFees: (bolt11: string) => LnCoreModule.estimateFees(bolt11),
+  listPayments: () => LnCoreModule.listPayments(),
+  addPaymentUpdatedListener,
+};

--- a/native/ln-core/ios/LnCoreModule.swift
+++ b/native/ln-core/ios/LnCoreModule.swift
@@ -1,0 +1,74 @@
+import ExpoModulesCore
+import Foundation
+
+public class LnCoreModule: Module {
+  private var payments: [[String: Any]] = []
+  private var network: String = "testnet"
+
+  public func definition() -> ModuleDefinition {
+    Name("LnCore")
+    Events("PaymentUpdated")
+
+    AsyncFunction("init") { (opts: [String: Any]?) -> [String: Bool] in
+      if let net = opts?["network"] as? String {
+        self.network = net
+      }
+      return ["ok": true]
+    }
+
+    AsyncFunction("isReady") { true }
+
+    AsyncFunction("nodeInfo") {
+      [
+        "pubkey": "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "alias": "MockNode",
+        "connected": false
+      ]
+    }
+
+    AsyncFunction("createInvoice") { (params: [String: Any]) -> [String: Any] in
+      let amount = params["amountSats"] as? Int ?? 0
+      let memo = params["memo"] as? String
+      let id = UUID().uuidString
+      let prefix: String
+      switch self.network {
+      case "mainnet": prefix = "lnbc"
+      case "signet": prefix = "lntbs"
+      default: prefix = "lntb"
+      }
+      let bolt11 = "\(prefix)1mock\(id.prefix(8))"
+      let payment: [String: Any] = [
+        "id": id,
+        "bolt11": bolt11,
+        "status": "pending",
+        "amountSats": amount,
+        "timestamp": Int(Date().timeIntervalSince1970)
+      ]
+      self.payments.append(payment)
+      var invoice: [String: Any] = ["bolt11": bolt11, "amountSats": amount]
+      if let memo = memo { invoice["memo"] = memo }
+      return invoice
+    }
+
+    AsyncFunction("payInvoice") { (bolt11: String, promise: Promise) in
+      guard let index = self.payments.firstIndex(where: { ($0["bolt11"] as? String) == bolt11 }) else {
+        promise.reject("", "Unknown invoice", nil)
+        return
+      }
+      let id = self.payments[index]["id"] as! String
+      self.sendEvent("PaymentUpdated", ["id": id, "status": "pending"])
+      let delay = DispatchTime.now() + .milliseconds(Int.random(in: 300...800))
+      DispatchQueue.main.asyncAfter(deadline: delay) {
+        self.payments[index]["status"] = "succeeded"
+        self.sendEvent("PaymentUpdated", ["id": id, "status": "succeeded"])
+        promise.resolve(["preimage": String(repeating: "a", count: 64), "feesSats": 1])
+      }
+    }
+
+    AsyncFunction("estimateFees") { (_: String) -> [String: Int] in
+      ["maxFeesSats": 1]
+    }
+
+    AsyncFunction("listPayments") { self.payments }
+  }
+}

--- a/native/ln-core/package.json
+++ b/native/ln-core/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@mchat/ln-core",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./with-ln-core": {
+      "types": "./dist/with-ln-core.d.ts",
+      "default": "./dist/with-ln-core.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/native/ln-core/tsconfig.json
+++ b/native/ln-core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["index.ts", "with-ln-core.ts"]
+}

--- a/native/ln-core/with-ln-core.ts
+++ b/native/ln-core/with-ln-core.ts
@@ -1,0 +1,27 @@
+import { ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
+
+/**
+ * Stub Expo config plugin for future Lightning core integration.
+ * Add Breez SDK or LDK native dependencies here in the future.
+ */
+const withLnCore: ConfigPlugin = (config) => {
+  config = withDangerousMod(config, [
+    'ios',
+    async (c) => {
+      console.log('with-ln-core: iOS configuration placeholder');
+      return c;
+    },
+  ]);
+
+  config = withDangerousMod(config, [
+    'android',
+    async (c) => {
+      console.log('with-ln-core: Android configuration placeholder');
+      return c;
+    },
+  ]);
+
+  return config;
+};
+
+export default withLnCore;

--- a/packages/lightning-ui/LnCoreDemoScreen.tsx
+++ b/packages/lightning-ui/LnCoreDemoScreen.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, FlatList } from 'react-native';
+import LnCore, { addPaymentUpdatedListener, LnInvoice, Payment } from '../../native/ln-core';
+
+const LnCoreDemoScreen: React.FC = () => {
+  const [info, setInfo] = useState<{ pubkey: string; alias: string; connected: boolean } | null>(null);
+  const [invoice, setInvoice] = useState<LnInvoice | null>(null);
+  const [payments, setPayments] = useState<Payment[]>([]);
+
+  useEffect(() => {
+    LnCore.init({ network: 'testnet' }).then(() => {
+      LnCore.nodeInfo().then(setInfo);
+      LnCore.listPayments().then(setPayments);
+    });
+    const sub = addPaymentUpdatedListener((evt) => {
+      setPayments((prev) => prev.map((p) => (p.id === evt.id ? { ...p, status: evt.status } : p)));
+    });
+    return () => sub.remove();
+  }, []);
+
+  const handleCreate = async () => {
+    const inv = await LnCore.createInvoice({ amountSats: 1000, memo: 'demo' });
+    setInvoice(inv);
+    setPayments(await LnCore.listPayments());
+  };
+
+  const handlePay = async () => {
+    if (!invoice) return;
+    await LnCore.payInvoice(invoice.bolt11);
+    setPayments(await LnCore.listPayments());
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text style={{ marginBottom: 8 }}>
+        {info ? `Node ${info.alias} (${info.pubkey.slice(0, 8)}...)` : 'Initializing...'}
+      </Text>
+      <Button title="Create Invoice" onPress={handleCreate} />
+      {invoice && (
+        <>
+          <Text selectable style={{ marginVertical: 8 }}>{invoice.bolt11}</Text>
+          <Button title="Pay Invoice" onPress={handlePay} />
+        </>
+      )}
+      <FlatList
+        style={{ marginTop: 16 }}
+        data={payments}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <Text>{`${item.bolt11.slice(0, 10)}… - ${item.status}`}</Text>
+        )}
+      />
+    </View>
+  );
+};
+
+export default LnCoreDemoScreen;

--- a/packages/lightning-ui/index.ts
+++ b/packages/lightning-ui/index.ts
@@ -1,0 +1,1 @@
+export { default as LnCoreDemoScreen } from './LnCoreDemoScreen';

--- a/packages/lightning-ui/package.json
+++ b/packages/lightning-ui/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@mchat/lightning-ui",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/lightning-ui/tsconfig.json
+++ b/packages/lightning-ui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["index.ts", "LnCoreDemoScreen.tsx"]
+}


### PR DESCRIPTION
## Summary
- scaffold `native/ln-core` expo module with typed API and stub config plugin
- add Swift and Kotlin shims with deterministic mock data and PaymentUpdated events
- provide `LnCoreDemoScreen` in new `@mchat/lightning-ui` package for testing the mock

## Testing
- `npm test` *(fails: Invalid package.json)*
- `apps/mobile/node_modules/.bin/tsc -p native/ln-core/tsconfig.json` *(fails: Cannot find module 'expo-modules-core')*

------
https://chatgpt.com/codex/tasks/task_e_68a981defb48832f8602b7724a06fa69