### PR TITLE
feat: add lightning payment UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "typecheck": "tsc -p packages/chat-types/tsconfig.json"
+    "typecheck": "tsc -p packages/chat-types/tsconfig.json",
     "lint": "eslint '**/*.{ts,tsx,js}'",
     "format": "prettier --write '**/*.{ts,tsx,js,json,md}'",
     "prepare": "husky install",
@@ -45,6 +45,6 @@
     "eslint-plugin-react-native": "^5.0.0",
     "husky": "^9.0.10",
     "lint-staged": "^15.2.0",
-    "prettier": "^3.3.2">>>>>> main
+    "prettier": "^3.3.2"
   }
 }

--- a/packages/lightning-ui/HighlightLightningText.tsx
+++ b/packages/lightning-ui/HighlightLightningText.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { detectPaymentStrings } from './detect';
+import PaymentSheet from './PaymentSheet';
+
+interface HighlightLightningTextProps {
+  text: string;
+}
+
+export const HighlightLightningText: React.FC<HighlightLightningTextProps> = ({ text }) => {
+  const [selected, setSelected] = useState<string | null>(null);
+  const matches = detectPaymentStrings(text);
+  let cursor = 0;
+  const elements: React.ReactNode[] = [];
+
+  const occurrences = matches.map((m) => {
+    const index = text.indexOf(m.value, cursor);
+    const occurrence = { ...m, index };
+    if (index >= 0) {
+      cursor = index + m.value.length;
+    }
+    return occurrence;
+  });
+  occurrences.sort((a, b) => a.index - b.index);
+
+  cursor = 0;
+  occurrences.forEach((m, i) => {
+    if (m.index > cursor) {
+      elements.push(<Text key={`t-${i}`}>{text.slice(cursor, m.index)}</Text>);
+    }
+    elements.push(
+      <TouchableOpacity
+        key={`c-${i}`}
+        onPress={() => setSelected(m.value)}
+        style={styles.chip}
+        accessibilityRole="button"
+      >
+        <Text style={styles.chipText}>{m.value}</Text>
+      </TouchableOpacity>
+    );
+    cursor = m.index + m.value.length;
+  });
+  if (cursor < text.length) {
+    elements.push(<Text key="tail">{text.slice(cursor)}</Text>);
+  }
+
+  return (
+    <>
+      <Text>{elements}</Text>
+      {selected && (
+        <PaymentSheet
+          visible={true}
+          invoice={selected}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  chip: {
+    backgroundColor: '#e0f7ff',
+    paddingHorizontal: 4,
+    borderRadius: 4,
+    marginHorizontal: 2,
+  },
+  chipText: {
+    color: '#0366d6',
+  },
+});
+
+export default HighlightLightningText;

--- a/packages/lightning-ui/LightningDemoScreen.tsx
+++ b/packages/lightning-ui/LightningDemoScreen.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { ScrollView, View, StyleSheet } from 'react-native';
+import HighlightLightningText from './HighlightLightningText';
+import RequestPaymentMock from './RequestPaymentMock';
+
+export const LightningDemoScreen: React.FC = () => {
+  const [messages, setMessages] = useState<string[]>([
+    'Pay me at lnbc2501hello for lunch.',
+    'Try this LNURL: lnurl1dp68gurn8ghj7ctsdyhxyctwv96kx.',
+    'Or a lightning URI lightning:lnbc501testmemo.',
+  ]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {messages.map((m, i) => (
+        <View key={i} style={styles.message}>
+          <HighlightLightningText text={m} />
+        </View>
+      ))}
+      <RequestPaymentMock onInvoice={(inv) => setMessages([...messages, inv])} />
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  message: {
+    marginBottom: 16,
+  },
+});
+
+export default LightningDemoScreen;

--- a/packages/lightning-ui/PaymentSheet.tsx
+++ b/packages/lightning-ui/PaymentSheet.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Linking,
+  Share,
+  ScrollView,
+} from 'react-native';
+import { normalizeInvoice } from './detect';
+import { parseBolt11 } from './bolt11';
+
+declare const process: { env?: Record<string, string | undefined> } | undefined;
+declare function require(name: string): unknown;
+
+type ClipboardModule = { setString?: (text: string) => void };
+let Clipboard: ClipboardModule | undefined;
+try {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+  Clipboard = require('@react-native-clipboard/clipboard') as ClipboardModule;
+} catch {
+  /* noop */
+}
+
+export interface PaymentSheetProps {
+  visible: boolean;
+  invoice: string;
+  onClose: () => void;
+}
+
+export const PaymentSheet: React.FC<PaymentSheetProps> = ({
+  visible,
+  invoice,
+  onClose,
+}) => {
+  const { amountSat, memo } = parseBolt11(invoice);
+  const normalized = normalizeInvoice(invoice);
+
+  const prefixes =
+    typeof process !== 'undefined'
+      ? process.env?.LIGHTNING_DEEP_LINK_SCHEME_PREFIXES
+      : undefined;
+  const schemePrefixes = prefixes
+    ? prefixes
+        .split(',')
+        .map((s: string) => s.trim())
+        .filter(Boolean)
+    : ['lightning:'];
+
+  const handlePay = async () => {
+    for (const prefix of schemePrefixes) {
+      const url = `${prefix}${normalized}`;
+      const canOpen = await Linking.canOpenURL(url);
+      if (canOpen) {
+        Linking.openURL(url);
+        return;
+      }
+    }
+    Linking.openURL(`lightning:${normalized}`);
+  };
+
+  const handleCopy = () => {
+    if (typeof Clipboard?.setString === 'function') {
+      Clipboard.setString(invoice);
+    } else if (typeof navigator !== 'undefined') {
+      try {
+        // @ts-expect-error navigator clipboard may exist in web
+        navigator.clipboard?.writeText(invoice);
+      } catch {
+        /* noop */
+      }
+    }
+  };
+
+  const handleShare = () => {
+    Share.share({ message: invoice });
+  };
+
+  return (
+    <Modal
+      transparent
+      visible={visible}
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <TouchableOpacity
+          style={styles.backdrop}
+          activeOpacity={1}
+          onPress={onClose}
+        />
+        <View style={styles.sheet}>
+          <Text style={styles.title}>Pay Lightning Invoice</Text>
+          <ScrollView style={styles.invoiceContainer}>
+            <Text selectable style={styles.invoiceText}>
+              {invoice}
+            </Text>
+          </ScrollView>
+          <Text style={styles.label}>
+            Amount (sats):{' '}
+            {typeof amountSat === 'number' ? amountSat : 'Amount set by wallet'}
+          </Text>
+          {memo ? <Text style={styles.label}>Memo: {memo}</Text> : null}
+          <View style={styles.actions}>
+            <TouchableOpacity
+              accessibilityRole="button"
+              style={styles.actionButton}
+              onPress={() => handlePay()}
+            >
+              <Text style={styles.actionText}>Pay with Wallet</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              accessibilityRole="button"
+              style={styles.actionButton}
+              onPress={handleCopy}
+            >
+              <Text style={styles.actionText}>Copy Invoice</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              accessibilityRole="button"
+              style={styles.actionButton}
+              onPress={handleShare}
+            >
+              <Text style={styles.actionText}>Share</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.3)',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  sheet: {
+    backgroundColor: '#fff',
+    padding: 16,
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  invoiceContainer: {
+    maxHeight: 100,
+    marginBottom: 12,
+  },
+  invoiceText: {
+    fontSize: 12,
+  },
+  label: {
+    marginBottom: 8,
+    fontSize: 14,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: 12,
+  },
+  actionButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: '#eee',
+    borderRadius: 6,
+    marginRight: 8,
+  },
+  actionText: {
+    fontSize: 14,
+  },
+});
+
+export default PaymentSheet;

