### PR TITLE
chore: add Matrix Core config plugin stub

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,18 +1,14 @@
 import { ExpoConfig, ConfigContext } from '@expo/config';
 
-const withMatrixCorePlugin = './plugins/with-matrix-core'; // Example custom plugin
-
-export default ({ config }: ConfigContext): ExpoConfig => {
-  const withMatrixCore = process.env.WITH_MATRIX_CORE === 'true';
-
-  return {
-    ...config,
-    name: config.name ?? 'mchat',
-    slug: config.slug ?? 'mchat',
-    plugins: [
-      ...(config.plugins ?? []),
-      // Add additional Expo config plugins here
-      ...(withMatrixCore ? [withMatrixCorePlugin] : []),
-    ],
-  };
-};
+// To experiment with the Matrix Core config plugin:
+// 1. Set WITH_MATRIX_CORE=true in your environment.
+// 2. Uncomment the line in the plugins array below.
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...config,
+  name: config.name ?? 'mchat',
+  slug: config.slug ?? 'mchat',
+  plugins: [
+    ...(config.plugins ?? []),
+    // './plugins/with-matrix-core',
+  ],
+});

--- a/apps/mobile/plugins/with-matrix-core.ts
+++ b/apps/mobile/plugins/with-matrix-core.ts
@@ -2,9 +2,19 @@ import { ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
 
 /**
  * Stub Expo config plugin for future Matrix core integration.
- * Currently logs intended changes without modifying native projects.
+ *
+ * When enabled (WITH_MATRIX_CORE=true), this plugin will later link the
+ * Matrix Core native binaries into the project. For now it only logs the
+ * intended actions without modifying the native projects.
  */
 const withMatrixCore: ConfigPlugin = (config) => {
+  if (process.env.WITH_MATRIX_CORE !== 'true') {
+    console.log(
+      'with-matrix-core: skipping native configuration (set WITH_MATRIX_CORE=true to enable)',
+    );
+    return config;
+  }
+
   config = withDangerousMod(config, [
     'ios',
     async (c) => {


### PR DESCRIPTION
## Summary
- add Expo config plugin stub for Matrix Core integration guarded by `WITH_MATRIX_CORE` env var
- document how to enable the plugin in `app.config.ts`

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run typecheck`
- `npx prettier apps/mobile/plugins/with-matrix-core.ts apps/mobile/app.config.ts --check`


------
https://chatgpt.com/codex/tasks/task_e_68ad617facc0832fbc5d813a504d5e92