### PR TITLE
fix storybook package aliases

### DIFF
--- a/apps/storybook/storybook/stories/MessageBubble.stories.tsx
+++ b/apps/storybook/storybook/stories/MessageBubble.stories.tsx
@@ -1,20 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
-
-let MessageBubble: React.ComponentType<any> | null = null;
-try {
-  // If your package exists, this will render it through react-native-web
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  MessageBubble = require('@mchat/message-ui/MessageBubble').default
-    || require('@mchat/message-ui').MessageBubble;
-} catch {
-  // Fallback demo if package not yet built
-  MessageBubble = null;
-}
-
-const Fallback: React.FC = () => (
-  <div style={{ padding: 24 }}>Package <code>@mchat/message-ui</code> not found. Build it first.</div>
-);
+import { MessageBubble } from '@mchat/message-ui';
 
 const meta: Meta = {
   title: 'Messages/MessageBubble',
@@ -24,16 +10,13 @@ export default meta;
 type Story = StoryObj;
 
 export const Demo: Story = {
-  render: () =>
-    MessageBubble ? (
-      <div style={{ padding: 24, maxWidth: 420 }}>
-        <MessageBubble
-          text="This is a message bubble rendered via react-native-web."
-          isMe
-          timestamp={Date.now()}
-        />
-      </div>
-    ) : (
-      <Fallback />
-    ),
+  render: () => (
+    <div style={{ padding: 24, maxWidth: 420 }}>
+      <MessageBubble
+        text="This is a message bubble rendered via react-native-web."
+        isMe
+        timestamp={Date.now()}
+      />
+    </div>
+  ),
 };

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -2,7 +2,12 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@mchat/ui-tokens": ["../../packages/ui-tokens/src"],
+      "@mchat/lightning-ui": ["../../packages/lightning-ui"],
+      "@mchat/message-ui": ["../../packages/message-ui"]
+    }
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
     alias: {
       'react-native': 'react-native-web',
       '@mchat/ui-tokens': r('../../packages/ui-tokens/src'),
-      '@mchat/lightning-ui': r('../../packages/lightning-ui/src'),
-      '@mchat/message-ui': r('../../packages/message-ui/src'),
+      '@mchat/lightning-ui': r('../../packages/lightning-ui'),
+      '@mchat/message-ui': r('../../packages/message-ui'),
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- fix Storybook Vite aliases for Lightning and Message packages
- map Storybook tsconfig paths to package sources

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm test`
- `pnpm --filter @mchat/storybook start` *(fails: storybook: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4616e8b0832fa671d0f514896fe8