### PR TITLE
chore: copy root src into mobile src

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,4 @@
+# Mobile App
+
+The canonical source root for the mobile app is `apps/mobile/src/`. All mobile-specific code will live under this directory going forward.
+

--- a/apps/mobile/src/components/conversation/ComposerMock.tsx
+++ b/apps/mobile/src/components/conversation/ComposerMock.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const ComposerMock: React.FC = () => (
+  <View style={styles.container}>
+    <Text style={styles.icon} accessibilityRole="button">
+      ＋
+    </Text>
+    <View style={styles.input}>
+      <Text style={styles.placeholder}>Message</Text>
+    </View>
+    <Text style={styles.icon} accessibilityRole="button">
+      🎤
+    </Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#ddd',
+  },
+  icon: {
+    fontSize: 24,
+    paddingHorizontal: 8,
+  },
+  input: {
+    flex: 1,
+    backgroundColor: '#f0f0f0',
+    borderRadius: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginHorizontal: 4,
+  },
+  placeholder: {
+    color: '#888',
+    fontSize: 16,
+  },
+});
+
+export default ComposerMock;

--- a/apps/mobile/src/components/conversation/ConversationHeader.tsx
+++ b/apps/mobile/src/components/conversation/ConversationHeader.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const ConversationHeader: React.FC = () => {
+  const online = true;
+  return (
+    <View style={styles.container}>
+      <Text style={styles.icon} accessibilityRole="button">
+        ‹
+      </Text>
+      <View style={styles.profile}>
+        <View style={styles.avatarContainer}>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarText}>A</Text>
+          </View>
+          <View
+            style={[
+              styles.presenceDot,
+              online ? styles.presenceOnline : styles.presenceOffline,
+            ]}
+          />
+        </View>
+        <Text style={styles.name}>Alice</Text>
+      </View>
+      <Text style={styles.icon} accessibilityRole="button">
+        ⋮
+      </Text>
+    </View>
+  );
+};
+
+const AVATAR_SIZE = 36;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#ddd',
+  },
+  icon: {
+    fontSize: 24,
+    width: 24,
+    textAlign: 'center',
+  },
+  profile: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+    marginHorizontal: 8,
+  },
+  avatarContainer: {
+    marginRight: 8,
+  },
+  avatar: {
+    width: AVATAR_SIZE,
+    height: AVATAR_SIZE,
+    borderRadius: AVATAR_SIZE / 2,
+    backgroundColor: '#bbb',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  avatarText: {
+    fontSize: 16,
+    color: '#fff',
+  },
+  presenceDot: {
+    position: 'absolute',
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    borderWidth: 2,
+    borderColor: '#fff',
+    right: -2,
+    bottom: -2,
+  },
+  presenceOnline: {
+    backgroundColor: '#4caf50',
+  },
+  presenceOffline: {
+    backgroundColor: '#9e9e9e',
+  },
+  name: {
+    fontSize: 16,
+  },
+});
+
+export default ConversationHeader;

--- a/apps/mobile/src/components/conversation/DaySeparator.tsx
+++ b/apps/mobile/src/components/conversation/DaySeparator.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export type DaySeparatorProps = {
+  label: string;
+};
+
+const DaySeparator: React.FC<DaySeparatorProps> = ({ label }) => (
+  <View style={styles.container}>
+    <View style={styles.line} />
+    <Text style={styles.label} accessibilityRole="text">
+      {label}
+    </Text>
+    <View style={styles.line} />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 8,
+    paddingHorizontal: 8,
+  },
+  line: {
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: '#ccc',
+  },
+  label: {
+    marginHorizontal: 8,
+    fontSize: 12,
+    color: '#555',
+  },
+});
+
+export default DaySeparator;

