### PR TITLE
chore: ignore extraneous react-native types

### DIFF
--- a/packages/chat-types/tsconfig.json
+++ b/packages/chat-types/tsconfig.json
@@ -7,7 +7,8 @@
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": []
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- prevent TypeScript from pulling in unused `@types` packages

## Testing
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68af59c38c50832faed79c093aeb118e