### PR TITLE
feat: add isolated storybook app

### DIFF
--- a/apps/storybook/App.tsx
+++ b/apps/storybook/App.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import StorybookUIRoot from './storybook';
+
+export default function App() {
+  return <StorybookUIRoot />;
+}

--- a/apps/storybook/app.json
+++ b/apps/storybook/app.json
@@ -1,0 +1,9 @@
+{
+  "expo": {
+    "name": "storybook",
+    "slug": "storybook",
+    "version": "1.0.0",
+    "sdkVersion": "51.0.0",
+    "platforms": ["ios", "android", "web"]
+  }
+}

--- a/apps/storybook/babel.config.js
+++ b/apps/storybook/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo']
+  };
+};

--- a/apps/storybook/index.js
+++ b/apps/storybook/index.js
@@ -1,0 +1,2 @@
+import App from './App';
+export default App;

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@mchat/storybook",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "ios": "expo run:ios",
+    "android": "expo run:android"
+  },
+  "dependencies": {
+    "expo": "~51.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.6",
+    "@mchat/message-ui": "workspace:*",
+    "@mchat/ui-tokens": "workspace:*",
+    "@mchat/lightning-ui": "workspace:*",
+    "@storybook/react-native": "^6.5.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  }
+}

--- a/apps/storybook/storybook/index.ts
+++ b/apps/storybook/storybook/index.ts
@@ -1,0 +1,6 @@
+import { getStorybookUI } from '@storybook/react-native';
+import './stories';
+
+const StorybookUIRoot = getStorybookUI({});
+
+export default StorybookUIRoot;

--- a/apps/storybook/storybook/stories/Lightning.stories.tsx
+++ b/apps/storybook/storybook/stories/Lightning.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react-native';
+import { ThemeProvider } from '@mchat/ui-tokens';
+import { LightningBolt } from '@mchat/lightning-ui';
+
+storiesOf('Lightning UI', module).add('LightningBolt', () => (
+  <ThemeProvider>
+    <LightningBolt label="Bolt" />
+  </ThemeProvider>
+));

--- a/apps/storybook/storybook/stories/MessageBubble.stories.tsx
+++ b/apps/storybook/storybook/stories/MessageBubble.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react-native';
+import { ThemeProvider } from '@mchat/ui-tokens';
+import { MessageBubble } from '@mchat/message-ui';
+
+storiesOf('Message UI', module).add('MessageBubble', () => (
+  <ThemeProvider>
+    <MessageBubble sender="me" text="Hello world" timestamp="09:41" status="sent" />
+  </ThemeProvider>
+));

--- a/apps/storybook/storybook/stories/Tokens.stories.tsx
+++ b/apps/storybook/storybook/stories/Tokens.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { storiesOf } from '@storybook/react-native';
+import { ThemeProvider, spacing, typography } from '@mchat/ui-tokens';
+
+storiesOf('Tokens', module).add('Basics', () => (
+  <ThemeProvider>
+    <View style={{ padding: spacing.lg }}>
+      <Text style={{ fontSize: typography.fontSize.lg }}>Tokens Demo</Text>
+    </View>
+  </ThemeProvider>
+));

--- a/apps/storybook/storybook/stories/index.ts
+++ b/apps/storybook/storybook/stories/index.ts
@@ -1,0 +1,3 @@
+import './MessageBubble.stories';
+import './Tokens.stories';
+import './Lightning.stories';

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "lint": "eslint '**/*.{ts,tsx,js}'",
     "format": "prettier --write '**/*.{ts,tsx,js,json,md}'",
     "prepare": "husky install",
-    "test": "jest"
+    "test": "jest",
+    "storybook:start": "npm --prefix apps/storybook start",
+    "storybook:ios": "npm --prefix apps/storybook run ios",
+    "storybook:android": "npm --prefix apps/storybook run android"
   },
   "keywords": [],
   "author": "",
@@ -24,7 +27,8 @@
   },
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "apps/*"
   ],
   "devDependencies": {
     "@types/jest": "^29.5.2",

--- a/packages/lightning-ui/LightningBolt.tsx
+++ b/packages/lightning-ui/LightningBolt.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
+import { spacing, typography, useTheme } from '@mchat/ui-tokens';
+
+export type LightningBoltProps = {
+  label?: string;
+};
+
+const LightningBolt: React.FC<LightningBoltProps> = ({ label = 'Lightning' }) => {
+  const { colors } = useTheme();
+  return <Text style={[styles.text, { color: colors.primary }]}>⚡ {label}</Text>;
+};
+
+const styles = StyleSheet.create({
+  text: {
+    fontSize: typography.fontSize.lg,
+    margin: spacing.md,
+    fontWeight: 'bold',
+  },
+});
+
+export default LightningBolt;

--- a/packages/lightning-ui/index.ts
+++ b/packages/lightning-ui/index.ts
@@ -1,1 +1,2 @@
 export { default as LnCoreDemoScreen } from './LnCoreDemoScreen';
+export { default as LightningBolt } from './LightningBolt';

--- a/packages/lightning-ui/package.json
+++ b/packages/lightning-ui/package.json
@@ -12,5 +12,12 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@mchat/ui-tokens": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
   }
 }

--- a/packages/lightning-ui/tsconfig.json
+++ b/packages/lightning-ui/tsconfig.json
@@ -5,5 +5,5 @@
     "declaration": true,
     "outDir": "dist"
   },
-  "include": ["index.ts", "LnCoreDemoScreen.tsx"]
+  "include": ["index.ts", "LnCoreDemoScreen.tsx", "LightningBolt.tsx"]
 }


### PR DESCRIPTION
## Summary
- scaffold new Expo Storybook app for isolated UI previews
- add LightningBolt sample component
- wire scripts for starting Storybook

## Testing
- `npm install` *(fails: Unsupported URL Type "workspace:" workspace:*)
- `npx jest` *(interactive install prompt for jest)*

------
https://chatgpt.com/codex/tasks/task_e_68ad61716c10832fa710b060be2452bd