--- a/apps/mobile/src/components/conversation/MessageBubble.tsx
+++ b/apps/mobile/src/components/conversation/MessageBubble.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export type MessageBubbleProps = {
+  sender: 'me' | 'them';
+  text?: string;
+  imageMock?: boolean;
+  time: string;
+  status?: 'sent' | 'delivered' | 'read';
+  isReply?: boolean;
+  replyPreviewText?: string;
+};
+
+const statusIcons: Record<string, string> = {
+  sent: '✓',
+  delivered: '✓✓',
+  read: '✓✓',
+};
+
+const MessageBubble: React.FC<MessageBubbleProps> = ({
+  sender,
+  text,
+  imageMock,
+  time,
+  status,
+  isReply,
+  replyPreviewText,
+}) => {
+  const alignment = sender === 'me' ? styles.meContainer : styles.themContainer;
+  const bubbleStyle = sender === 'me' ? styles.meBubble : styles.themBubble;
+
+  const labelParts = [sender === 'me' ? 'You' : 'Them', time];
+  if (sender === 'me' && status) {
+    labelParts.push(status);
+  }
+  if (text) {
+    labelParts.push(text);
+  } else if (imageMock) {
+    labelParts.push('Image');
+  }
+
+  return (
+    <View style={[styles.container, alignment]}>
+      <View
+        accessible
+        accessibilityRole="text"
+        accessibilityLabel={labelParts.join(', ')}
+        style={[styles.bubble, bubbleStyle]}
+      >
+        {isReply && replyPreviewText ? (
+          <Text style={styles.replyPreview} numberOfLines={1}>
+            {replyPreviewText}
+          </Text>
+        ) : null}
+        {imageMock ? (
+          <View style={styles.imageMock} />
+        ) : (
+          <Text style={styles.messageText}>{text}</Text>
+        )}
+        <View style={styles.meta}>
+          <Text style={styles.time}>{time}</Text>
+          {sender === 'me' && status ? (
+            <Text
+              style={[styles.status, status === 'read' && styles.statusRead]}
+            >
+              {statusIcons[status]}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginVertical: 2,
+    flexDirection: 'row',
+    paddingHorizontal: 8,
+  },
+  meContainer: {
+    justifyContent: 'flex-end',
+  },
+  themContainer: {
+    justifyContent: 'flex-start',
+  },
+  bubble: {
+    maxWidth: '75%',
+    padding: 8,
+    borderRadius: 16,
+  },
+  meBubble: {
+    backgroundColor: '#dcf8c6',
+    borderBottomRightRadius: 2,
+    alignSelf: 'flex-end',
+  },
+  themBubble: {
+    backgroundColor: '#fff',
+    borderBottomLeftRadius: 2,
+    alignSelf: 'flex-start',
+  },
+  messageText: {
+    fontSize: 16,
+    lineHeight: 20,
+  },
+  replyPreview: {
+    fontSize: 12,
+    color: '#555',
+    marginBottom: 4,
+  },
+  meta: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginTop: 4,
+  },
+  time: {
+    fontSize: 10,
+    color: '#555',
+  },
+  status: {
+    fontSize: 10,
+    color: '#555',
+    marginLeft: 4,
+  },
+  statusRead: {
+    color: '#1a73e8',
+  },
+  imageMock: {
+    width: 180,
+    height: 120,
+    backgroundColor: '#ccc',
+    borderRadius: 8,
+  },
+});
+
+export default MessageBubble;

--- a/apps/mobile/src/components/settings/ProfileCard.tsx
+++ b/apps/mobile/src/components/settings/ProfileCard.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { View, Text, StyleSheet, useColorScheme } from 'react-native';
+
+interface Props {
+  name: string;
+  handle: string;
+}
+
+const ProfileCard = ({ name, handle }: Props) => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.card, shadowColor: colors.shadow }]}> 
+      <View style={[styles.avatar, { backgroundColor: colors.avatar }]} />
+      <View style={styles.info}>
+        <Text style={[styles.name, { color: colors.text }]}>{name}</Text>
+        <Text style={[styles.handle, { color: colors.subtext }]}>{handle}</Text>
+      </View>
+      <Text style={[styles.qr, { color: colors.subtext }]}>QR</Text>
+    </View>
+  );
+};
+
+const lightColors = { card: '#ffffff', text: '#000000', subtext: '#555555', avatar: '#cccccc', shadow: '#000000' };
+const darkColors = { card: '#222222', text: '#ffffff', subtext: '#aaaaaa', avatar: '#444444', shadow: '#000000' };
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    margin: 16,
+    borderRadius: 8,
+    elevation: 2,
+    shadowOpacity: 0.2,
+    shadowOffset: { width: 0, height: 1 },
+    shadowRadius: 2,
+  },
+  avatar: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+  },
+  info: {
+    flex: 1,
+    marginLeft: 16,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  handle: {
+    marginTop: 4,
+    fontSize: 14,
+  },
+  qr: {
+    fontSize: 16,
+  },
+});
+
+export default ProfileCard;

