### PR TITLE
chore: rename mchat references to hum

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 mchat contributors
+Copyright (c) 2024 hum contributors
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mchat
+# hum
 
-Placeholder for mchat, an open-source, privacy-first, federated messenger
+Placeholder for hum, an open-source, privacy-first, federated messenger
 built with React Native, Expo, and a Rust core.
 
 This repository currently contains the initial project skeleton.
@@ -12,42 +12,42 @@ This repository currently contains the initial project skeleton.
 
 ## Packages
 
-| Package | Description |
-| --- | --- |
-| [@mchat/a11y-utils](packages/a11y-utils/README.md) | Accessibility utilities |
-| [@mchat/chat-types](packages/chat-types/README.md) | Shared chat domain TypeScript definitions |
-| [@mchat/lightning-ui](packages/lightning-ui/README.md) | Lightning Network UI components |
-| [@mchat/lightning-utils](packages/lightning-utils/README.md) | Lightning Network helper utilities |
-| [@mchat/message-ui](packages/message-ui/README.md) | Chat message UI components |
-| [@mchat/push-contract](packages/push-contract/README.md) | Types for push notification contract |
-| [@mchat/ui-tokens](packages/ui-tokens/README.md) | Design tokens for consistent theming |
+| Package                                                    | Description                               |
+| ---------------------------------------------------------- | ----------------------------------------- |
+| [@hum/a11y-utils](packages/a11y-utils/README.md)           | Accessibility utilities                   |
+| [@hum/chat-types](packages/chat-types/README.md)           | Shared chat domain TypeScript definitions |
+| [@hum/lightning-ui](packages/lightning-ui/README.md)       | Lightning Network UI components           |
+| [@hum/lightning-utils](packages/lightning-utils/README.md) | Lightning Network helper utilities        |
+| [@hum/message-ui](packages/message-ui/README.md)           | Chat message UI components                |
+| [@hum/push-contract](packages/push-contract/README.md)     | Types for push notification contract      |
+| [@hum/ui-tokens](packages/ui-tokens/README.md)             | Design tokens for consistent theming      |
 
 ## Project Map
 
-| Path | Purpose |
-| ---- | ------- |
-| apps/mobile | React Native mobile application |
-| packages/a11y-utils | Accessibility utilities |
-| packages/chat-types | Shared chat domain TypeScript definitions |
-| packages/lightning-ui | Lightning Network UI components |
-| packages/lightning-utils | Lightning Network helper utilities |
-| packages/message-ui | Chat message UI components |
-| packages/push-contract | Types for push notification contract |
-| packages/ui-tokens | Design tokens for consistent theming |
-| native/ln-core | Mock Lightning node core for Expo modules |
-| native/rust | Rust workspace for core functionality |
-| docs/adr | Architecture decision records |
-| docs/a11y-checklist.md | Accessibility checklist |
-| docs/dev-setup.md | Development environment setup |
-| docs/push-contract.md | Push notification contract details |
-| docs/ui-previews | UI component previews |
+| Path                     | Purpose                                   |
+| ------------------------ | ----------------------------------------- |
+| apps/mobile              | React Native mobile application           |
+| packages/a11y-utils      | Accessibility utilities                   |
+| packages/chat-types      | Shared chat domain TypeScript definitions |
+| packages/lightning-ui    | Lightning Network UI components           |
+| packages/lightning-utils | Lightning Network helper utilities        |
+| packages/message-ui      | Chat message UI components                |
+| packages/push-contract   | Types for push notification contract      |
+| packages/ui-tokens       | Design tokens for consistent theming      |
+| native/ln-core           | Mock Lightning node core for Expo modules |
+| native/rust              | Rust workspace for core functionality     |
+| docs/adr                 | Architecture decision records             |
+| docs/a11y-checklist.md   | Accessibility checklist                   |
+| docs/dev-setup.md        | Development environment setup             |
+| docs/push-contract.md    | Push notification contract details        |
+| docs/ui-previews         | UI component previews                     |
 
 ## Storybook and Mobile
 
 ### Storybook
 
 - Storybook packages are pinned to **8.6.14** to avoid internal import errors.
