### PR TITLE
test: replace any in ThemeProvider tests

### DIFF
--- a/packages/ui-tokens/ThemeProvider.test.ts
+++ b/packages/ui-tokens/ThemeProvider.test.ts
@@ -1,12 +1,15 @@
-import { ThemeProvider } from './src/ThemeProvider';
+import type { ReactElement } from 'react';
+import { ThemeProvider, type Theme } from './src/ThemeProvider';
 import { colors } from './src/colors';
 import { spacing } from './src/spacing';
 import { typography } from './src/typography';
 
 describe('ThemeProvider', () => {
   test('provides light theme by default', () => {
-    const element = ThemeProvider({ children: null });
-    const value = (element as any).props.value;
+    const element: ReactElement<{ value: Theme }> = ThemeProvider({
+      children: null,
+    });
+    const value = element.props.value;
     expect(value).toEqual({
       colors: colors.light,
       spacing,
@@ -15,8 +18,11 @@ describe('ThemeProvider', () => {
   });
 
   test('provides dark theme when mode is dark', () => {
-    const element = ThemeProvider({ children: null, mode: 'dark' });
-    const value = (element as any).props.value;
+    const element: ReactElement<{ value: Theme }> = ThemeProvider({
+      children: null,
+      mode: 'dark',
+    });
+    const value = element.props.value;
     expect(value).toEqual({
       colors: colors.dark,
       spacing,


### PR DESCRIPTION
## Summary
- replace `any` casts in ThemeProvider tests with typed `ReactElement`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68af529e4568832f8c642bf5ba4a577e