### PR TITLE
chore: remove IDE metadata from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ web-build/
 target/
 **/target/
 native/rust/target/
+# IDE
+.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 ## How we work
 Describe how to get involved and the development workflow.
+Avoid committing IDE-specific folders (e.g., `.idea/`).
 
 ## Commit style
 Use concise, conventional commit messages (e.g., `feat:`, `fix:`, `chore:`).


### PR DESCRIPTION
## Summary
- delete leftover .idea directory and add IDE folders to .gitignore
- document that IDE folders like `.idea` must not be committed

## Testing
- `npm install` *(fails: Unsupported URL Type "workspace:")*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6188f1a0832fb6358df75656210c