-- Vite aliases map `react-native` to `react-native-web` and `@mchat/*` packages to their `src` directories so Storybook can bundle TypeScript directly.
+- Vite aliases map `react-native` to `react-native-web` and `@hum/*` packages to their `src` directories so Storybook can bundle TypeScript directly.
 - Add new stories using [Component Story Format](https://storybook.js.org/docs/react/writing-stories/introduction) under `apps/storybook/storybook/stories`. Rename any legacy `storiesOf` files to `*.stories.tsx.skip`.
 - `react-native-web` logs peer dependency warnings for React 18; these are safe to ignore when using React 19.
 - TypeScript prop extraction is disabled (`reactDocgen: false`) to avoid `jsdoc-type-pratt-parser` runtime errors with React 19.
@@ -61,4 +61,3 @@ Start the Expo app with `pnpm -F mobile start -- --clear`.
 ## Contributing Flow
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. In short: fork the repo, create a branch, commit your changes, and open a pull request for review.
-

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -5,8 +5,8 @@ import { ExpoConfig, ConfigContext } from '@expo/config';
 // 2. Uncomment the line in the plugins array below.
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
-  name: config.name ?? 'mchat',
-  slug: config.slug ?? 'mchat',
+  name: config.name ?? 'hum',
+  slug: config.slug ?? 'hum',
   version: config.version ?? '1.0.0',
   orientation: config.orientation ?? 'portrait',
   userInterfaceStyle: config.userInterfaceStyle ?? 'light',

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,11 +25,11 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mchat/mchat",
+    "url": "https://github.com/hum/hum",
     "directory": "apps/mobile"
   },
   "bugs": {
-    "url": "https://github.com/mchat/mchat/issues"
+    "url": "https://github.com/hum/hum/issues"
   },
-  "homepage": "https://github.com/mchat/mchat#readme"
+  "homepage": "https://github.com/hum/hum#readme"
 }

--- a/apps/mobile/src/screens/ChatsListMock.tsx
+++ b/apps/mobile/src/screens/ChatsListMock.tsx
@@ -125,7 +125,7 @@ export default function ChatsListMock() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.headerTitle}>mChat</Text>
+        <Text style={styles.headerTitle}>hum</Text>
         <Text style={styles.headerIcon}>🔍</Text>
       </View>
       <View style={styles.tabs}>

