### PR TITLE
feat: add push-contract payload types and docs

### DIFF
--- a/packages/push-contract/README.md
+++ b/packages/push-contract/README.md
@@ -1,0 +1,84 @@
+# Push Contract
+
+Platform-agnostic TypeScript definitions for registering devices and
+delivering push notifications. These contracts are intended to be shared
+between server, CLI, and client applications.
+
+## Token Registration
+
+```ts
+interface PushToken {
+  platform: 'apns' | 'fcm';
+  value: string;
+}
+
+interface RegistrationRequest {
+  deviceId: string;
+  token: PushToken;
+}
+```
+
+A client registers a stable `deviceId` along with the opaque push token
+issued by FCM or APNs.
+
+## Notification Payload
+
+```ts
+interface NotificationPayload {
+  room_id: string;
+  event_id: string;
+  sender: string;
+  type: string;
+  unread_count?: number;
+}
+```
+
+The payload contains the Matrix identifiers needed by a client to fetch
+and display the originating event. `unread_count` is optional and, when
+present, represents the total unread messages for the room.
+
+## Provider Messages
+
+### FCM
+
+```ts
+interface FcmMessage {
+  token: string;
+  data: NotificationPayload;
+  notification?: {
+    title?: string;
+    body?: string;
+  };
+}
+```
+
+The `notification` field is optional and, when set, controls the display
+notification handled by the platform. `data` always carries the
+`NotificationPayload`.
+
+### APNs
+
+```ts
+interface ApnsMessage {
+  token: string;
+  aps: {
+    alert: {
+      title: string;
+      body: string;
+    };
+    badge?: number;
+  };
+  data: NotificationPayload;
+}
+```
+
+The `aps` dictionary follows APNs conventions. The client should read the
+custom `data` field for Matrix-specific information.
+
+## Delivery Semantics
+
+Messages are delivered on a best-effort basis. Providers may drop or
+duplicate notifications, so clients must de-duplicate using `event_id`.
+Tokens are assumed to be valid until revoked; re-registration replaces
+any existing token for the same `deviceId`.
+

--- a/packages/push-contract/src/index.ts
+++ b/packages/push-contract/src/index.ts
@@ -27,9 +27,56 @@ export interface NotificationPayload {
   unread_count?: number;
 }
 
+export interface FcmMessage {
+  /** Target device token */
+  token: string;
+  /** Transported notification payload */
+  data: NotificationPayload;
+  /** Optional display notification */
+  notification?: {
+    title?: string;
+    body?: string;
+  };
+}
+
+export interface ApnsMessage {
+  /** Target device token */
+  token: string;
+  /** Standard APNs aps dictionary */
+  aps: {
+    alert: {
+      title: string;
+      body: string;
+    };
+    badge?: number;
+  };
+  /** Custom data sent alongside the aps dictionary */
+  data: NotificationPayload;
+}
+
 /**
- * Mock function that simulates sending a push notification.
+ * Helper to create an FCM message
  */
-export function sendTestPush(token: PushToken): void {
-  console.log(`Mock push to ${token.platform} token ${token.value}`);
+export function createFcmMessage(
+  token: string,
+  payload: NotificationPayload,
+  notification?: { title?: string; body?: string },
+): FcmMessage {
+  return { token, data: payload, notification };
+}
+
+/**
+ * Helper to create an APNs message
+ */
+export function createApnsMessage(
+  token: string,
+  payload: NotificationPayload,
+  alert: { title: string; body: string },
+  badge?: number,
+): ApnsMessage {
+  return {
+    token,
+    aps: { alert, badge },
+    data: payload,
+  };
 }


### PR DESCRIPTION
## Summary
- expand push contract with FCM/APNs message types and pure helpers
- document token registration, notification payloads, and delivery semantics

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad618e37b0832f8007138c7f5f6054