### PR TITLE
chore: prepare packages for scoped publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format": "prettier --write '**/*.{ts,tsx,js,json,md}'",
     "prepare": "husky install",
     "test": "jest",
+    "build": "pnpm -r --filter './packages/*' build",
     "storybook:start": "npm --prefix apps/storybook start",
     "storybook:ios": "npm --prefix apps/storybook run ios",
     "storybook:android": "npm --prefix apps/storybook run android"

--- a/packages/a11y-utils/package.json
+++ b/packages/a11y-utils/package.json
@@ -2,7 +2,7 @@
   "name": "@mchat/a11y-utils",
   "version": "0.1.0",
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/a11y-utils/package.json
+++ b/packages/a11y-utils/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@mchat/a11y-utils",
   "version": "0.1.0",
-  "private": true,
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
@@ -15,6 +15,10 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-native": "*"
   },
   "license": "AGPL-3.0-only",
   "repository": {

--- a/packages/chat-types/package.json
+++ b/packages/chat-types/package.json
@@ -2,7 +2,7 @@
   "name": "@mchat/chat-types",
   "version": "0.1.0",
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/chat-types/package.json
+++ b/packages/chat-types/package.json
@@ -2,8 +2,11 @@
   "name": "@mchat/chat-types",
   "version": "0.1.0",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/packages/lightning-ui/package.json
+++ b/packages/lightning-ui/package.json
@@ -2,7 +2,7 @@
   "name": "@mchat/lightning-ui",
   "version": "0.1.0",
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/lightning-ui/package.json
+++ b/packages/lightning-ui/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@mchat/lightning-ui",
   "version": "0.1.0",
-  "private": true,
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/lightning-utils/package.json
+++ b/packages/lightning-utils/package.json
@@ -2,6 +2,7 @@
   "name": "@mchat/lightning-utils",
   "version": "0.1.0",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
@@ -12,7 +13,6 @@
       "default": "./dist/index.js"
     }
   },
-  "private": true,
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/packages/lightning-utils/package.json
+++ b/packages/lightning-utils/package.json
@@ -2,7 +2,7 @@
   "name": "@mchat/lightning-utils",
   "version": "0.1.0",
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/message-ui/package.json
+++ b/packages/message-ui/package.json
@@ -2,7 +2,7 @@
   "name": "@mchat/message-ui",
   "version": "0.1.0",
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/message-ui/package.json
+++ b/packages/message-ui/package.json
@@ -2,6 +2,7 @@
   "name": "@mchat/message-ui",
   "version": "0.1.0",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
@@ -12,7 +13,6 @@
   "files": [
     "dist"
   ],
-  "private": true,
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/packages/push-contract/package.json
+++ b/packages/push-contract/package.json
@@ -2,7 +2,7 @@
   "name": "@mchat/push-contract",
   "version": "0.1.0",
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/push-contract/package.json
+++ b/packages/push-contract/package.json
@@ -2,6 +2,7 @@
   "name": "@mchat/push-contract",
   "version": "0.1.0",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
@@ -13,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsc -p tsconfig.json"
   },
   "devDependencies": {
     "typescript": "^5.3.3"

--- a/packages/ui-tokens/package.json
+++ b/packages/ui-tokens/package.json
@@ -2,7 +2,7 @@
   "name": "@mchat/ui-tokens",
   "version": "0.1.0",
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/ui-tokens/package.json
+++ b/packages/ui-tokens/package.json
@@ -2,6 +2,7 @@
   "name": "@mchat/ui-tokens",
   "version": "0.1.0",
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
@@ -16,7 +17,8 @@
     "build": "tsc -p tsconfig.json"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-native": "*"
   },
   "devDependencies": {
     "typescript": "^5.0.0",


### PR DESCRIPTION
## Summary
- add module fields and peer React deps to UI packages
- expose build script for workspace packages
- ensure packages publish only built dist files

## Testing
- `pnpm -w build`
- `for d in packages/*; do (cd $d && npm pack --dry-run); done`


------
https://chatgpt.com/codex/tasks/task_e_68ad8cf9501c832fad6d318fdaf3db5d