### PR TITLE
fix: add React type definitions for UI packages

### DIFF
--- a/packages/lightning-ui/package.json
+++ b/packages/lightning-ui/package.json
@@ -16,6 +16,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },
+  "devDependencies": {
+    "@types/react": "^19.1.12",
+    "@types/react-native": "^0.73.0"
+  },
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/packages/message-ui/package.json
+++ b/packages/message-ui/package.json
@@ -23,6 +23,10 @@
     "react": ">=18",
     "react-native": ">=0.75"
   },
+  "devDependencies": {
+    "@types/react": "^19.1.12",
+    "@types/react-native": "^0.73.0"
+  },
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         version: 7.28.3
       '@storybook/addon-docs':
         specifier: 9.1.3
-        version: 9.1.3(@types/react@19.0.14)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@24.3.0)(lightningcss@1.27.0)(terser@5.43.1)))
+        version: 9.1.3(@types/react@19.1.12)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@24.3.0)(lightningcss@1.27.0)(terser@5.43.1)))
       '@storybook/addon-links':
         specifier: 9.1.3
         version: 9.1.3(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@24.3.0)(lightningcss@1.27.0)(terser@5.43.1)))
@@ -153,7 +153,7 @@ importers:
         version: 19.1.1
       react-native:
         specifier: '*'
-        version: 0.79.5(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.1.1)
+        version: 0.79.5(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)
 
   packages/a11y-utils:
     dependencies:
@@ -162,7 +162,7 @@ importers:
         version: 19.1.1
       react-native:
         specifier: '>=0.75'
-        version: 0.79.5(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.1.1)
+        version: 0.79.5(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)
 
   packages/chat-types: {}
 
@@ -171,18 +171,19 @@ importers:
       '@mchat/ui-tokens':
         specifier: workspace:*
         version: link:../ui-tokens
-      '@types/react':
-        specifier: ^18.0.0
-        version: 18.3.24
-      '@types/react-native':
-        specifier: ^0.73.0
-        version: 0.73.0(@babel/core@7.28.3)(@types/react@18.3.24)(react@19.1.1)
       react:
         specifier: '>=18'
         version: 19.1.1
       react-native:
         specifier: '>=0.75'
-        version: 0.79.5(@babel/core@7.28.3)(@types/react@18.3.24)(react@19.1.1)
+        version: 0.79.5(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.12
+        version: 19.1.12
+      '@types/react-native':
+        specifier: ^0.73.0
+        version: 0.73.0(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)
 
   packages/lightning-utils: {}
 
@@ -196,7 +197,14 @@ importers:
         version: 19.1.1
       react-native:
         specifier: '>=0.75'
-        version: 0.79.5(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.1.1)
+        version: 0.79.5(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.12
+        version: 19.1.12
+      '@types/react-native':
+        specifier: ^0.73.0
+        version: 0.73.0(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)
 
   packages/push-contract:
     devDependencies:
@@ -2009,6 +2017,9 @@ packages:
 
   '@types/react@19.0.14':
     resolution: {integrity: sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==}
+
+  '@types/react@19.1.12':
+    resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
@@ -7259,10 +7270,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mdx-js/react@3.1.0(@types/react@19.0.14)(react@19.1.1)':
+  '@mdx-js/react@3.1.0(@types/react@19.1.12)(react@19.1.1)':
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 19.0.14
+      '@types/react': 19.1.12
       react: 19.1.1
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -7581,15 +7592,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.24
 
-  '@react-native/virtualized-lists@0.79.5(@types/react@18.3.24)(react-native@0.79.5(@babel/core@7.28.3)(@types/react@18.3.24)(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react: 19.1.1
-      react-native: 0.79.5(@babel/core@7.28.3)(@types/react@18.3.24)(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 18.3.24
-
   '@react-native/virtualized-lists@0.79.5(@types/react@19.0.14)(react-native@0.79.5(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)':
     dependencies:
       invariant: 2.2.4
@@ -7598,6 +7600,15 @@ snapshots:
       react-native: 0.79.5(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.0.14
+
+  '@react-native/virtualized-lists@0.79.5(@types/react@19.1.12)(react-native@0.79.5(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.12
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -7685,9 +7696,9 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@storybook/addon-docs@9.1.3(@types/react@19.0.14)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@24.3.0)(lightningcss@1.27.0)(terser@5.43.1)))':
+  '@storybook/addon-docs@9.1.3(@types/react@19.1.12)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@24.3.0)(lightningcss@1.27.0)(terser@5.43.1)))':
     dependencies:
-      '@mdx-js/react': 3.1.0(@types/react@19.0.14)(react@19.1.1)
+      '@mdx-js/react': 3.1.0(@types/react@19.1.12)(react@19.1.1)
       '@storybook/csf-plugin': 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@24.3.0)(lightningcss@1.27.0)(terser@5.43.1)))
       '@storybook/icons': 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@storybook/react-dom-shim': 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.19(@types/node@24.3.0)(lightningcss@1.27.0)(terser@5.43.1)))