--- a/apps/mobile/src/components/settings/SectionHeader.tsx
+++ b/apps/mobile/src/components/settings/SectionHeader.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Text, StyleSheet, useColorScheme } from 'react-native';
+
+interface Props {
+  title: string;
+}
+
+const SectionHeader = ({ title }: Props) => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+
+  return <Text style={[styles.header, { color: colors.subtext }]}>{title}</Text>;
+};
+
+const lightColors = { subtext: '#555555' };
+const darkColors = { subtext: '#aaaaaa' };
+
+const styles = StyleSheet.create({
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});
+
+export default SectionHeader;

--- a/apps/mobile/src/components/settings/SettingsListItem.tsx
+++ b/apps/mobile/src/components/settings/SettingsListItem.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, useColorScheme } from 'react-native';
+
+interface Props {
+  label: string;
+  onPress?: () => void;
+  accessibilityHint?: string;
+}
+
+const SettingsListItem = ({ label, onPress, accessibilityHint }: Props) => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityHint={accessibilityHint || `Activates ${label}`}
+      onPress={onPress}
+    >
+      <View style={[styles.container, { borderBottomColor: colors.border, backgroundColor: colors.card }]}> 
+        <Text style={[styles.label, { color: colors.text }]}>{label}</Text>
+        <Text style={[styles.chevron, { color: colors.subtext }]}>›</Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+const lightColors = { card: '#ffffff', text: '#000000', subtext: '#777777', border: '#e0e0e0' };
+const darkColors = { card: '#1c1c1c', text: '#ffffff', subtext: '#aaaaaa', border: '#333333' };
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  label: {
+    flex: 1,
+    fontSize: 16,
+  },
+  chevron: {
+    fontSize: 18,
+    marginLeft: 4,
+  },
+});
+
+export default SettingsListItem;

--- a/apps/mobile/src/components/shell/TabBarMock.tsx
+++ b/apps/mobile/src/components/shell/TabBarMock.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View, Text, StyleSheet, useColorScheme } from 'react-native';
+
+const TabBarMock = () => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+
+  const tabs = [
+    { label: 'Chats', icon: '💬' },
+    { label: 'Calls', icon: '📞' },
+    { label: 'Settings', icon: '⚙️' },
+  ];
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.card, borderTopColor: colors.border }]}> 
+      {tabs.map((tab) => (
+        <View key={tab.label} style={styles.tab}>
+          <Text style={styles.icon}>{tab.icon}</Text>
+          <Text style={[styles.label, { color: colors.text }]}>{tab.label}</Text>
+        </View>
+      ))}
+    </View>
+  );
+};
+
+const lightColors = { card: '#ffffff', text: '#222222', border: '#e0e0e0' };
+const darkColors = { card: '#1c1c1c', text: '#f2f2f2', border: '#333333' };
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  icon: {
+    fontSize: 20,
+    marginBottom: 2,
+  },
+  label: {
+    fontSize: 12,
+  },
+});
+
+export default TabBarMock;

--- a/apps/mobile/src/example.ts
+++ b/apps/mobile/src/example.ts
@@ -1,0 +1,1 @@
+export const example = 42;

