### PR TITLE
Improve error handling in Rust stores

### DIFF
--- a/native/rust/matrix_core/src/error.rs
+++ b/native/rust/matrix_core/src/error.rs
@@ -12,6 +12,9 @@ pub enum CoreError {
     #[cfg(feature = "sqlite")]
     #[error(transparent)]
     Sqlite(#[from] rusqlite::Error),
+    /// Mutex was poisoned
+    #[error("mutex poisoned: {0}")]
+    MutexPoisoned(String),
 }
 
 /// Convenient result type used throughout the crate.

--- a/native/rust/matrix_core/src/lib.rs
+++ b/native/rust/matrix_core/src/lib.rs
@@ -27,6 +27,7 @@ pub use store::sqlite::SqliteStore;
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "mem-store")]
     use futures::executor::block_on;
 
     #[cfg(feature = "mem-store")]

--- a/native/rust/matrix_core/src/store/mem.rs
+++ b/native/rust/matrix_core/src/store/mem.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 
 use super::IMatrixStore;
 use crate::{
-    error::CoreResult,
+    error::{CoreError, CoreResult},
     events::{MatrixEvent, RoomState},
     session::Session,
 };
@@ -26,25 +26,37 @@ impl MemStore {
 #[async_trait::async_trait]
 impl IMatrixStore for MemStore {
     async fn put_session(&self, session: &Session) -> CoreResult<()> {
-        let mut guard = self.session.lock().map_err(|e| CoreError::PoisonedLock(e.to_string()))?;
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|e| CoreError::MutexPoisoned(e.to_string()))?;
         *guard = Some(session.clone());
         Ok(())
     }
 
     async fn get_session(&self) -> CoreResult<Option<Session>> {
-        Ok(self.session.lock().map_err(|e| CoreError::PoisonedLock(e.to_string()))?.clone())
+        Ok(self
+            .session
+            .lock()
+            .map_err(|e| CoreError::MutexPoisoned(e.to_string()))?
+            .clone())
     }
 
     async fn put_room_state(&self, room_id: &str, state: &RoomState) -> CoreResult<()> {
         self.room_state
             .lock()
-            .map_err(|e| CoreError::PoisonedLock(e.to_string()))?
+            .map_err(|e| CoreError::MutexPoisoned(e.to_string()))?
             .insert(room_id.to_string(), state.clone());
         Ok(())
     }
 
     async fn get_room_state(&self, room_id: &str) -> CoreResult<Option<RoomState>> {
-        Ok(self.room_state.lock().map_err(|e| CoreError::PoisonedLock(e.to_string()))?.get(room_id).cloned())
+        Ok(self
+            .room_state
+            .lock()
+            .map_err(|e| CoreError::MutexPoisoned(e.to_string()))?
+            .get(room_id)
+            .cloned())
     }
 
     async fn append_timeline_events(
@@ -52,7 +64,10 @@ impl IMatrixStore for MemStore {
         room_id: &str,
         events: &[MatrixEvent],
     ) -> CoreResult<()> {
-        let mut timelines = self.timelines.lock().unwrap();
+        let mut timelines = self
+            .timelines
+            .lock()
+            .map_err(|e| CoreError::MutexPoisoned(e.to_string()))?;
         let timeline = timelines.entry(room_id.to_string()).or_default();
         timeline.extend_from_slice(events);
         Ok(())
@@ -64,7 +79,10 @@ impl IMatrixStore for MemStore {
         start: usize,
         end: usize,
     ) -> CoreResult<Vec<MatrixEvent>> {
-        let timelines = self.timelines.lock().unwrap();
+        let timelines = self
+            .timelines
+            .lock()
+            .map_err(|e| CoreError::MutexPoisoned(e.to_string()))?;
         let timeline = timelines.get(room_id).cloned().unwrap_or_default();
         let slice = timeline.into_iter().skip(start).take(end - start).collect();
         Ok(slice)

--- a/native/rust/matrix_core/src/store/sqlite.rs
+++ b/native/rust/matrix_core/src/store/sqlite.rs
@@ -34,23 +34,34 @@ impl SqliteStore {
 impl IMatrixStore for SqliteStore {
     async fn put_session(&self, session: &Session) -> CoreResult<()> {
         let json = serde_json::to_string(session)?;
-        let conn = self.conn.lock().map_err(|e| crate::error::CoreError::MutexPoisoned(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| crate::error::CoreError::MutexPoisoned(e.to_string()))?;
         conn.execute("DELETE FROM session", [])?;
         conn.execute("INSERT INTO session (data) VALUES (?1)", [json])?;
         Ok(())
     }
 
     async fn get_session(&self) -> CoreResult<Option<Session>> {
-        let conn = self.conn.lock().map_err(|e| crate::error::CoreError::MutexPoisoned(e.to_string()))?;
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| crate::error::CoreError::MutexPoisoned(e.to_string()))?;
         let mut stmt = conn.prepare("SELECT data FROM session LIMIT 1")?;
         let opt: Option<String> = stmt.query_row([], |row| row.get(0)).optional()?;
-        let session = opt.map(|json| serde_json::from_str(&json)).transpose()?;
+        let session = opt
+            .map(|json| serde_json::from_str::<Session>(&json))
+            .transpose()?;
         Ok(session)
     }
 
     async fn put_room_state(&self, room_id: &str, state: &RoomState) -> CoreResult<()> {
         let json = serde_json::to_string(state)?;
-        let conn = self.conn.lock().unwrap();
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| crate::error::CoreError::MutexPoisoned(e.to_string()))?;
         conn.execute(
             "INSERT INTO room_state (room_id, data) VALUES (?1, ?2)
              ON CONFLICT(room_id) DO UPDATE SET data=excluded.data",
@@ -60,10 +71,15 @@ impl IMatrixStore for SqliteStore {
     }
 
     async fn get_room_state(&self, room_id: &str) -> CoreResult<Option<RoomState>> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| crate::error::CoreError::MutexPoisoned(e.to_string()))?;
         let mut stmt = conn.prepare("SELECT data FROM room_state WHERE room_id = ?1")?;
         let opt: Option<String> = stmt.query_row([room_id], |row| row.get(0)).optional()?;
-        let state = opt.map(|json| serde_json::from_str(&json)).transpose()?;
+        let state = opt
+            .map(|json| serde_json::from_str::<RoomState>(&json))
+            .transpose()?;
         Ok(state)
     }
 
@@ -72,7 +88,10 @@ impl IMatrixStore for SqliteStore {
         room_id: &str,
         events: &[MatrixEvent],
     ) -> CoreResult<()> {
-        let mut conn = self.conn.lock().unwrap();
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| crate::error::CoreError::MutexPoisoned(e.to_string()))?;
         let tx = conn.transaction()?;
         let mut idx: i64 = tx.query_row(
             "SELECT COALESCE(MAX(idx), -1) FROM timeline WHERE room_id = ?1",
@@ -97,7 +116,10 @@ impl IMatrixStore for SqliteStore {
         start: usize,
         end: usize,
     ) -> CoreResult<Vec<MatrixEvent>> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| crate::error::CoreError::MutexPoisoned(e.to_string()))?;
         let mut stmt = conn.prepare(
             "SELECT data FROM timeline WHERE room_id = ?1 AND idx >= ?2 AND idx < ?3 ORDER BY idx ASC",
         )?;


### PR DESCRIPTION
## Summary
- add `MutexPoisoned` error variant for lock failures
- handle mutex poisoning in SQLite and memory stores and specify JSON types
- conditionally import `block_on` in tests

## Testing
- `cargo test`
- `cargo test --features mem-store`


------
https://chatgpt.com/codex/tasks/task_e_68aa0b7fecbc832fa4802093fa443ce2