### PR TITLE
chore: configure root workspace and base tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   },
   "private": true,
   "workspaces": [
-    "packages/*"
+    "apps/*",
+    "packages/*",
+    "native/*"
   ],
   "devDependencies": {
     "@types/jest": "^29.5.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'
+  - 'native/*'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "ES2022",
+    "lib": ["ES2022"],
     "module": "commonjs",
     "moduleResolution": "node",
     "strict": true,
@@ -10,7 +11,9 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
-      "@mchat/*": ["packages/*/src"]
+      "@apps/*": ["apps/*/src"],
+      "@packages/*": ["packages/*/src"],
+      "@native/*": ["native/*/src"]
     }
   },
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,14 @@
 {
-  "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "declaration": true,
-    "outDir": "dist"
-  },
-  "include": ["packages/**/*"]
+  "files": [],
+  "references": [
+    { "path": "./apps/mobile" },
+    { "path": "./packages/a11y-utils" },
+    { "path": "./packages/chat-types" },
+    { "path": "./packages/lightning-ui" },
+    { "path": "./packages/lightning-utils" },
+    { "path": "./packages/message-ui" },
+    { "path": "./packages/push-contract" },
+    { "path": "./packages/ui-tokens" },
+    { "path": "./native/ln-core" }
+  ]
 }


### PR DESCRIPTION
## Summary
- add workspace configuration for apps, packages, and native projects
- introduce root TypeScript base config with strict settings and path aliases
- wire up project references for existing apps and packages

## Testing
- `pnpm install -w`
- `npx tsc -b` *(fails: Cannot find name 'process'; Cannot find module 'expo-modules-core'; Cannot find module '@mchat/ui-tokens')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad615fabf8832f8b603e0387c7551e