--- a/apps/mobile/src/screens/ConversationMock.tsx
+++ b/apps/mobile/src/screens/ConversationMock.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { View, FlatList, StyleSheet } from 'react-native';
+import ConversationHeader from '../components/conversation/ConversationHeader';
+import MessageBubble, {
+  MessageBubbleProps,
+} from '../components/conversation/MessageBubble';
+import DaySeparator from '../components/conversation/DaySeparator';
+import ComposerMock from '../components/conversation/ComposerMock';
+
+const messages: Array<
+  | { id: string; type: 'separator'; label: string }
+  | (MessageBubbleProps & { id: string })
+> = [
+  { id: 'sep1', type: 'separator', label: 'Yesterday' },
+  {
+    id: '1',
+    sender: 'them',
+    text: 'Hey, are we still on for tonight?',
+    time: '09:41',
+  },
+  {
+    id: '2',
+    sender: 'me',
+    text: 'Absolutely! Looking forward to catching up later. This is a bit longer to wrap across lines.',
+    time: '09:42',
+    status: 'delivered',
+  },
+  { id: '3', sender: 'them', text: '👍', time: '09:43' },
+  { id: 'sep2', type: 'separator', label: 'Today' },
+  {
+    id: '4',
+    sender: 'me',
+    isReply: true,
+    replyPreviewText: 'Hey, are we still on for tonight?',
+    text: 'Yep, leaving in 5.',
+    time: '17:10',
+    status: 'sent',
+  },
+  { id: '5', sender: 'them', imageMock: true, time: '17:12' },
+  {
+    id: '6',
+    sender: 'me',
+    text: 'See you soon! 👋',
+    time: '17:13',
+    status: 'read',
+  },
+];
+
+const ConversationMock: React.FC = () => {
+  return (
+    <View style={styles.container}>
+      <ConversationHeader />
+      <FlatList
+        data={messages}
+        inverted
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) =>
+          'type' in item && item.type === 'separator' ? (
+            <DaySeparator label={item.label} />
+          ) : (
+            <MessageBubble {...(item as MessageBubbleProps)} />
+          )
+        }
+        contentContainerStyle={styles.listContent}
+      />
+      <ComposerMock />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#e5ddd5',
+  },
+  listContent: {
+    flexGrow: 1,
+    justifyContent: 'flex-end',
+    paddingVertical: 8,
+  },
+});
+
+export default ConversationMock;

--- a/apps/mobile/src/screens/SettingsMock.tsx
+++ b/apps/mobile/src/screens/SettingsMock.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { ScrollView, View, Text, StyleSheet, useColorScheme } from 'react-native';
+import ProfileCard from '../components/settings/ProfileCard';
+import SectionHeader from '../components/settings/SectionHeader';
+import SettingsListItem from '../components/settings/SettingsListItem';
+
+const SettingsMock = () => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+
+  return (
+    <ScrollView style={[styles.screen, { backgroundColor: colors.background }]}> 
+      <ProfileCard name="Jane Doe" handle="@jane" />
+      <View style={styles.section}>
+        <SectionHeader title="Account" />
+        <SettingsListItem label="Phone Number" />
+        <SettingsListItem label="Privacy" />
+        <SettingsListItem label="Security" />
+        <SettingsListItem label="Two-Step Verify" />
+      </View>
+      <View style={styles.section}>
+        <SectionHeader title="Appearance" />
+        <SettingsListItem label="Theme" />
+        <SettingsListItem label="Wallpapers" />
+      </View>
+      <View style={styles.section}>
+        <SectionHeader title="Notifications" />
+        <SettingsListItem label="Message tones" />
+        <SettingsListItem label="Vibrate" />
+      </View>
+      <View style={styles.section}>
+        <SectionHeader title="Data & Storage" />
+        <SettingsListItem label="Media auto-download" />
+      </View>
+      <View style={styles.section}>
+        <SectionHeader title="Help" />
+        <SettingsListItem label="FAQ" />
+        <SettingsListItem label="Report a problem" />
+      </View>
+      <View style={styles.footer}>
+        <Text style={[styles.version, { color: colors.subtext }]}>v0.0.0</Text>
+        <Text style={[styles.license, { color: colors.subtext }]}>Open source, no telemetry</Text>
+      </View>
+    </ScrollView>
+  );
+};
+
+const lightColors = { background: '#f5f5f5', subtext: '#777777' };
+const darkColors = { background: '#000000', subtext: '#aaaaaa' };
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+  section: {
+    marginTop: 8,
+  },
+  footer: {
+    alignItems: 'center',
+    paddingVertical: 32,
+  },
+  version: {
+    fontSize: 12,
+  },
+  license: {
+    fontSize: 12,
+    marginTop: 4,
+  },
+});
+
+export default SettingsMock;

