### PR TITLE
feat: add lightning payment UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "typecheck": "tsc -p packages/chat-types/tsconfig.json"
+    "typecheck": "tsc -p packages/chat-types/tsconfig.json",
     "lint": "eslint '**/*.{ts,tsx,js}'",
     "format": "prettier --write '**/*.{ts,tsx,js,json,md}'",
     "prepare": "husky install",
@@ -45,6 +45,6 @@
     "eslint-plugin-react-native": "^5.0.0",
     "husky": "^9.0.10",
     "lint-staged": "^15.2.0",
-    "prettier": "^3.3.2">>>>>> main
+    "prettier": "^3.3.2"
   }
 }

--- a/packages/lightning-ui/HighlightLightningText.tsx
+++ b/packages/lightning-ui/HighlightLightningText.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { detectPaymentStrings } from './detect';
+import PaymentSheet from './PaymentSheet';
+
+interface HighlightLightningTextProps {
+  text: string;
+}
+
+export const HighlightLightningText: React.FC<HighlightLightningTextProps> = ({ text }) => {
+  const [selected, setSelected] = useState<string | null>(null);
+  const matches = detectPaymentStrings(text);
+  let cursor = 0;
+  const elements: React.ReactNode[] = [];
+
+  const occurrences = matches.map((m) => {
+    const index = text.indexOf(m.value, cursor);
+    const occurrence = { ...m, index };
+    if (index >= 0) {
+      cursor = index + m.value.length;
+    }
+    return occurrence;
+  });
+  occurrences.sort((a, b) => a.index - b.index);
+
+  cursor = 0;
+  occurrences.forEach((m, i) => {
+    if (m.index > cursor) {
+      elements.push(<Text key={`t-${i}`}>{text.slice(cursor, m.index)}</Text>);
+    }
+    elements.push(
+      <TouchableOpacity
+        key={`c-${i}`}
+        onPress={() => setSelected(m.value)}
+        style={styles.chip}
+        accessibilityRole="button"
+      >
+        <Text style={styles.chipText}>{m.value}</Text>
+      </TouchableOpacity>
+    );
+    cursor = m.index + m.value.length;
+  });
+  if (cursor < text.length) {
+    elements.push(<Text key="tail">{text.slice(cursor)}</Text>);
+  }
+
+  return (
+    <>
+      <Text>{elements}</Text>
+      {selected && (
+        <PaymentSheet
+          visible={true}
+          invoice={selected}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  chip: {
+    backgroundColor: '#e0f7ff',
+    paddingHorizontal: 4,
+    borderRadius: 4,
+    marginHorizontal: 2,
+  },
+  chipText: {
+    color: '#0366d6',
+  },
+});
+
+export default HighlightLightningText;

--- a/packages/lightning-ui/LightningDemoScreen.tsx
+++ b/packages/lightning-ui/LightningDemoScreen.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { ScrollView, View, StyleSheet } from 'react-native';
+import HighlightLightningText from './HighlightLightningText';
+import RequestPaymentMock from './RequestPaymentMock';
+
+export const LightningDemoScreen: React.FC = () => {
+  const [messages, setMessages] = useState<string[]>([
+    'Pay me at lnbc2501hello for lunch.',
+    'Try this LNURL: lnurl1dp68gurn8ghj7ctsdyhxyctwv96kx.',
+    'Or a lightning URI lightning:lnbc501testmemo.',
+  ]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {messages.map((m, i) => (
+        <View key={i} style={styles.message}>
+          <HighlightLightningText text={m} />
+        </View>
+      ))}
+      <RequestPaymentMock onInvoice={(inv) => setMessages([...messages, inv])} />
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  message: {
+    marginBottom: 16,
+  },
+});
+
+export default LightningDemoScreen;

--- a/packages/lightning-ui/PaymentSheet.tsx
+++ b/packages/lightning-ui/PaymentSheet.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Linking,
+  Share,
+  ScrollView,
+} from 'react-native';
+// Clipboard has been moved out of core, but for demo purposes we keep a simple
+// reference that works in the RN environment without additional deps.
+// @ts-ignore
+import { Clipboard } from 'react-native';
+import { normalizeInvoice } from './detect';
+
+declare const process: any;
+
+interface ParsedInvoice {
+  amountSat?: number;
+  memo?: string;
+}
+
+function parseInvoice(invoice: string): ParsedInvoice {
+  const normalized = normalizeInvoice(invoice);
+  const match = normalized.match(/^ln[a-z]{2}(\d*)1([02-9ac-hj-np-z]+)$/i);
+  const amount = match && match[1] ? Number(match[1]) : undefined;
+  const memo = match && match[2] ? match[2] : undefined;
+  return { amountSat: amount, memo };
+}
+
+export interface PaymentSheetProps {
+  visible: boolean;
+  invoice: string;
+  onClose: () => void;
+}
+
+export const PaymentSheet: React.FC<PaymentSheetProps> = ({
+  visible,
+  invoice,
+  onClose,
+}) => {
+  const { amountSat, memo } = parseInvoice(invoice);
+  const normalized = normalizeInvoice(invoice);
+
+  const prefixes = (typeof process !== 'undefined'
+    ? process.env?.LIGHTNING_DEEP_LINK_SCHEME_PREFIXES
+    : undefined);
+  const schemePrefixes = prefixes
+    ? prefixes.split(',').map((s: string) => s.trim()).filter(Boolean)
+    : ['lightning:'];
+
+  const handlePay = async () => {
+    for (const prefix of schemePrefixes) {
+      const url = `${prefix}${normalized}`;
+      const canOpen = await Linking.canOpenURL(url);
+      if (canOpen) {
+        Linking.openURL(url);
+        return;
+      }
+    }
+    Linking.openURL(`lightning:${normalized}`);
+  };
+
+  const handleCopy = () => {
+    if (typeof Clipboard?.setString === 'function') {
+      Clipboard.setString(invoice);
+    }
+  };
+
+  const handleShare = () => {
+    Share.share({ message: invoice });
+  };
+
+  return (
+    <Modal transparent visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <TouchableOpacity style={styles.backdrop} activeOpacity={1} onPress={onClose} />
+        <View style={styles.sheet}>
+          <Text style={styles.title}>Pay Lightning Invoice</Text>
+          <ScrollView style={styles.invoiceContainer}>
+            <Text selectable style={styles.invoiceText}>
+              {invoice}
+            </Text>
+          </ScrollView>
+          <Text style={styles.label}>
+            Amount (sats):{' '}
+            {typeof amountSat === 'number' ? amountSat : 'Amount set by wallet'}
+          </Text>
+          {memo ? (
+            <Text style={styles.label}>Memo: {memo}</Text>
+          ) : null}
+          <View style={styles.actions}>
+            <TouchableOpacity
+              accessibilityRole="button"
+              style={styles.actionButton}
+              onPress={() => handlePay()}
+            >
+              <Text style={styles.actionText}>Pay with Wallet</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              accessibilityRole="button"
+              style={styles.actionButton}
+              onPress={handleCopy}
+            >
+              <Text style={styles.actionText}>Copy Invoice</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              accessibilityRole="button"
+              style={styles.actionButton}
+              onPress={handleShare}
+            >
+              <Text style={styles.actionText}>Share</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.3)',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  sheet: {
+    backgroundColor: '#fff',
+    padding: 16,
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  invoiceContainer: {
+    maxHeight: 100,
+    marginBottom: 12,
+  },
+  invoiceText: {
+    fontSize: 12,
+  },
+  label: {
+    marginBottom: 8,
+    fontSize: 14,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 12,
+  },
+  actionButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: '#eee',
+    borderRadius: 6,
+    marginRight: 8,
+  },
+  actionText: {
+    fontSize: 14,
+  },
+});
+
+export default PaymentSheet;