--- a/apps/mobile/src/screens/ShellMock.tsx
+++ b/apps/mobile/src/screens/ShellMock.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useRef } from 'react';
-import { View, Text, StyleSheet, useColorScheme, Animated, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  useColorScheme,
+  Animated,
+  ScrollView,
+} from 'react-native';
 import TabBarMock from '../components/shell/TabBarMock';
 
 const ShellMock = () => {
@@ -10,29 +17,52 @@ const ShellMock = () => {
   useEffect(() => {
     Animated.loop(
       Animated.sequence([
-        Animated.timing(shimmer, { toValue: 1, duration: 1000, useNativeDriver: true }),
-        Animated.timing(shimmer, { toValue: 0.3, duration: 1000, useNativeDriver: true }),
+        Animated.timing(shimmer, {
+          toValue: 1,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+        Animated.timing(shimmer, {
+          toValue: 0.3,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
       ]),
     ).start();
   }, [shimmer]);
 
   return (
-    <View style={[styles.screen, { backgroundColor: colors.background }]}> 
-      <View style={[styles.topBar, { backgroundColor: colors.card, borderBottomColor: colors.border }]}> 
-        <Text style={[styles.title, { color: colors.text }]}>mChat</Text>
+    <View style={[styles.screen, { backgroundColor: colors.background }]}>
+      <View
+        style={[
+          styles.topBar,
+          { backgroundColor: colors.card, borderBottomColor: colors.border },
+        ]}
+      >
+        <Text style={[styles.title, { color: colors.text }]}>hum</Text>
         <View style={styles.topIcons}>
           <Text style={[styles.topIcon, { color: colors.subtext }]}>🔍</Text>
           <Text style={[styles.topIcon, { color: colors.subtext }]}>📷</Text>
         </View>
       </View>
       <ScrollView contentContainerStyle={styles.content}>
-        <View style={[styles.card, { backgroundColor: colors.card, shadowColor: colors.shadow }]}> 
-          <Text style={[styles.cardText, { color: colors.text }]}>This is the shell</Text>
+        <View
+          style={[
+            styles.card,
+            { backgroundColor: colors.card, shadowColor: colors.shadow },
+          ]}
+        >
+          <Text style={[styles.cardText, { color: colors.text }]}>
+            This is the shell
+          </Text>
         </View>
         {[0, 1, 2, 3].map((i) => (
           <Animated.View
             key={i}
-            style={[styles.placeholder, { backgroundColor: colors.placeholder, opacity: shimmer }]}
+            style={[
+              styles.placeholder,
+              { backgroundColor: colors.placeholder, opacity: shimmer },
+            ]}
           />
         ))}
       </ScrollView>

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/storybook",
+  "name": "@hum/storybook",
   "private": true,
   "main": "index.js",
   "scripts": {
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "@babel/runtime": "7.28.3",
-    "@mchat/lightning-ui": "workspace:*",
-    "@mchat/message-ui": "workspace:*",
-    "@mchat/ui-tokens": "workspace:*",
+    "@hum/lightning-ui": "workspace:*",
+    "@hum/message-ui": "workspace:*",
+    "@hum/ui-tokens": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-native-web": "~0.19.13"

--- a/apps/storybook/storybook/stories/Lightning.stories.tsx
+++ b/apps/storybook/storybook/stories/Lightning.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
-import { ThemeProvider } from '@mchat/ui-tokens';
-import { LightningBolt } from '@mchat/lightning-ui';
+import { ThemeProvider } from '@hum/ui-tokens';
+import { LightningBolt } from '@hum/lightning-ui';
 
 const meta: Meta<typeof LightningBolt> = {
   title: 'Lightning/LightningBolt',
@@ -19,4 +19,3 @@ export const Basic: Story = {
   ),
   args: { label: 'Bolt' },
 };
-

--- a/apps/storybook/storybook/stories/LnCoreDemo.stories.tsx.skip
+++ b/apps/storybook/storybook/stories/LnCoreDemo.stories.tsx.skip
@@ -5,7 +5,7 @@ import LnCore, {
   addPaymentUpdatedListener,
   LnInvoice,
   Payment,
-} from '@mchat/ln-core';
+} from '@hum/ln-core';
 
 const LnCoreDemo = () => {
   const [info, setInfo] = useState<{

--- a/apps/storybook/storybook/stories/MessageBubble.stories.tsx
+++ b/apps/storybook/storybook/stories/MessageBubble.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
-import { MessageBubble } from '@mchat/message-ui';
+import { MessageBubble } from '@hum/message-ui';
 
 const meta: Meta = {
   title: 'Messages/MessageBubble',
@@ -9,9 +9,11 @@ export default meta;
 
 type Story = StoryObj;
 
+const containerStyle = { padding: 24, maxWidth: 420 };
+
 export const Demo: Story = {
   render: () => (
-    <div style={{ padding: 24, maxWidth: 420 }}>
+    <div style={containerStyle}>
       <MessageBubble
         text="This is a message bubble rendered via react-native-web."
         isMe

--- a/apps/storybook/storybook/stories/MessageDemo.stories.tsx.skip
+++ b/apps/storybook/storybook/stories/MessageDemo.stories.tsx.skip
@@ -1,8 +1,8 @@
 import React from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
 import { storiesOf } from '@storybook/react-native';
-import { ThemeProvider, spacing, useTheme } from '@mchat/ui-tokens';
-import { MessageListItem } from '@mchat/message-ui';
+import { ThemeProvider, spacing, useTheme } from '@hum/ui-tokens';
+import { MessageListItem } from '@hum/message-ui';
 
 const MessageDemo = () => {
   const { colors } = useTheme();

--- a/apps/storybook/storybook/stories/Tokens.stories.tsx
+++ b/apps/storybook/storybook/stories/Tokens.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 import { View, Text } from 'react-native';
-import { ThemeProvider, useTheme } from '@mchat/ui-tokens';
+import { ThemeProvider, useTheme } from '@hum/ui-tokens';
 
 const Demo: React.FC = () => {
   const { colors, spacing, typography } = useTheme();
@@ -29,4 +29,3 @@ export const Basic: Story = {
     </ThemeProvider>
   ),
 };
-

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -4,9 +4,9 @@
     "jsx": "react-jsx",
     "noEmit": true,
     "paths": {
-      "@mchat/ui-tokens": ["../../packages/ui-tokens/src"],
-      "@mchat/lightning-ui": ["../../packages/lightning-ui"],
-      "@mchat/message-ui": ["../../packages/message-ui"]
+      "@hum/ui-tokens": ["../../packages/ui-tokens/src"],
+      "@hum/lightning-ui": ["../../packages/lightning-ui"],
+      "@hum/message-ui": ["../../packages/message-ui"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"]

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -16,9 +16,9 @@ export default defineConfig({
   resolve: {
     alias: {
       'react-native': 'react-native-web',
-      '@mchat/ui-tokens': r('../../packages/ui-tokens/src'),
-      '@mchat/lightning-ui': r('../../packages/lightning-ui'),
-      '@mchat/message-ui': r('../../packages/message-ui'),
+      '@hum/ui-tokens': r('../../packages/ui-tokens/src'),
+      '@hum/lightning-ui': r('../../packages/lightning-ui'),
+      '@hum/message-ui': r('../../packages/message-ui'),
     },
   },
   optimizeDeps: {

--- a/docs/package-scoping.md
+++ b/docs/package-scoping.md
@@ -1,20 +1,20 @@
 # Package Scoping Plan
 
-We plan to publish all packages under the `@mchat` scope to prevent naming conflicts and clarify ownership.
+We plan to publish all packages under the `@hum` scope to prevent naming conflicts and clarify ownership.
 
 ## Proposed Package Names
 
-- `@mchat/ui-tokens` (current: `ui-tokens`)
-- `@mchat/message-ui` (current: `message-ui`)
-- `@mchat/chat-types` (current: `chat-types`)
-- `@mchat/lightning-utils` (current: `lightning-utils`)
-- `@mchat/a11y-utils` (current: `a11y-utils`)
-- `@mchat/push-contract` (current: `push-contract`)
+- `@hum/ui-tokens` (current: `ui-tokens`)
+- `@hum/message-ui` (current: `message-ui`)
+- `@hum/chat-types` (current: `chat-types`)
+- `@hum/lightning-utils` (current: `lightning-utils`)
+- `@hum/a11y-utils` (current: `a11y-utils`)
+- `@hum/push-contract` (current: `push-contract`)
 
 ## Migration Plan
 
 1. **Keep existing package names.** Continue publishing and consuming the unscoped packages so no projects break.
-2. **Add scoped aliases.** Publish new packages under the `@mchat/*` scope that mirror the existing packages while keeping the original names available.
+2. **Add scoped aliases.** Publish new packages under the `@hum/*` scope that mirror the existing packages while keeping the original names available.
 3. **Update imports in one PR.** After the scoped packages are released, change all internal imports and documentation to use the new scoped names in a single pull request.
 4. **Deprecate old names.** Once dependents have migrated, mark the unscoped packages as deprecated and eventually stop publishing them.
 

--- a/docs/push-contract.md
+++ b/docs/push-contract.md
@@ -1,6 +1,6 @@
 # Push Notifications Contract
 
-This document defines the contract for push notifications used by the mchat application. It covers token registration, the payload delivered by the push service, and how the app should wake and sync on receipt.
+This document defines the contract for push notifications used by the hum application. It covers token registration, the payload delivered by the push service, and how the app should wake and sync on receipt.
 
 ## Token Registration
 

--- a/native/ln-core/README.md
+++ b/native/ln-core/README.md
@@ -1,8 +1,8 @@
 # Ln Core Native Module
 
-This package hosts the future Lightning node core for the mChat app.
+This package hosts the future Lightning node core for the hum app.
 The native module is registered as **`LnCore`**, matching the Android
-package path `com.mchat.lncore`.
+package path `com.hum.lncore`.
 
 ## Current status
 
@@ -24,4 +24,3 @@ This package will be linked into the app via an Expo Config Plugin
 (`with-ln-core`) which will configure the native build to include the
 module on both Android and iOS. The config plugin will be added in a
 future update.
-

--- a/native/ln-core/android/src/main/AndroidManifest.xml
+++ b/native/ln-core/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.mchat.lncore">
+  package="com.hum.lncore">
 </manifest>

--- a/native/ln-core/android/src/main/java/com/hum/lncore/LnCoreModule.kt
+++ b/native/ln-core/android/src/main/java/com/hum/lncore/LnCoreModule.kt
@@ -1,4 +1,4 @@
-package com.mchat.lncore
+package com.hum.lncore
 
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition

--- a/native/ln-core/ios/LnCore.podspec
+++ b/native/ln-core/ios/LnCore.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.summary      = 'Lightning core native module stub.'
   s.homepage     = 'https://example.com'
   s.license      = { :type => 'AGPL-3.0-only' }
-  s.authors      = { 'mChat' => 'support@example.com' }
+  s.authors      = { 'hum' => 'support@example.com' }
   s.platform     = :ios, '13.0'
   s.source       = { :git => 'https://example.com', :tag => s.version }
   s.source_files = '*.{h,m,mm,swift}'

--- a/native/ln-core/package.json
+++ b/native/ln-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/ln-core",
+  "name": "@hum/ln-core",
   "version": "0.1.0",
   "private": true,
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mchat",
+  "name": "hum",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/packages/a11y-utils/README.md
+++ b/packages/a11y-utils/README.md
@@ -1,19 +1,19 @@
-# @mchat/a11y-utils
+# @hum/a11y-utils
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](../../LICENSE)
 
-Accessibility helpers for building inclusive mchat clients.
+Accessibility helpers for building inclusive hum clients.
 
 ## Installation
 
 ```sh
-npm install @mchat/a11y-utils
+npm install @hum/a11y-utils
 ```
 
 ## Usage
 
 ```ts
-import { accessibleLabel, hitSlop } from '@mchat/a11y-utils';
+import { accessibleLabel, hitSlop } from '@hum/a11y-utils';
 
 accessibleLabel('Send', 'button');
 hitSlop(8);

--- a/packages/a11y-utils/package.json
+++ b/packages/a11y-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/a11y-utils",
+  "name": "@hum/a11y-utils",
   "version": "0.1.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -23,11 +23,11 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mchat/mchat",
+    "url": "https://github.com/hum/hum",
     "directory": "packages/a11y-utils"
   },
   "bugs": {
-    "url": "https://github.com/mchat/mchat/issues"
+    "url": "https://github.com/hum/hum/issues"
   },
-  "homepage": "https://github.com/mchat/mchat#readme"
+  "homepage": "https://github.com/hum/hum#readme"
 }

--- a/packages/chat-types/README.md
+++ b/packages/chat-types/README.md
@@ -1,19 +1,19 @@
-# @mchat/chat-types
+# @hum/chat-types
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](../../LICENSE)
 
-Shared TypeScript definitions and mocks for mchat domain models.
+Shared TypeScript definitions and mocks for hum domain models.
 
 ## Installation
 
 ```sh
-npm install @mchat/chat-types
+npm install @hum/chat-types
 ```
 
 ## Usage
 
 ```ts
-import { mockChat } from '@mchat/chat-types';
+import { mockChat } from '@hum/chat-types';
 
 const chat = mockChat();
 console.log(chat.messages[0].text);

--- a/packages/chat-types/package.json
+++ b/packages/chat-types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/chat-types",
+  "name": "@hum/chat-types",
   "version": "0.1.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -13,11 +13,11 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mchat/mchat",
+    "url": "https://github.com/hum/hum",
     "directory": "packages/chat-types"
   },
   "bugs": {
-    "url": "https://github.com/mchat/mchat/issues"
+    "url": "https://github.com/hum/hum/issues"
   },
-  "homepage": "https://github.com/mchat/mchat#readme"
+  "homepage": "https://github.com/hum/hum#readme"
 }

--- a/packages/lightning-ui/LightningBolt.tsx
+++ b/packages/lightning-ui/LightningBolt.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, StyleSheet } from 'react-native';
-import { spacing, typography, useTheme } from '@mchat/ui-tokens';
+import { spacing, typography, useTheme } from '@hum/ui-tokens';
 
 export type LightningBoltProps = {
   label?: string;

--- a/packages/lightning-ui/README.md
+++ b/packages/lightning-ui/README.md
@@ -1,4 +1,4 @@
-# @mchat/lightning-ui
+# @hum/lightning-ui
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](../../LICENSE)
 
@@ -7,13 +7,13 @@ React Native components for Lightning Network interactions.
 ## Installation
 
 ```sh
-npm install @mchat/lightning-ui
+npm install @hum/lightning-ui
 ```
 
 ## Usage
 
 ```tsx
-import { LightningBolt } from '@mchat/lightning-ui';
+import { LightningBolt } from '@hum/lightning-ui';
 
 <LightningBolt label="Zap" />;
 ```

--- a/packages/lightning-ui/package.json
+++ b/packages/lightning-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/lightning-ui",
+  "name": "@hum/lightning-ui",
   "version": "0.1.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -23,15 +23,15 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mchat/mchat",
+    "url": "https://github.com/hum/hum",
     "directory": "packages/lightning-ui"
   },
   "bugs": {
-    "url": "https://github.com/mchat/mchat/issues"
+    "url": "https://github.com/hum/hum/issues"
   },
-  "homepage": "https://github.com/mchat/mchat#readme",
+  "homepage": "https://github.com/hum/hum#readme",
   "dependencies": {
-    "@mchat/ui-tokens": "workspace:*"
+    "@hum/ui-tokens": "workspace:*"
   },
   "peerDependencies": {
     "@types/react": "^18.0.0",

--- a/packages/lightning-utils/README.md
+++ b/packages/lightning-utils/README.md
@@ -1,4 +1,4 @@
-# @mchat/lightning-utils
+# @hum/lightning-utils
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](../../LICENSE)
 
@@ -7,13 +7,13 @@ Utilities for detecting and normalising Lightning Network payment strings.
 ## Installation
 
 ```sh
-npm install @mchat/lightning-utils
+npm install @hum/lightning-utils
 ```
 
 ## Usage
 
 ```ts
-import { detectPaymentStrings } from '@mchat/lightning-utils';
+import { detectPaymentStrings } from '@hum/lightning-utils';
 
 const matches = detectPaymentStrings('pay to lnbc1...');
 ```

--- a/packages/lightning-utils/package.json
+++ b/packages/lightning-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/lightning-utils",
+  "name": "@hum/lightning-utils",
   "version": "0.1.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -19,11 +19,11 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mchat/mchat",
+    "url": "https://github.com/hum/hum",
     "directory": "packages/lightning-utils"
   },
   "bugs": {
-    "url": "https://github.com/mchat/mchat/issues"
+    "url": "https://github.com/hum/hum/issues"
   },
-  "homepage": "https://github.com/mchat/mchat#readme"
+  "homepage": "https://github.com/hum/hum#readme"
 }

--- a/packages/message-ui/MessageBubble.test.tsx
+++ b/packages/message-ui/MessageBubble.test.tsx
@@ -9,7 +9,7 @@ jest.mock('react-native', () => {
 });
 
 jest.mock(
-  '@mchat/ui-tokens',
+  '@hum/ui-tokens',
   () => ({
     spacing: { xs: 2, sm: 4, md: 8 },
     typography: { fontSize: { xs: 10, md: 14 } },

--- a/packages/message-ui/MessageBubble.tsx
+++ b/packages/message-ui/MessageBubble.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { spacing, typography, useTheme } from '@mchat/ui-tokens';
+import { spacing, typography, useTheme } from '@hum/ui-tokens';
 
 export type MessageBubbleProps = {
   sender: 'me' | 'them';

--- a/packages/message-ui/MessageListItem.test.tsx
+++ b/packages/message-ui/MessageListItem.test.tsx
@@ -10,7 +10,7 @@ jest.mock('react-native', () => {
 });
 
 jest.mock(
-  '@mchat/ui-tokens',
+  '@hum/ui-tokens',
   () => ({
     spacing: { xs: 2, sm: 4, md: 8 },
     typography: { fontSize: { xs: 10, md: 14 } },

--- a/packages/message-ui/MessageListItem.tsx
+++ b/packages/message-ui/MessageListItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { spacing } from '@mchat/ui-tokens';
+import { spacing } from '@hum/ui-tokens';
 import MessageBubble, { MessageBubbleProps } from './MessageBubble';
 
 export type MessageListItemProps = MessageBubbleProps;

--- a/packages/message-ui/README.md
+++ b/packages/message-ui/README.md
@@ -1,4 +1,4 @@
-# @mchat/message-ui
+# @hum/message-ui
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](../../LICENSE)
 
@@ -7,13 +7,13 @@ Reusable React Native message components.
 ## Installation
 
 ```sh
-npm install @mchat/message-ui
+npm install @hum/message-ui
 ```
 
 ## Usage
 
 ```tsx
-import { MessageBubble } from '@mchat/message-ui';
+import { MessageBubble } from '@hum/message-ui';
 
 <MessageBubble sender="me" text="Hi" timestamp="10:00" />;
 ```

--- a/packages/message-ui/package.json
+++ b/packages/message-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/message-ui",
+  "name": "@hum/message-ui",
   "version": "0.1.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -17,7 +17,7 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@mchat/ui-tokens": "workspace:*"
+    "@hum/ui-tokens": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=18",
@@ -30,11 +30,11 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mchat/mchat",
+    "url": "https://github.com/hum/hum",
     "directory": "packages/message-ui"
   },
   "bugs": {
-    "url": "https://github.com/mchat/mchat/issues"
+    "url": "https://github.com/hum/hum/issues"
   },
-  "homepage": "https://github.com/mchat/mchat#readme"
+  "homepage": "https://github.com/hum/hum#readme"
 }

--- a/packages/push-contract/README.md
+++ b/packages/push-contract/README.md
@@ -1,4 +1,4 @@
-# @mchat/push-contract
+# @hum/push-contract
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](../../LICENSE)
 
@@ -7,13 +7,13 @@ Platform-agnostic TypeScript contracts for push notification registration and pa
 ## Installation
 
 ```sh
-npm install @mchat/push-contract
+npm install @hum/push-contract
 ```
 
 ## Usage
 
 ```ts
-import { PushToken } from '@mchat/push-contract';
+import { PushToken } from '@hum/push-contract';
 
 const token: PushToken = { platform: 'fcm', value: 'abc' };
 ```

--- a/packages/push-contract/package.json
+++ b/packages/push-contract/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/push-contract",
+  "name": "@hum/push-contract",
   "version": "0.1.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -22,11 +22,11 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mchat/mchat",
+    "url": "https://github.com/hum/hum",
     "directory": "packages/push-contract"
   },
   "bugs": {
-    "url": "https://github.com/mchat/mchat/issues"
+    "url": "https://github.com/hum/hum/issues"
   },
-  "homepage": "https://github.com/mchat/mchat#readme"
+  "homepage": "https://github.com/hum/hum#readme"
 }

--- a/packages/ui-tokens/README.md
+++ b/packages/ui-tokens/README.md
@@ -1,12 +1,13 @@
-# @mchat/ui-tokens
+# @hum/ui-tokens
+
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](../../LICENSE)
 
-Design tokens shared across mchat clients. Provides color, spacing and typography scales along with a minimal `ThemeProvider`.
+Design tokens shared across hum clients. Provides color, spacing and typography scales along with a minimal `ThemeProvider`.
 
 ## Installation
 
 ```sh
-npm install @mchat/ui-tokens
+npm install @hum/ui-tokens
 ```
 
 ## Usage
@@ -14,7 +15,7 @@ npm install @mchat/ui-tokens
 Wrap your application with the `ThemeProvider` and access tokens via `useTheme`:
 
 ```tsx
-import { ThemeProvider, useTheme } from '@mchat/ui-tokens';
+import { ThemeProvider, useTheme } from '@hum/ui-tokens';
 
 const Box = () => {
   const { colors, spacing, typography } = useTheme();
@@ -52,7 +53,7 @@ The `mode` prop toggles between the `light` and `dark` color palettes. Each pale
 Import tokens individually if you need static values without React context:
 
 ```ts
-import { lightColors, spacing, typography } from '@mchat/ui-tokens';
+import { lightColors, spacing, typography } from '@hum/ui-tokens';
 ```
 
 No circular dependencies exist within this package, keeping the tokens portable and framework agnostic.

--- a/packages/ui-tokens/package.json
+++ b/packages/ui-tokens/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mchat/ui-tokens",
+  "name": "@hum/ui-tokens",
   "version": "0.1.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -28,11 +28,11 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mchat/mchat",
+    "url": "https://github.com/hum/hum",
     "directory": "packages/ui-tokens"
   },
   "bugs": {
-    "url": "https://github.com/mchat/mchat/issues"
+    "url": "https://github.com/hum/hum/issues"
   },
-  "homepage": "https://github.com/mchat/mchat#readme"
+  "homepage": "https://github.com/hum/hum#readme"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,13 +99,13 @@ importers:
       '@babel/runtime':
         specifier: 7.28.3
         version: 7.28.3
-      '@mchat/lightning-ui':
+      '@hum/lightning-ui':
         specifier: workspace:*
         version: link:../../packages/lightning-ui
-      '@mchat/message-ui':
+      '@hum/message-ui':
         specifier: workspace:*
         version: link:../../packages/message-ui
-      '@mchat/ui-tokens':
+      '@hum/ui-tokens':
         specifier: workspace:*
         version: link:../../packages/ui-tokens
       react:
@@ -174,7 +174,7 @@ importers:
 
   packages/lightning-ui:
     dependencies:
-      '@mchat/ui-tokens':
+      '@hum/ui-tokens':
         specifier: workspace:*
         version: link:../ui-tokens
       react:
@@ -195,7 +195,7 @@ importers:
 
   packages/message-ui:
     dependencies:
-      '@mchat/ui-tokens':
+      '@hum/ui-tokens':
         specifier: workspace:*
         version: link:../ui-tokens
       react:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,7 @@
     "paths": {
       "@apps/*": ["apps/*/src"],
       "@packages/*": ["packages/*/src"],
-      "@mchat/*": ["packages/*/src"],
+      "@hum/*": ["packages/*/src"],
       "@native/*": ["native/*/src"]
     }
   },


### PR DESCRIPTION
## Summary
- rename mchat project and package scope to hum
- update native module identifiers and app strings

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68af6a543a28832fb667c1f63a554b6f