--- a/apps/mobile/src/screens/ShellMock.tsx
+++ b/apps/mobile/src/screens/ShellMock.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, useColorScheme, Animated, ScrollView } from 'react-native';
+import TabBarMock from '../components/shell/TabBarMock';
+
+const ShellMock = () => {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+  const shimmer = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(shimmer, { toValue: 1, duration: 1000, useNativeDriver: true }),
+        Animated.timing(shimmer, { toValue: 0.3, duration: 1000, useNativeDriver: true }),
+      ]),
+    ).start();
+  }, [shimmer]);
+
+  return (
+    <View style={[styles.screen, { backgroundColor: colors.background }]}> 
+      <View style={[styles.topBar, { backgroundColor: colors.card, borderBottomColor: colors.border }]}> 
+        <Text style={[styles.title, { color: colors.text }]}>mChat</Text>
+        <View style={styles.topIcons}>
+          <Text style={[styles.topIcon, { color: colors.subtext }]}>🔍</Text>
+          <Text style={[styles.topIcon, { color: colors.subtext }]}>📷</Text>
+        </View>
+      </View>
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={[styles.card, { backgroundColor: colors.card, shadowColor: colors.shadow }]}> 
+          <Text style={[styles.cardText, { color: colors.text }]}>This is the shell</Text>
+        </View>
+        {[0, 1, 2, 3].map((i) => (
+          <Animated.View
+            key={i}
+            style={[styles.placeholder, { backgroundColor: colors.placeholder, opacity: shimmer }]}
+          />
+        ))}
+      </ScrollView>
+      <TabBarMock />
+    </View>
+  );
+};
+
+const lightColors = {
+  background: '#f5f5f5',
+  card: '#ffffff',
+  text: '#000000',
+  subtext: '#777777',
+  border: '#e0e0e0',
+  placeholder: '#e0e0e0',
+  shadow: '#000000',
+};
+const darkColors = {
+  background: '#000000',
+  card: '#1c1c1c',
+  text: '#ffffff',
+  subtext: '#aaaaaa',
+  border: '#333333',
+  placeholder: '#333333',
+  shadow: '#000000',
+};
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+  topBar: {
+    height: 56,
+    paddingHorizontal: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    justifyContent: 'space-between',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  topIcons: {
+    flexDirection: 'row',
+  },
+  topIcon: {
+    marginLeft: 16,
+    fontSize: 18,
+  },
+  content: {
+    padding: 16,
+  },
+  card: {
+    padding: 24,
+    borderRadius: 8,
+    marginBottom: 24,
+    elevation: 2,
+    shadowOpacity: 0.2,
+    shadowOffset: { width: 0, height: 1 },
+    shadowRadius: 2,
+  },
+  cardText: {
+    fontSize: 16,
+  },
+  placeholder: {
+    height: 40,
+    borderRadius: 4,
+    marginBottom: 12,
+  },
+});
+
+export default ShellMock;


### PR DESCRIPTION
## Summary
- mirror root `src` tree into `apps/mobile/src` so mobile code lives under one root
- document `apps/mobile/src` as the canonical source directory

## Testing
- `npm install` *(fails: Unsupported URL Type "workspace:". cannot install dependencies)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad648cb33c832f89f56178fc43c6c1