--- a/packages/lightning-ui/RequestPaymentMock.tsx
+++ b/packages/lightning-ui/RequestPaymentMock.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { createMockBolt11 } from './bolt11';
+
+interface RequestPaymentMockProps {
+  onInvoice?: (invoice: string) => void;
+}
+
+export const RequestPaymentMock: React.FC<RequestPaymentMockProps> = ({
+  onInvoice,
+}) => {
+  const [amount, setAmount] = useState('');
+  const [memo, setMemo] = useState('');
+  const [invoice, setInvoice] = useState<string | null>(null);
+
+  const handleCreate = () => {
+    const sats = parseInt(amount, 10);
+    if (Number.isNaN(sats)) return;
+    const inv = createMockBolt11(sats, memo);
+    setInvoice(inv);
+    onInvoice?.(inv);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Request Lightning Payment (mock)</Text>
+      <Text>Amount (sats)</Text>
+      <TextInput
+        accessibilityLabel="Amount (sats)"
+        keyboardType="numeric"
+        style={styles.input}
+        value={amount}
+        onChangeText={setAmount}
+      />
+      <Text>Memo</Text>
+      <TextInput
+        accessibilityLabel="Memo"
+        style={styles.input}
+        value={memo}
+        onChangeText={setMemo}
+      />
+      <Button title="Generate" onPress={handleCreate} />
+      {invoice && (
+        <Text selectable style={styles.invoice}>
+          {invoice}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 24,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+  },
+  title: {
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    padding: 4,
+    marginBottom: 12,
+  },
+  invoice: {
+    marginTop: 12,
+    fontSize: 12,
+  },
+});
+
+export default RequestPaymentMock;

--- a/packages/lightning-ui/bolt11.ts
+++ b/packages/lightning-ui/bolt11.ts
@@ -1,0 +1,190 @@
+// Minimal BOLT11 invoice utilities without external dependencies.
+import { normalizeInvoice } from './detect';
+
+const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+const CHARSET_REV: Record<string, number> = CHARSET.split('').reduce(
+  (acc, c, i) => ({ ...acc, [c]: i }),
+  {} as Record<string, number>,
+);
+
+function polymod(values: number[]): number {
+  const GENERATORS = [
+    0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3,
+  ];
+  let chk = 1;
+  for (const v of values) {
+    const top = chk >> 25;
+    chk = ((chk & 0x1ffffff) << 5) ^ v;
+    for (let i = 0; i < 5; i++) {
+      if ((top >> i) & 1) chk ^= GENERATORS[i];
+    }
+  }
+  return chk;
+}
+
+function hrpExpand(hrp: string): number[] {
+  const ret: number[] = [];
+  for (let i = 0; i < hrp.length; i++) ret.push(hrp.charCodeAt(i) >> 5);
+  ret.push(0);
+  for (let i = 0; i < hrp.length; i++) ret.push(hrp.charCodeAt(i) & 31);
+  return ret;
+}
+
+function verifyChecksum(hrp: string, data: number[]): boolean {
+  return polymod([...hrpExpand(hrp), ...data]) === 1;
+}
+
+function createChecksum(hrp: string, data: number[]): number[] {
+  const values = [...hrpExpand(hrp), ...data, 0, 0, 0, 0, 0, 0];
+  const mod = polymod(values) ^ 1;
+  const ret: number[] = [];
+  for (let p = 0; p < 6; p++) {
+    ret.push((mod >> (5 * (5 - p))) & 31);
+  }
+  return ret;
+}
+
+function bech32Decode(str: string): { hrp: string; words: number[] } {
+  const pos = str.lastIndexOf('1');
+  if (pos < 1) throw new Error('invalid bech32');
+  const hrp = str.slice(0, pos);
+  const data = str
+    .slice(pos + 1)
+    .toLowerCase()
+    .split('')
+    .map((c) => {
+      const v = CHARSET_REV[c];
+      if (v === undefined) throw new Error('invalid bech32 char');
+      return v;
+    });
+  if (!verifyChecksum(hrp, data)) throw new Error('invalid checksum');
+  return { hrp, words: data.slice(0, -6) };
+}
+
+function bech32Encode(hrp: string, words: number[]): string {
+  const combined = [...words, ...createChecksum(hrp, words)];
+  let out = `${hrp}1`;
+  for (const w of combined) out += CHARSET[w];
+  return out;
+}
+
+function convertBits(
+  data: number[],
+  from: number,
+  to: number,
+  pad: boolean,
+): number[] {
+  let acc = 0;
+  let bits = 0;
+  const maxv = (1 << to) - 1;
+  const ret: number[] = [];
+  for (const value of data) {
+    if (value < 0 || value >> from) return [];
+    acc = (acc << from) | value;
+    bits += from;
+    while (bits >= to) {
+      bits -= to;
+      ret.push((acc >> bits) & maxv);
+    }
+  }
+  if (pad && bits) {
+    ret.push((acc << (to - bits)) & maxv);
+  } else if (!pad && (bits >= from || (acc << (to - bits)) & maxv)) {
+    return [];
+  }
+  return ret;
+}
+
+function bytesToUtf8(bytes: number[]): string {
+  if (typeof TextDecoder !== 'undefined') {
+    return new TextDecoder().decode(new Uint8Array(bytes));
+  }
+  return String.fromCharCode(...bytes);
+}
+
+function utf8ToBytes(str: string): number[] {
+  if (typeof TextEncoder !== 'undefined') {
+    return Array.from(new TextEncoder().encode(str));
+  }
+  return str.split('').map((c) => c.charCodeAt(0));
+}
+
+function parseAmount(amount: string | undefined): number | undefined {
+  if (!amount) return undefined;
+  const unit = amount.match(/[munp]$/i)?.[0];
+  const num = Number(unit ? amount.slice(0, -1) : amount);
+  if (!Number.isFinite(num)) return undefined;
+  switch (unit) {
+    case 'm':
+      return num * 1e8;
+    case 'u':
+      return num * 1e5;
+    case 'n':
+      return num * 1e2;
+    case 'p':
+      return num / 10;
+    default:
+      return num * 1e11;
+  }
+}
+
+function encodeAmount(msat: number): string {
+  if (msat % 1e11 === 0) return `${msat / 1e11}`;
+  if (msat % 1e8 === 0) return `${msat / 1e8}m`;
+  if (msat % 1e5 === 0) return `${msat / 1e5}u`;
+  if (msat % 1e2 === 0) return `${msat / 1e2}n`;
+  return `${Math.round(msat * 10)}p`;
+}
+
+export interface ParsedBolt11 {
+  amountSat?: number;
+  memo?: string;
+}
+
+export function parseBolt11(invoice: string): ParsedBolt11 {
+  try {
+    const normalized = normalizeInvoice(invoice);
+    const match = normalized.match(/^ln([a-z]{2,})(\d*[munp]?)1/);
+    if (!match) return {};
+    const amountMsat = parseAmount(match[2]);
+    const { words } = bech32Decode(normalized);
+    let memo: string | undefined;
+    let idx = 7; // skip timestamp
+    while (idx < words.length - 104) {
+      const tag = words[idx];
+      const len = (words[idx + 1] << 5) | words[idx + 2];
+      idx += 3;
+      const data = words.slice(idx, idx + len);
+      idx += len;
+      if (tag === 13) {
+        const bytes = convertBits(data, 5, 8, false);
+        memo = bytesToUtf8(bytes);
+      }
+    }
+    return {
+      amountSat: amountMsat ? Math.floor(amountMsat / 1000) : undefined,
+      memo,
+    };
+  } catch {
+    return {};
+  }
+}
+
+export function createMockBolt11(amountSat: number, memo: string): string {
+  const amountMsat = amountSat * 1000;
+  const hrp = `lnbc${encodeAmount(amountMsat)}`;
+  const words: number[] = [];
+  // timestamp (7 words)
+  words.push(0, 0, 0, 0, 0, 0, 0);
+  // description tag
+  const desc = convertBits(utf8ToBytes(memo), 8, 5, true);
+  words.push(13, (desc.length >> 5) & 31, desc.length & 31, ...desc);
+  // payment hash tag with zeros
+  const ph = convertBits(new Array(32).fill(0), 8, 5, true);
+  words.push(1, (ph.length >> 5) & 31, ph.length & 31, ...ph);
+  // signature placeholder
+  words.push(...new Array(104).fill(0));
+  return bech32Encode(hrp, words);
+}
+
+export default parseBolt11;

--- a/packages/lightning-ui/detect.ts
+++ b/packages/lightning-ui/detect.ts
@@ -1,0 +1,88 @@
+/**
+ * Types of payment strings that can be detected.
+ */
+export type PaymentStringType = 'bolt11' | 'bolt12' | 'lnurl' | 'lightning';
+
+/**
+ * Result of detecting a payment string in a piece of text.
+ */
+export interface PaymentString {
+  type: PaymentStringType;
+  value: string;
+}
+
+// Character class for Bech32 encodings used by Lightning payment strings.
+const BECH32_CHARS = '[02-9ac-hj-np-z]';
+
+// Base patterns without anchors. These are reused for validation and extraction.
+const BOLT11_PATTERN = `ln(?!url|o|r|i)[a-z0-9]+1${BECH32_CHARS}+`;
+const BOLT12_PATTERN = `ln(?:o|r|i)[a-z0-9]*1${BECH32_CHARS}+`;
+const LNURL_PATTERN = `lnurl1${BECH32_CHARS}{10,}`;
+
+// Compiled regexes for strict validation of individual strings.
+const bolt11Regex = new RegExp(`^${BOLT11_PATTERN}$`, 'i');
+const bolt12Regex = new RegExp(`^${BOLT12_PATTERN}$`, 'i');
+const lnurlRegex = new RegExp(`^${LNURL_PATTERN}$`, 'i');
+
+function isBolt11(str: string): boolean {
+  return bolt11Regex.test(str);
+}
+
+function isBolt12(str: string): boolean {
+  return bolt12Regex.test(str);
+}
+
+function isLnurl(str: string): boolean {
+  return lnurlRegex.test(str);
+}
+
+/**
+ * Normalise a lightning invoice by removing any `lightning:` prefix,
+ * trimming surrounding whitespace and lowercasing the result.
+ */
+export function normalizeInvoice(str: string): string {
+  return str.trim().replace(/^lightning:/i, '').toLowerCase();
+}
+
+/**
+ * Detect Lightning payment strings in arbitrary text.
+ *
+ * Matches bare BOLT11, BOLT12 and LNURL strings as well as `lightning:` URIs.
+ * Returns an array describing each match with its detected type and original
+ * value as it appeared in the text.
+ */
+export function detectPaymentStrings(text: string): PaymentString[] {
+  const results: PaymentString[] = [];
+
+  // Detect `lightning:` URIs first.
+  const lightningPattern = /lightning:([^\s]+)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = lightningPattern.exec(text))) {
+    const candidate = normalizeInvoice(match[1]);
+    if (isBolt11(candidate) || isBolt12(candidate) || isLnurl(candidate)) {
+      results.push({ type: 'lightning', value: match[0] });
+    }
+  }
+
+  // Remove `lightning:` URIs to avoid duplicate detection in later regexes.
+  const sanitized = text.replace(/lightning:\s*[^\s]+/gi, ' ');
+
+  // Detect bare payment strings.
+  const bolt11Pattern = new RegExp(`\\b${BOLT11_PATTERN}\\b`, 'gi');
+  while ((match = bolt11Pattern.exec(sanitized))) {
+    results.push({ type: 'bolt11', value: match[0] });
+  }
+
+  const bolt12Pattern = new RegExp(`\\b${BOLT12_PATTERN}\\b`, 'gi');
+  while ((match = bolt12Pattern.exec(sanitized))) {
+    results.push({ type: 'bolt12', value: match[0] });
+  }
+
+  const lnurlPattern = new RegExp(`\\b${LNURL_PATTERN}\\b`, 'gi');
+  while ((match = lnurlPattern.exec(sanitized))) {
+    results.push({ type: 'lnurl', value: match[0] });
+  }
+
+  return results;
+}
+