@@ -7856,9 +7867,9 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
-  '@types/react-native@0.73.0(@babel/core@7.28.3)(@types/react@18.3.24)(react@19.1.1)':
+  '@types/react-native@0.73.0(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)':
     dependencies:
-      react-native: 0.79.5(@babel/core@7.28.3)(@types/react@18.3.24)(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@react-native-community/cli'
@@ -7874,6 +7885,10 @@ snapshots:
       csstype: 3.1.3
 
   '@types/react@19.0.14':
+    dependencies:
+      csstype: 3.1.3
+
+  '@types/react@19.1.12':
     dependencies:
       csstype: 3.1.3
 
@@ -11122,54 +11137,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  react-native@0.79.5(@babel/core@7.28.3)(@types/react@18.3.24)(react@19.1.1):
-    dependencies:
-      '@jest/create-cache-key-function': 29.7.0
-      '@react-native/assets-registry': 0.79.5
-      '@react-native/codegen': 0.79.5(@babel/core@7.28.3)
-      '@react-native/community-cli-plugin': 0.79.5
-      '@react-native/gradle-plugin': 0.79.5
-      '@react-native/js-polyfills': 0.79.5
-      '@react-native/normalize-colors': 0.79.5
-      '@react-native/virtualized-lists': 0.79.5(@types/react@18.3.24)(react-native@0.79.5(@babel/core@7.28.3)(@types/react@18.3.24)(react@19.1.1))(react@19.1.1)
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      babel-jest: 29.7.0(@babel/core@7.28.3)
-      babel-plugin-syntax-hermes-parser: 0.25.1
-      base64-js: 1.5.1
-      chalk: 4.1.2
-      commander: 12.1.0
-      event-target-shim: 5.0.1
-      flow-enums-runtime: 0.0.6
-      glob: 7.2.3
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      memoize-one: 5.2.1
-      metro-runtime: 0.82.5
-      metro-source-map: 0.82.5
-      nullthrows: 1.1.1
-      pretty-format: 29.7.0
-      promise: 8.3.0
-      react: 19.1.1
-      react-devtools-core: 6.1.5
-      react-refresh: 0.14.2
-      regenerator-runtime: 0.13.11
-      scheduler: 0.25.0
-      semver: 7.7.2
-      stacktrace-parser: 0.1.11
-      whatwg-fetch: 3.6.20
-      ws: 6.2.3
-      yargs: 17.7.2
-    optionalDependencies:
-      '@types/react': 18.3.24
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@react-native-community/cli'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   react-native@0.79.5(@babel/core@7.28.3)(@types/react@19.0.14)(react@19.1.1):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
@@ -11211,6 +11178,54 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       '@types/react': 19.0.14
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-community/cli'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  react-native@0.79.5(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native/assets-registry': 0.79.5
+      '@react-native/codegen': 0.79.5(@babel/core@7.28.3)
+      '@react-native/community-cli-plugin': 0.79.5
+      '@react-native/gradle-plugin': 0.79.5
+      '@react-native/js-polyfills': 0.79.5
+      '@react-native/normalize-colors': 0.79.5
+      '@react-native/virtualized-lists': 0.79.5(@types/react@19.1.12)(react-native@0.79.5(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      babel-jest: 29.7.0(@babel/core@7.28.3)
+      babel-plugin-syntax-hermes-parser: 0.25.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      commander: 12.1.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      glob: 7.2.3
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.82.5
+      metro-source-map: 0.82.5
+      nullthrows: 1.1.1
+      pretty-format: 29.7.0
+      promise: 8.3.0
+      react: 19.1.1
+      react-devtools-core: 6.1.5
+      react-refresh: 0.14.2
+      regenerator-runtime: 0.13.11
+      scheduler: 0.25.0
+      semver: 7.7.2
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+      ws: 6.2.3
+      yargs: 17.7.2
+    optionalDependencies:
+      '@types/react': 19.1.12
     transitivePeerDependencies:
       - '@babel/core'
       - '@react-native-community/cli'


### PR DESCRIPTION
## Summary
- add React and React Native type packages to message-ui and lightning-ui
- ensure package builds complete

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68af4e15bf88832f876bb4424f07a9dc