### PR TITLE
chore: add config plugin stubs for native modules

### DIFF
--- a/apps/mobile/plugins/with-matrix-core.ts
+++ b/apps/mobile/plugins/with-matrix-core.ts
@@ -19,6 +19,7 @@ const withMatrixCore: ConfigPlugin = (config) => {
     'ios',
     async (c) => {
       console.log('with-matrix-core: iOS configuration placeholder');
+      // TODO: Inject Matrix Core XCFramework into Xcode project.
       return c;
     },
   ]);
@@ -27,6 +28,7 @@ const withMatrixCore: ConfigPlugin = (config) => {
     'android',
     async (c) => {
       console.log('with-matrix-core: Android configuration placeholder');
+      // TODO: Inject Matrix Core AAR into Gradle project.
       return c;
     },
   ]);

--- a/native/ln-core/with-ln-core.ts
+++ b/native/ln-core/with-ln-core.ts
@@ -2,17 +2,35 @@ import { ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
 
 /**
  * Stub Expo config plugin for future Lightning core integration.
- * Add Breez SDK or LDK native dependencies here in the future.
+ *
+ * When enabled (WITH_LN_CORE=true), this plugin will later link the
+ * Lightning Core native binaries into the project. For now it only logs the
+ * intended actions without modifying the native projects.
  */
 const withLnCore: ConfigPlugin = (config) => {
+  if (process.env.WITH_LN_CORE !== 'true') {
+    console.log(
+      'with-ln-core: skipping native configuration (set WITH_LN_CORE=true to enable)',
+    );
+    return config;
+  }
+
   config = withDangerousMod(config, [
     'ios',
-    async (c: Record<string, unknown>) => c,
+    async (c) => {
+      console.log('with-ln-core: iOS configuration placeholder');
+      // TODO: Inject Lightning Core XCFramework into Xcode project.
+      return c;
+    },
   ]);
 
   config = withDangerousMod(config, [
     'android',
-    async (c: Record<string, unknown>) => c,
+    async (c) => {
+      console.log('with-ln-core: Android configuration placeholder');
+      // TODO: Inject Lightning Core AAR into Gradle project.
+      return c;
+    },
   ]);
 
   return config;


### PR DESCRIPTION
## Summary
- scaffold Matrix core config plugin guarded by WITH_MATRIX_CORE env flag and log placeholders
- stub Lightning core config plugin with WITH_LN_CORE flag and platform placeholders

## Testing
- `npx tsx -e "import withMatrixCore from './plugins/with-matrix-core'; withMatrixCore({name:'test',slug:'test'});"`
- `npx tsx -e "import {compileModsAsync} from '@expo/config-plugins'; import withMatrixCore from './plugins/with-matrix-core'; process.env.WITH_MATRIX_CORE='true'; const run=async()=>{const config=withMatrixCore({name:'test',slug:'test'}); await compileModsAsync(config,{projectRoot:process.cwd()});}; run();"`
- `NODE_PATH=apps/mobile/node_modules npx tsx -e "import withLnCore from './native/ln-core/with-ln-core'; withLnCore({name:'test',slug:'test'});"`
- `NODE_PATH=apps/mobile/node_modules npx tsx -e "import {compileModsAsync} from '@expo/config-plugins'; import withLnCore from './native/ln-core/with-ln-core'; process.env.WITH_LN_CORE='true'; const run=async()=>{const config=withLnCore({name:'test',slug:'test'}); await compileModsAsync(config,{projectRoot:process.cwd()});}; run();"`
- `npx eslint@8.57.0 apps/mobile/plugins/with-matrix-core.ts native/ln-core/with-ln-core.ts` (fails: Could not find @typescript-eslint/eslint-plugin)
- `pnpm --filter @mchat/ln-core build` (fails: Cannot find name 'process' / missing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68ad8d12fb2c832fa8b42373fd5a1f94