### PR TITLE
feat(storybook): use package imports and add tokens theme toggle

### DIFF
--- a/apps/storybook/storybook/stories/Tokens.stories.tsx
+++ b/apps/storybook/storybook/stories/Tokens.stories.tsx
@@ -1,12 +1,66 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
-import { ThemeProvider, spacing, typography } from '@mchat/ui-tokens';
+import { ThemeProvider, spacing, typography, useTheme } from '@mchat/ui-tokens';
 
-storiesOf('Tokens', module).add('Basics', () => (
+const tokensStories = storiesOf('Tokens', module);
+
+tokensStories.add('Basics', () => (
   <ThemeProvider>
     <View style={{ padding: spacing.lg }}>
       <Text style={{ fontSize: typography.fontSize.lg }}>Tokens Demo</Text>
     </View>
   </ThemeProvider>
 ));
+
+const ThemeToggleContent = ({
+  mode,
+  onToggle,
+}: {
+  mode: 'light' | 'dark';
+  onToggle: () => void;
+}) => {
+  const {
+    colors,
+    spacing: spacingTokens,
+    typography: typographyTokens,
+  } = useTheme();
+
+  const containerStyle = {
+    padding: spacingTokens.lg,
+    backgroundColor: colors.surface,
+  };
+
+  const textStyle = {
+    color: colors.text,
+    fontSize: typographyTokens.fontSize.lg,
+    marginBottom: spacingTokens.md,
+  };
+
+  return (
+    <View style={[styles.container, containerStyle]}>
+      <Text style={textStyle}>Current theme: {mode}</Text>
+      <Button title="Toggle Theme" color={colors.primary} onPress={onToggle} />
+    </View>
+  );
+};
+
+const ThemeToggleDemo = () => {
+  const [mode, setMode] = useState<'light' | 'dark'>('light');
+  const toggle = () => setMode((m) => (m === 'light' ? 'dark' : 'light'));
+  return (
+    <ThemeProvider mode={mode}>
+      <ThemeToggleContent mode={mode} onToggle={toggle} />
+    </ThemeProvider>
+  );
+};
+
+tokensStories.add('Theme Toggle', () => <ThemeToggleDemo />);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add light/dark theme toggle story for ui-tokens
- ensure storybook stories use package imports only

## Testing
- `npm test`
- `npx eslint apps/storybook/storybook/stories/Tokens.stories.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ad8d047bfc832fbabe233aa6b1b1e1