### PR TITLE
feat: add react native accordion component

### DIFF
--- a/apps/storybook/stories/accordion.stories.tsx
+++ b/apps/storybook/stories/accordion.stories.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Text } from 'react-native';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+  AccordionProps,
+} from '../../packages/hum-ui-components/accordion';
+
+type DemoProps = Omit<AccordionProps, 'children' | 'onValueChange' | 'style'>;
+
+const AccordionDemo: React.FC<DemoProps> = (props) => {
+  const [value, setValue] = useState(
+    props.value ?? (props.type === 'multiple' ? [] : ''),
+  );
+  return (
+    <Accordion {...props} value={value} onValueChange={setValue}>
+      <AccordionItem value="item1">
+        <AccordionTrigger>
+          <Text>First Item</Text>
+        </AccordionTrigger>
+        <AccordionContent>
+          <Text>Content for item one.</Text>
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item2">
+        <AccordionTrigger>
+          <Text>Second Item</Text>
+        </AccordionTrigger>
+        <AccordionContent>
+          <Text>More content here.</Text>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+const meta: Meta<typeof AccordionDemo> = {
+  title: 'Components/Accordion',
+  component: AccordionDemo,
+  argTypes: {
+    type: { control: { type: 'select', options: ['single', 'multiple'] } },
+    value: { control: 'object' },
+  },
+  args: { type: 'single' },
+};
+export default meta;
+
+type Story = StoryObj<typeof AccordionDemo>;
+
+export const Basic: Story = {};
+
+export const Multiple: Story = {
+  args: { type: 'multiple' },
+};
+
+export const PreOpen: Story = {
+  args: { value: 'item2' },
+};

--- a/packages/hum-ui-components/__snapshots__/accordion.test.tsx.snap
+++ b/packages/hum-ui-components/__snapshots__/accordion.test.tsx.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Accordion renders without crashing 1`] = `
+{
+  "props": {
+    "children": [
+      {
+        "props": {
+          "children": [
+            {
+              "props": {
+                "accessibilityRole": "button",
+                "accessibilityState": {
+                  "expanded": true,
+                },
+                "children": [
+                  {
+                    "props": {
+                      "children": [
+                        {
+                          "props": {
+                            "children": [
+                              "Item 1",
+                            ],
+                            "style": [
+                              {
+                                "fontSize": 16,
+                                "fontWeight": "500",
+                              },
+                              {
+                                "color": "#000000",
+                              },
+                              undefined,
+                            ],
+                          },
+                          "type": "Text",
+                        },
+                        {
+                          "props": {
+                            "children": [
+                              "⌄",
+                            ],
+                            "style": [
+                              {
+                                "color": "#FECA1A",
+                                "fontSize": 16,
+                                "transform": [
+                                  {
+                                    "rotate": "0deg",
+                                  },
+                                ],
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "rotate": "180deg",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                          "type": "Text",
+                        },
+                      ],
+                      "style": {
+                        "alignItems": "center",
+                        "flexDirection": "row",
+                        "justifyContent": "space-between",
+                      },
+                    },
+                    "type": "View",
+                  },
+                ],
+                "onPress": [Function],
+                "style": [
+                  {
+                    "paddingVertical": 12,
+                  },
+                  undefined,
+                ],
+              },
+              "type": "Pressable",
+            },
+            {
+              "props": {
+                "children": [
+                  "Content 1",
+                ],
+                "style": [
+                  {
+                    "paddingBottom": 16,
+                  },
+                  undefined,
+                ],
+              },
+              "type": "View",
+            },
+          ],
+          "style": [
+            {
+              "borderBottomWidth": 1,
+            },
+            {
+              "borderColor": "#e5e5e5",
+            },
+            undefined,
+          ],
+        },
+        "type": "View",
+      },
+    ],
+    "style": undefined,
+  },
+  "type": "View",
+}
+`;

--- a/packages/hum-ui-components/accordion.test.tsx
+++ b/packages/hum-ui-components/accordion.test.tsx
@@ -1,0 +1,171 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports */
+jest.mock('react-native', () => {
+  const create =
+    (name: string) =>
+    ({ children, ...props }: any) => ({
+      type: name,
+      props: { ...props, children },
+    });
+  return {
+    View: create('View'),
+    Text: create('Text'),
+    Pressable: create('Pressable'),
+    StyleSheet: { create: (s: any) => s, hairlineWidth: 1 },
+    useColorScheme: jest.fn(() => 'light'),
+  };
+});
+
+import React from 'react';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from './accordion';
+
+function render(element: any): any {
+  if (element == null || typeof element !== 'object') return element;
+  if (typeof element.type === 'function') {
+    return render(element.type(element.props));
+  }
+  const { children, ...rest } = element.props || {};
+  const renderedChildren = Array.isArray(children)
+    ? children.map(render)
+    : children !== undefined
+      ? [render(children)]
+      : [];
+  return { type: element.type, props: { ...rest, children: renderedChildren } };
+}
+
+function findNode(node: any, type: string, text?: string): any | undefined {
+  if (!node || typeof node !== 'object') return undefined;
+  if (node.type === type) {
+    const child = node.props.children;
+    if (
+      text === undefined ||
+      child === text ||
+      (Array.isArray(child) && child.includes(text))
+    ) {
+      return node;
+    }
+  }
+  const children = node.props?.children || [];
+  for (const child of Array.isArray(children) ? children : [children]) {
+    const found = findNode(child, type, text);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function findAll(node: any, type: string, acc: any[] = []): any[] {
+  if (!node || typeof node !== 'object') return acc;
+  if (node.type === type) acc.push(node);
+  const children = node.props?.children || [];
+  for (const child of Array.isArray(children) ? children : [children]) {
+    findAll(child, type, acc);
+  }
+  return acc;
+}
+
+function flatten(style: any): any {
+  return Array.isArray(style)
+    ? style.reduce((acc: any, cur: any) => Object.assign(acc, cur), {})
+    : style;
+}
+
+describe('Accordion', () => {
+  it('renders without crashing', () => {
+    const element = React.createElement(
+      Accordion as any,
+      { value: 'item1', onValueChange: jest.fn() } as any,
+      React.createElement(
+        AccordionItem as any,
+        { value: 'item1' } as any,
+        React.createElement(AccordionTrigger as any, null, 'Item 1'),
+        React.createElement(AccordionContent as any, null, 'Content 1'),
+      ),
+    );
+    const tree = render(element);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('calls onValueChange with single value', () => {
+    const onChange = jest.fn();
+    const element = React.createElement(
+      Accordion as any,
+      { value: '', onValueChange: onChange } as any,
+      React.createElement(
+        AccordionItem as any,
+        { value: 'a' } as any,
+        React.createElement(AccordionTrigger as any, null, 'A'),
+      ),
+    );
+    const tree = render(element);
+    const pressable = findNode(tree, 'Pressable');
+    pressable.props.onPress();
+    expect(onChange).toHaveBeenCalledWith('a');
+  });
+
+  it('calls onValueChange with array when multiple', () => {
+    const onChange = jest.fn();
+    const element = React.createElement(
+      Accordion as any,
+      { value: ['a'], type: 'multiple', onValueChange: onChange } as any,
+      React.createElement(
+        AccordionItem as any,
+        { value: 'a' } as any,
+        React.createElement(AccordionTrigger as any, null, 'A'),
+      ),
+      React.createElement(
+        AccordionItem as any,
+        { value: 'b' } as any,
+        React.createElement(AccordionTrigger as any, null, 'B'),
+      ),
+    );
+    const tree = render(element);
+    const pressables = findAll(tree, 'Pressable');
+    pressables[1].props.onPress();
+    expect(onChange).toHaveBeenCalledWith(['a', 'b']);
+  });
+
+  it('exposes accessibility props', () => {
+    const element = React.createElement(
+      Accordion as any,
+      { value: 'item1', onValueChange: jest.fn() } as any,
+      React.createElement(
+        AccordionItem as any,
+        { value: 'item1' } as any,
+        React.createElement(AccordionTrigger as any, null, 'Item 1'),
+      ),
+    );
+    const tree = render(element);
+    const pressable = findNode(tree, 'Pressable');
+    expect(pressable.props.accessibilityRole).toBe('button');
+    expect(pressable.props.accessibilityState.expanded).toBe(true);
+  });
+
+  it('applies light and dark theme styles', () => {
+    const rn = require('react-native');
+    rn.useColorScheme.mockReturnValue('light');
+    const lightTree = render(
+      React.createElement(
+        AccordionItem as any,
+        { value: 'x', openValues: ['x'] } as any,
+        React.createElement(AccordionTrigger as any, null, 'Txt'),
+      ),
+    );
+    const lightText = findNode(lightTree, 'Text', 'Txt');
+    expect(flatten(lightText.props.style).color).toBe('#000000');
+
+    rn.useColorScheme.mockReturnValue('dark');
+    const darkTree = render(
+      React.createElement(
+        AccordionItem as any,
+        { value: 'x', openValues: ['x'] } as any,
+        React.createElement(AccordionTrigger as any, null, 'Txt'),
+      ),
+    );
+    const darkText = findNode(darkTree, 'Text', 'Txt');
+    expect(flatten(darkText.props.style).color).toBe('#ffffff');
+  });
+});

--- a/packages/hum-ui-components/accordion.tsx
+++ b/packages/hum-ui-components/accordion.tsx
@@ -1,0 +1,207 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import * as RN from 'react-native';
+
+const { View, Text, Pressable, StyleSheet, useColorScheme } = RN as any;
+
+// Minimal style type placeholders to avoid requiring full react-native typings
+type StyleProp = any;
+
+export type AccordionValue = string | string[];
+
+export interface AccordionProps {
+  /**
+   * Currently opened item(s).
+   * If `type` is `single`, use a string. If `multiple`, use an array of strings.
+   */
+  value?: AccordionValue;
+  /**
+   * Callback when item is toggled.
+   */
+  onValueChange?: (value: AccordionValue) => void;
+  /**
+   * Allow multiple items to be expanded.
+   */
+  type?: 'single' | 'multiple';
+  children: React.ReactNode;
+  style?: StyleProp;
+}
+
+interface AccordionItemInternalProps {
+  openValues?: string[];
+  onToggle?: (value: string) => void;
+  type?: 'single' | 'multiple';
+}
+
+export interface AccordionItemProps {
+  value: string;
+  children: React.ReactNode;
+  style?: StyleProp;
+}
+
+export interface AccordionTriggerProps {
+  children: React.ReactNode;
+  isOpen?: boolean;
+  onToggle?: () => void;
+  style?: StyleProp;
+  textStyle?: StyleProp;
+}
+
+export interface AccordionContentProps {
+  children: React.ReactNode;
+  isOpen?: boolean;
+  style?: StyleProp;
+}
+
+/**
+ * Root accordion component providing open state to items.
+ */
+export function Accordion({
+  value,
+  onValueChange,
+  type = 'single',
+  children,
+  style,
+}: AccordionProps) {
+  const values = value ? (Array.isArray(value) ? value : [value]) : [];
+
+  const handleToggle = (val: string) => {
+    const isOpen = values.includes(val);
+    let next: string[];
+    if (type === 'multiple') {
+      next = isOpen ? values.filter((v) => v !== val) : [...values, val];
+      onValueChange?.(next);
+    } else {
+      next = isOpen ? [] : [val];
+      onValueChange?.(next[0] ?? '');
+    }
+  };
+
+  const rendered = React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) return child;
+    return React.cloneElement(
+      child as any,
+      {
+        openValues: values,
+        onToggle: handleToggle,
+        type,
+      } as any,
+    );
+  });
+
+  return <View style={style}>{rendered}</View>;
+}
+
+const lightColors = {
+  border: '#e5e5e5',
+  text: '#000000',
+};
+const darkColors = {
+  border: '#333333',
+  text: '#ffffff',
+};
+
+/**
+ * Item wrapper that knows its own open state.
+ */
+export function AccordionItem({
+  value,
+  children,
+  style,
+  openValues = [],
+  onToggle = () => {},
+}: AccordionItemProps & AccordionItemInternalProps) {
+  const scheme = useColorScheme();
+  const colors = scheme === 'dark' ? darkColors : lightColors;
+  const isOpen = openValues.includes(value);
+
+  const rendered = React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) return child;
+    return React.cloneElement(child as React.ReactElement<any>, {
+      isOpen,
+      onToggle: () => onToggle(value),
+      textColor: colors.text,
+    });
+  });
+
+  return (
+    <View style={[styles.item, { borderColor: colors.border }, style]}>
+      {rendered}
+    </View>
+  );
+}
+
+/**
+ * Pressable trigger to open/close the item.
+ */
+export function AccordionTrigger({
+  children,
+  isOpen = false,
+  onToggle = () => {},
+  style,
+  textStyle,
+  textColor,
+}: AccordionTriggerProps & { textColor?: string }) {
+  return (
+    <Pressable
+      onPress={onToggle}
+      style={[styles.trigger, style]}
+      accessibilityRole="button"
+      accessibilityState={{ expanded: isOpen }}
+    >
+      <View style={styles.triggerRow}>
+        {typeof children === 'string' ? (
+          <Text style={[styles.triggerText, { color: textColor }, textStyle]}>
+            {children}
+          </Text>
+        ) : (
+          children
+        )}
+        <Text style={[styles.chevron, isOpen && styles.chevronOpen]}>⌄</Text>
+      </View>
+    </Pressable>
+  );
+}
+
+/**
+ * Content shown when the item is open.
+ */
+export function AccordionContent({
+  children,
+  isOpen = false,
+  style,
+}: AccordionContentProps) {
+  if (!isOpen) return null;
+  return <View style={[styles.content, style]}>{children}</View>;
+}
+
+const styles = StyleSheet.create({
+  item: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  trigger: {
+    paddingVertical: 12,
+  },
+  triggerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  triggerText: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  chevron: {
+    fontSize: 16,
+    color: '#FECA1A',
+    transform: [{ rotate: '0deg' }],
+  },
+  chevronOpen: {
+    transform: [{ rotate: '180deg' }],
+  },
+  content: {
+    paddingBottom: 16,
+  },
+});
+
+export default Accordion;


### PR DESCRIPTION
## Summary
- add reusable Accordion, AccordionItem, AccordionTrigger and AccordionContent components for React Native
- document usage in Storybook
- cover accordion behaviour with unit tests

## Testing
- `npm test packages/hum-ui-components/accordion.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1f3f3a708832fb4766bdd7d1610b1