### PR TITLE
feat: align LnCore module naming with ping stub

### DIFF
--- a/native/ln-core/README.md
+++ b/native/ln-core/README.md
@@ -6,8 +6,8 @@ package path `com.mchat.lncore`.
 
 ## Current status
 
-Only a minimal Expo Modules stub is provided for iOS. It exposes a
-single `ping()` function that returns a static `"pong"` string. This
+Only a minimal Expo Modules stub is provided. It exposes a
+single `ping()` function that returns a static `"ok"` string. This
 serves as a placeholder so other parts of the project can link against
 the module while the real Lightning functionality is built.
 

--- a/native/ln-core/android/src/main/java/com/mchat/lncore/LnCoreModule.kt
+++ b/native/ln-core/android/src/main/java/com/mchat/lncore/LnCoreModule.kt
@@ -2,69 +2,14 @@ package com.mchat.lncore
 
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import kotlinx.coroutines.delay
-import java.util.UUID
 
 class LnCoreModule : Module() {
-  private val payments = mutableListOf<MutableMap<String, Any>>()
-  private var network: String = "testnet"
-
   override fun definition() = ModuleDefinition {
     Name("LnCore")
-    Events("PaymentUpdated")
 
-    AsyncFunction("init") { opts: Map<String, Any>? ->
-      opts?.get("network")?.let { network = it as String }
-      mapOf("ok" to true)
+    AsyncFunction("ping") {
+      "ok"
     }
-
-    AsyncFunction("isReady") { true }
-
-    AsyncFunction("nodeInfo") {
-      mapOf(
-        "pubkey" to "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "alias" to "MockNode",
-        "connected" to false
-      )
-    }
-
-    AsyncFunction("createInvoice") { params: Map<String, Any> ->
-      val amount = (params["amountSats"] as? Number)?.toLong() ?: 0L
-      val memo = params["memo"] as? String
-      val id = UUID.randomUUID().toString()
-      val prefix = when (network) {
-        "mainnet" -> "lnbc"
-        "signet" -> "lntbs"
-        else -> "lntb"
-      }
-      val bolt11 = "${prefix}1mock${id.take(8)}"
-      val payment = mutableMapOf<String, Any>(
-        "id" to id,
-        "bolt11" to bolt11,
-        "status" to "pending",
-        "amountSats" to amount,
-        "timestamp" to System.currentTimeMillis() / 1000
-      )
-      payments.add(payment)
-      mutableMapOf<String, Any>("bolt11" to bolt11, "amountSats" to amount).apply {
-        memo?.let { put("memo", it) }
-      }
-    }
-
-    AsyncFunction("payInvoice") { bolt11: String ->
-      val payment = payments.find { it["bolt11"] == bolt11 }
-      val id = payment?.get("id") as? String ?: UUID.randomUUID().toString()
-      sendEvent("PaymentUpdated", mapOf("id" to id, "status" to "pending"))
-      delay((300..800).random().toLong())
-      payment?.set("status", "succeeded")
-      sendEvent("PaymentUpdated", mapOf("id" to id, "status" to "succeeded"))
-      mapOf("preimage" to "a".repeat(64), "feesSats" to 1)
-    }
-
-    AsyncFunction("estimateFees") { _: String ->
-      mapOf("maxFeesSats" to 1)
-    }
-
-    AsyncFunction("listPayments") { payments.toList() }
   }
 }
+

--- a/native/ln-core/index.ts
+++ b/native/ln-core/index.ts
@@ -1,58 +1,14 @@
-import {
-  EventEmitter,
-  Subscription,
-  requireNativeModule,
-} from 'expo-modules-core';
-
-export type LnInitOptions = {
-  dataDir?: string;
-  network?: 'mainnet' | 'testnet' | 'signet';
-};
-export type LnInvoice = { bolt11: string; amountSats?: number; memo?: string };
-export type Payment = {
-  id: string;
-  bolt11: string;
-  status: 'pending' | 'succeeded' | 'failed';
-  amountSats: number;
-  timestamp: number;
-};
-export type PaymentUpdatedEvent = {
-  id: string;
-  status: 'pending' | 'succeeded' | 'failed';
-};
+import { requireNativeModule } from 'expo-modules-core';
 
 export interface LnCore {
-  init(opts: LnInitOptions): Promise<{ ok: true }>;
-  isReady(): Promise<boolean>;
-  nodeInfo(): Promise<{ pubkey: string; alias: string; connected: boolean }>;
-  createInvoice(params: {
-    amountSats: number;
-    memo?: string;
-  }): Promise<LnInvoice>;
-  payInvoice(bolt11: string): Promise<{ preimage: string; feesSats: number }>;
-  estimateFees(bolt11: string): Promise<{ maxFeesSats: number }>;
-  listPayments(): Promise<Payment[]>;
+  ping(): Promise<string>;
 }
 
 const LnCoreModule = requireNativeModule<LnCore>('LnCore');
-const emitter = new EventEmitter(LnCoreModule);
-
-export function addPaymentUpdatedListener(
-  listener: (event: PaymentUpdatedEvent) => void,
-): Subscription {
-  return emitter.addListener('PaymentUpdated', listener);
-}
 
 export const LnCore = {
-  init: (opts: LnInitOptions) => LnCoreModule.init(opts),
-  isReady: () => LnCoreModule.isReady(),
-  nodeInfo: () => LnCoreModule.nodeInfo(),
-  createInvoice: (params: { amountSats: number; memo?: string }) =>
-    LnCoreModule.createInvoice(params),
-  payInvoice: (bolt11: string) => LnCoreModule.payInvoice(bolt11),
-  estimateFees: (bolt11: string) => LnCoreModule.estimateFees(bolt11),
-  listPayments: () => LnCoreModule.listPayments(),
-  addPaymentUpdatedListener,
+  ping: () => LnCoreModule.ping(),
 };
 
 export default LnCore;
+

--- a/native/ln-core/ios/LnCoreModule.swift
+++ b/native/ln-core/ios/LnCoreModule.swift
@@ -5,7 +5,7 @@ public class LnCoreModule: Module {
     Name("LnCore")
 
     AsyncFunction("ping") {
-      "pong"
+      "ok"
     }
   }
 }


### PR DESCRIPTION
## Summary
- simplify LnCore JS shim to only expose a ping stub
- implement matching ping("ok") on Android and iOS native modules
- document minimal ping API in package README

## Testing
- `pnpm --filter @mchat/ln-core build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8d116c88832fb506271e27450981