### PR TITLE
fix: stub expo modules for ln-core

### DIFF
--- a/native/ln-core/tsconfig.json
+++ b/native/ln-core/tsconfig.json
@@ -5,5 +5,5 @@
     "declaration": true,
     "outDir": "dist"
   },
-  "include": ["index.ts", "with-ln-core.ts"]
+  "include": ["*.ts", "*.d.ts"]
 }

--- a/native/ln-core/typings.d.ts
+++ b/native/ln-core/typings.d.ts
@@ -1,0 +1,15 @@
+declare module 'expo-modules-core' {
+  export class EventEmitter {
+    constructor(...args: any[]);
+    addListener(eventName: string, listener: (...args: any[]) => void): Subscription;
+  }
+  export interface Subscription {
+    remove(): void;
+  }
+  export function requireNativeModule<T>(name: string): T;
+}
+
+declare module '@expo/config-plugins' {
+  export type ConfigPlugin = (config: any) => any;
+  export function withDangerousMod(config: any, mods: any): any;
+}

--- a/native/ln-core/with-ln-core.ts
+++ b/native/ln-core/with-ln-core.ts
@@ -4,10 +4,10 @@ import { ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
  * Stub Expo config plugin for future Lightning core integration.
  * Add Breez SDK or LDK native dependencies here in the future.
  */
-const withLnCore: ConfigPlugin = (config) => {
+const withLnCore: ConfigPlugin = (config: any) => {
   config = withDangerousMod(config, [
     'ios',
-    async (c) => {
+    async (c: any) => {
       console.log('with-ln-core: iOS configuration placeholder');
       return c;
     },
@@ -15,7 +15,7 @@ const withLnCore: ConfigPlugin = (config) => {
 
   config = withDangerousMod(config, [
     'android',
-    async (c) => {
+    async (c: any) => {
       console.log('with-ln-core: Android configuration placeholder');
       return c;
     },


### PR DESCRIPTION
## Summary
- add local type stubs for expo modules and config plugins
- annotate config plugin parameters and expand tsconfig includes

## Testing
- `npm run build` (ln-core)
- `yarn test`
- `yarn lint` *(fails: prettier/eslint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0b518434832fab52604a0133070d