--- a/packages/lightning-ui/RequestPaymentMock.tsx
+++ b/packages/lightning-ui/RequestPaymentMock.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+
+interface RequestPaymentMockProps {
+  onInvoice?: (invoice: string) => void;
+}
+
+export const RequestPaymentMock: React.FC<RequestPaymentMockProps> = ({ onInvoice }) => {
+  const [amount, setAmount] = useState('');
+  const [memo, setMemo] = useState('');
+  const [invoice, setInvoice] = useState<string | null>(null);
+
+  const handleCreate = () => {
+    const memoSanitized = memo.toLowerCase().replace(/[^02-9ac-hj-np-z]/g, '') || 'qq';
+    const amt = amount.replace(/[^0-9]/g, '');
+    const inv = `lnbc${amt}1${memoSanitized}`;
+    setInvoice(inv);
+    onInvoice?.(inv);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Request Lightning Payment (mock)</Text>
+      <Text>Amount (sats)</Text>
+      <TextInput
+        accessibilityLabel="Amount (sats)"
+        keyboardType="numeric"
+        style={styles.input}
+        value={amount}
+        onChangeText={setAmount}
+      />
+      <Text>Memo</Text>
+      <TextInput
+        accessibilityLabel="Memo"
+        style={styles.input}
+        value={memo}
+        onChangeText={setMemo}
+      />
+      <Button title="Generate" onPress={handleCreate} />
+      {invoice && (
+        <Text selectable style={styles.invoice}>{invoice}</Text>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 24,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+  },
+  title: {
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    padding: 4,
+    marginBottom: 12,
+  },
+  invoice: {
+    marginTop: 12,
+    fontSize: 12,
+  },
+});
+
+export default RequestPaymentMock;

--- a/packages/lightning-ui/detect.ts
+++ b/packages/lightning-ui/detect.ts
@@ -1,0 +1,88 @@
+/**
+ * Types of payment strings that can be detected.
+ */
+export type PaymentStringType = 'bolt11' | 'bolt12' | 'lnurl' | 'lightning';
+
+/**
+ * Result of detecting a payment string in a piece of text.
+ */
+export interface PaymentString {
+  type: PaymentStringType;
+  value: string;
+}
+
+// Character class for Bech32 encodings used by Lightning payment strings.
+const BECH32_CHARS = '[02-9ac-hj-np-z]';
+
+// Base patterns without anchors. These are reused for validation and extraction.
+const BOLT11_PATTERN = `ln(?!url|o|r|i)[a-z0-9]+1${BECH32_CHARS}+`;
+const BOLT12_PATTERN = `ln(?:o|r|i)[a-z0-9]*1${BECH32_CHARS}+`;
+const LNURL_PATTERN = `lnurl1${BECH32_CHARS}{10,}`;
+
+// Compiled regexes for strict validation of individual strings.
+const bolt11Regex = new RegExp(`^${BOLT11_PATTERN}$`, 'i');
+const bolt12Regex = new RegExp(`^${BOLT12_PATTERN}$`, 'i');
+const lnurlRegex = new RegExp(`^${LNURL_PATTERN}$`, 'i');
+
+function isBolt11(str: string): boolean {
+  return bolt11Regex.test(str);
+}
+
+function isBolt12(str: string): boolean {
+  return bolt12Regex.test(str);
+}
+
+function isLnurl(str: string): boolean {
+  return lnurlRegex.test(str);
+}
+
+/**
+ * Normalise a lightning invoice by removing any `lightning:` prefix,
+ * trimming surrounding whitespace and lowercasing the result.
+ */
+export function normalizeInvoice(str: string): string {
+  return str.trim().replace(/^lightning:/i, '').toLowerCase();
+}
+
+/**
+ * Detect Lightning payment strings in arbitrary text.
+ *
+ * Matches bare BOLT11, BOLT12 and LNURL strings as well as `lightning:` URIs.
+ * Returns an array describing each match with its detected type and original
+ * value as it appeared in the text.
+ */
+export function detectPaymentStrings(text: string): PaymentString[] {
+  const results: PaymentString[] = [];
+
+  // Detect `lightning:` URIs first.
+  const lightningPattern = /lightning:([^\s]+)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = lightningPattern.exec(text))) {
+    const candidate = normalizeInvoice(match[1]);
+    if (isBolt11(candidate) || isBolt12(candidate) || isLnurl(candidate)) {
+      results.push({ type: 'lightning', value: match[0] });
+    }
+  }
+
+  // Remove `lightning:` URIs to avoid duplicate detection in later regexes.
+  const sanitized = text.replace(/lightning:\s*[^\s]+/gi, ' ');
+
+  // Detect bare payment strings.
+  const bolt11Pattern = new RegExp(`\\b${BOLT11_PATTERN}\\b`, 'gi');
+  while ((match = bolt11Pattern.exec(sanitized))) {
+    results.push({ type: 'bolt11', value: match[0] });
+  }
+
+  const bolt12Pattern = new RegExp(`\\b${BOLT12_PATTERN}\\b`, 'gi');
+  while ((match = bolt12Pattern.exec(sanitized))) {
+    results.push({ type: 'bolt12', value: match[0] });
+  }
+
+  const lnurlPattern = new RegExp(`\\b${LNURL_PATTERN}\\b`, 'gi');
+  while ((match = lnurlPattern.exec(sanitized))) {
+    results.push({ type: 'lnurl', value: match[0] });
+  }
+
+  return results;
+}
+

--- a/packages/lightning-ui/index.ts
+++ b/packages/lightning-ui/index.ts
@@ -1,0 +1,6 @@
+export { detectPaymentStrings, normalizeInvoice } from './detect';
+export type { PaymentString, PaymentStringType } from './detect';
+export { default as PaymentSheet } from './PaymentSheet';
+export { default as HighlightLightningText } from './HighlightLightningText';
+export { default as RequestPaymentMock } from './RequestPaymentMock';
+export { default as LightningDemoScreen } from './LightningDemoScreen';

--- a/packages/lightning-ui/package.json
+++ b/packages/lightning-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/message-ui",
+  "name": "@mchat/lightning-ui",
   "version": "0.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/lightning-ui/tsconfig.json
+++ b/packages/lightning-ui/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "jsx": "react-native",
+    "types": ["react", "react-native"],
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}


### PR DESCRIPTION
## Summary
- add standalone `@mchat/lightning-ui` package with invoice detection utilities
- implement React Native payment sheet, text highlighter, request mock, and demo screen
- remove placeholder lightning preview screenshot and fix malformed package manifests

## Testing
- `npm run lint` *(fails: see Prettier and react-native/no-inline-styles errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a981636e2c832fbf2968a2c6f8d509