--- a/packages/lightning-ui/index.ts
+++ b/packages/lightning-ui/index.ts
@@ -1,0 +1,7 @@
+export { detectPaymentStrings, normalizeInvoice } from './detect';
+export type { PaymentString, PaymentStringType } from './detect';
+export { parseBolt11, createMockBolt11 } from './bolt11';
+export { default as PaymentSheet } from './PaymentSheet';
+export { default as HighlightLightningText } from './HighlightLightningText';
+export { default as RequestPaymentMock } from './RequestPaymentMock';
+export { default as LightningDemoScreen } from './LightningDemoScreen';

--- a/packages/lightning-ui/package.json
+++ b/packages/lightning-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/message-ui",
+  "name": "@mchat/lightning-ui",
   "version": "0.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/lightning-ui/tsconfig.json
+++ b/packages/lightning-ui/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "jsx": "react-native",
+    "types": ["react", "react-native"],
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}


### PR DESCRIPTION
## Summary
- add standalone `@mchat/lightning-ui` package with invoice detection utilities
- implement React Native payment sheet, text highlighter, request mock, and demo screen
- remove placeholder lightning preview screenshot and fix malformed package manifests
- handle BOLT11 invoices with proper parsing and mock generation
- add clipboard fallback using optional `@react-native-clipboard/clipboard` or browser API

## Testing
- `npm run lint` *(fails: Prettier and react-native/no-inline-styles errors)*
- `npm test`
- `npx tsc -p packages/lightning-ui/tsconfig.json` *(fails: TS5055 cannot write files in dist)*

------
https://chatgpt.com/codex/tasks/task_e_68a981636e2c832fbf2968a2c6f8d509