### PR TITLE
feat: add React Native AlertDialog component

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -35,6 +35,15 @@ const config: StorybookConfig = {
       'index.ts',
     );
     const uiAlias = { find: /^@hum\/ui-components$/, replacement: uiSrc };
+    const safeAreaSrc = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'react-native-safe-area-context.tsx',
+    );
+    const safeAreaAlias = {
+      find: /^react-native-safe-area-context$/,
+      replacement: safeAreaSrc,
+    };
 
     // Support both array and object alias shapes
     if (Array.isArray(viteConfig.resolve.alias)) {
@@ -42,6 +51,7 @@ const config: StorybookConfig = {
         ...viteConfig.resolve.alias,
         rnAlias,
         uiAlias,
+        safeAreaAlias,
       ];
     } else {
       viteConfig.resolve.alias = {
@@ -50,6 +60,7 @@ const config: StorybookConfig = {
         // Keep an object alias as a safety net for tools reading object shape:
         'react-native': 'react-native-web',
         '@hum/ui-components': uiSrc,
+        'react-native-safe-area-context': safeAreaSrc,
       };
     }
 

--- a/apps/storybook/react-native-safe-area-context.tsx
+++ b/apps/storybook/react-native-safe-area-context.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { View } from 'react-native';
+
+export const SafeAreaView = View;
+export const SafeAreaProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => <>{children}</>;
+export function useSafeAreaInsets() {
+  return { top: 0, right: 0, bottom: 0, left: 0 };
+}

--- a/apps/storybook/storybook/stories/alert-dialog.stories.tsx
+++ b/apps/storybook/storybook/stories/alert-dialog.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { Text } from 'react-native';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+  type AlertDialogProps,
+} from '@hum/ui-components';
+
+const ExampleAlertDialog: React.FC<AlertDialogProps> = (props) => (
+  <AlertDialog {...props}>
+    <AlertDialogTrigger>
+      <Text>Open</Text>
+    </AlertDialogTrigger>
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>
+          <Text>Are you sure?</Text>
+        </AlertDialogTitle>
+        <AlertDialogDescription>
+          <Text>This action cannot be undone.</Text>
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel>
+          <Text>Cancel</Text>
+        </AlertDialogCancel>
+        <AlertDialogAction>
+          <Text>Continue</Text>
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+);
+
+const meta: Meta<typeof ExampleAlertDialog> = {
+  title: 'Components/AlertDialog',
+  component: ExampleAlertDialog,
+  argTypes: {
+    defaultOpen: { control: 'boolean' },
+    open: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ExampleAlertDialog>;
+
+export const Basic: Story = {};
+export const Opened: Story = { args: { defaultOpen: true } };
+export const Controlled: Story = {
+  render: (args) => {
+    const ControlledExample: React.FC = () => {
+      const [open, setOpen] = React.useState(false);
+      return (
+        <ExampleAlertDialog {...args} open={open} onOpenChange={setOpen} />
+      );
+    };
+    return <ControlledExample />;
+  },
+};

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
     alias: {
       'react-native': 'react-native-web',
       '@hum/ui-components': r('../../packages/ui-components/'),
+      'react-native-safe-area-context': r(
+        './react-native-safe-area-context.tsx',
+      ),
     },
   },
   optimizeDeps: {

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -23,4 +23,3 @@ export {
 export type { AlertDialogProps } from './src/alert-dialog';
 export { Alert, AlertTitle, AlertDescription } from './src/alert';
 export type { AlertProps, AlertVariant } from './src/alert';
-

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -7,3 +7,18 @@ export {
   AccordionContent,
 } from './src/accordion';
 export type { AccordionProps } from './src/accordion';
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from './src/alert-dialog';
+export type { AlertDialogProps } from './src/alert-dialog';

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -18,10 +18,12 @@
   },
   "peerDependencies": {
     "react": "^19.0.0",
-    "react-native": ">=0.75"
+    "react-native": ">=0.75",
+    "react-native-safe-area-context": ">=5.4.0"
   },
   "devDependencies": {
-    "@types/react": "^19.1.12"
+    "@types/react": "^19.1.12",
+    "react-native-safe-area-context": "5.4.0"
   },
   "dependencies": {
     "@testing-library/jest-dom": "6.8.0"

--- a/packages/ui-components/src/__snapshots__/alert-dialog.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/alert-dialog.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`AlertDialog renders closed by default 1`] = `
+<body>
+  <div>
+    <button
+      class="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73"
+      role="button"
+      tabindex="0"
+      type="button"
+    >
+      <div
+        class="css-text-146c3p1"
+        dir="auto"
+      >
+        Open
+      </div>
+    </button>
+  </div>
+  <div />
+</body>
+`;

--- a/packages/ui-components/src/alert-dialog.test.tsx
+++ b/packages/ui-components/src/alert-dialog.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const expectAny = expect as any;
+
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+  type AlertDialogProps,
+} from './alert-dialog';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+function renderDialog(
+  scheme: 'light' | 'dark' = 'light',
+  props?: Partial<AlertDialogProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <AlertDialog {...props}>
+        <AlertDialogTrigger>
+          <Text>Open</Text>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              <Text>Title</Text>
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              <Text>Description</Text>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              <Text>Cancel</Text>
+            </AlertDialogCancel>
+            <AlertDialogAction>
+              <Text>Ok</Text>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </ThemeProvider>,
+  );
+}
+
+describe('AlertDialog', () => {
+  it('renders closed by default', () => {
+    const { baseElement } = renderDialog();
+    expectAny(screen.queryByText('Title')).not.toBeInTheDocument();
+    expectAny(baseElement).toMatchSnapshot();
+  });
+
+  it('opens on trigger press and calls onOpenChange', async () => {
+    const onOpenChange = jest.fn();
+    renderDialog('light', { onOpenChange });
+
+    const trigger = screen.getByText('Open');
+    fireEvent.click(trigger);
+    await waitFor(() => expectAny(onOpenChange).toHaveBeenCalledWith(true));
+    expectAny(screen.getByText('Title')).toBeInTheDocument();
+  });
+
+  it('applies theme colors', async () => {
+    const { unmount } = renderDialog('light');
+    fireEvent.click(screen.getByText('Open'));
+    await waitFor(() =>
+      expectAny(
+        screen.getByRole('heading', { name: 'Title' }),
+      ).toBeInTheDocument(),
+    );
+    const lightTitle = screen.getByRole('heading', { name: 'Title' });
+    expectAny(lightTitle).toHaveStyle({ color: colors.light.foreground });
+    unmount();
+
+    renderDialog('dark');
+    fireEvent.click(screen.getByText('Open'));
+    await waitFor(() =>
+      expectAny(
+        screen.getByRole('heading', { name: 'Title' }),
+      ).toBeInTheDocument(),
+    );
+    const darkTitle = screen.getByRole('heading', { name: 'Title' });
+    expectAny(darkTitle).toHaveStyle({ color: colors.dark.foreground });
+  });
+});

--- a/packages/ui-components/src/alert-dialog.tsx
+++ b/packages/ui-components/src/alert-dialog.tsx
@@ -1,0 +1,321 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  ViewProps,
+  TextProps,
+  PressableProps,
+  GestureResponderEvent,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme } from './theme/ThemeProvider';
+
+interface AlertDialogContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const AlertDialogContext = createContext<AlertDialogContextValue | null>(null);
+
+const useAlertDialog = () => {
+  const ctx = useContext(AlertDialogContext);
+  if (!ctx)
+    throw new Error('AlertDialog components must be used within AlertDialog');
+  return ctx;
+};
+
+export interface AlertDialogProps {
+  children: ReactNode;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export const AlertDialog: React.FC<AlertDialogProps> = ({
+  children,
+  open,
+  defaultOpen = false,
+  onOpenChange,
+}) => {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isControlled = open !== undefined;
+  const currentOpen = isControlled ? open : internalOpen;
+
+  const setOpen = (next: boolean) => {
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
+
+  return (
+    <AlertDialogContext.Provider value={{ open: currentOpen, setOpen }}>
+      {children}
+    </AlertDialogContext.Provider>
+  );
+};
+
+export const AlertDialogTrigger: React.FC<
+  PressableProps & { children: ReactNode }
+> = ({ children, onPress, ...props }) => {
+  const { setOpen } = useAlertDialog();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={(e: GestureResponderEvent) => {
+        setOpen(true);
+        onPress?.(e);
+      }}
+      {...props}
+    >
+      {typeof children === 'string' ? <Text>{children}</Text> : children}
+    </Pressable>
+  );
+};
+
+export const AlertDialogPortal: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => <>{children}</>;
+
+export const AlertDialogOverlay: React.FC<PressableProps> = ({
+  style,
+  ...props
+}) => (
+  <Pressable
+    style={[StyleSheet.absoluteFillObject, styles.overlay, style]}
+    {...props}
+  />
+);
+
+export interface AlertDialogContentProps extends ViewProps {
+  children: ReactNode;
+}
+
+export const AlertDialogContent: React.FC<AlertDialogContentProps> = ({
+  children,
+  style,
+  ...props
+}) => {
+  const { open, setOpen } = useAlertDialog();
+  const { colors, radius, spacing } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal
+      transparent
+      visible={open}
+      animationType="fade"
+      onRequestClose={() => setOpen(false)}
+    >
+      <View
+        style={[
+          styles.modal,
+          {
+            paddingTop: insets.top,
+            paddingBottom: insets.bottom,
+            paddingLeft: insets.left,
+            paddingRight: insets.right,
+          },
+        ]}
+      >
+        <AlertDialogOverlay onPress={() => setOpen(false)} />
+        <View
+          style={[
+            styles.content,
+            {
+              backgroundColor: colors.background,
+              borderColor: colors.border,
+              borderRadius: radius.lg,
+              padding: spacing.lg,
+            },
+            style,
+          ]}
+          accessibilityRole="alert"
+          {...props}
+        >
+          {children}
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export const AlertDialogHeader: React.FC<ViewProps> = ({ style, ...props }) => {
+  const { spacing } = useTheme();
+  return (
+    <View
+      style={[styles.header, { marginBottom: spacing.md }, style]}
+      {...props}
+    />
+  );
+};
+
+export const AlertDialogFooter: React.FC<ViewProps> = ({ style, ...props }) => {
+  const { spacing } = useTheme();
+  return (
+    <View
+      style={[styles.footer, { marginTop: spacing.lg }, style]}
+      {...props}
+    />
+  );
+};
+
+export const AlertDialogTitle: React.FC<TextProps> = ({ style, ...props }) => {
+  const { colors, type } = useTheme();
+  return (
+    <Text
+      accessibilityRole="header"
+      style={[
+        styles.title,
+        {
+          color: colors.foreground,
+          fontSize: type.size.lg,
+          fontWeight: type.weight.bold,
+        },
+        style,
+      ]}
+      {...props}
+    />
+  );
+};
+
+export const AlertDialogDescription: React.FC<TextProps> = ({
+  style,
+  ...props
+}) => {
+  const { colors, type } = useTheme();
+  return (
+    <Text
+      style={[
+        styles.description,
+        { color: colors.mutedForeground, fontSize: type.size.sm },
+        style,
+      ]}
+      {...props}
+    />
+  );
+};
+
+export const AlertDialogAction: React.FC<
+  PressableProps & { children: ReactNode }
+> = ({ children, style, onPress, ...props }) => {
+  const { colors, spacing, radius, type } = useTheme();
+  const { setOpen } = useAlertDialog();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={(e: GestureResponderEvent) => {
+        setOpen(false);
+        onPress?.(e);
+      }}
+      style={[
+        styles.button,
+        {
+          backgroundColor: colors.humPrimary,
+          borderColor: colors.humPrimary,
+          borderRadius: radius.md,
+          paddingVertical: spacing.sm,
+          paddingHorizontal: spacing.lg,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      {typeof children === 'string' ? (
+        <Text
+          style={{
+            color: colors.humPrimaryForeground,
+            fontSize: type.size.md,
+            fontWeight: type.weight.medium,
+          }}
+        >
+          {children}
+        </Text>
+      ) : (
+        children
+      )}
+    </Pressable>
+  );
+};
+
+export const AlertDialogCancel: React.FC<
+  PressableProps & { children: ReactNode }
+> = ({ children, style, onPress, ...props }) => {
+  const { colors, spacing, radius, type } = useTheme();
+  const { setOpen } = useAlertDialog();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={(e: GestureResponderEvent) => {
+        setOpen(false);
+        onPress?.(e);
+      }}
+      style={[
+        styles.button,
+        styles.cancelButton,
+        {
+          borderColor: colors.border,
+          borderRadius: radius.md,
+          paddingVertical: spacing.sm,
+          paddingHorizontal: spacing.lg,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      {typeof children === 'string' ? (
+        <Text
+          style={{
+            color: colors.foreground,
+            fontSize: type.size.md,
+            fontWeight: type.weight.medium,
+          }}
+        >
+          {children}
+        </Text>
+      ) : (
+        children
+      )}
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  modal: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  overlay: {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  content: {
+    borderWidth: 1,
+    maxWidth: 420,
+    width: '90%',
+  },
+  header: {
+    width: '100%',
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    width: '100%',
+  },
+  title: {
+    textAlign: 'left',
+  },
+  description: {
+    marginTop: 4,
+  },
+  button: {
+    marginLeft: 8,
+  },
+  cancelButton: {
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+  },
+});
+
+export default AlertDialog;

--- a/packages/ui-components/src/alert-dialog.tsx
+++ b/packages/ui-components/src/alert-dialog.tsx
@@ -5,6 +5,8 @@ import {
   Text,
   Pressable,
   StyleSheet,
+  StyleProp,
+  ViewStyle,
   ViewProps,
   TextProps,
   PressableProps,
@@ -78,7 +80,11 @@ export const AlertDialogPortal: React.FC<{ children: ReactNode }> = ({
   children,
 }) => <>{children}</>;
 
-export const AlertDialogOverlay: React.FC<PressableProps> = ({
+interface AlertDialogOverlayProps extends Omit<PressableProps, 'style'> {
+  style?: StyleProp<ViewStyle>;
+}
+
+export const AlertDialogOverlay: React.FC<AlertDialogOverlayProps> = ({
   style,
   ...props
 }) => (
@@ -197,9 +203,17 @@ export const AlertDialogDescription: React.FC<TextProps> = ({
   );
 };
 
-export const AlertDialogAction: React.FC<
-  PressableProps & { children: ReactNode }
-> = ({ children, style, onPress, ...props }) => {
+interface AlertDialogActionProps extends Omit<PressableProps, 'style'> {
+  children: ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+export const AlertDialogAction: React.FC<AlertDialogActionProps> = ({
+  children,
+  style,
+  onPress,
+  ...props
+}) => {
   const { colors, spacing, radius, type } = useTheme();
   const { setOpen } = useAlertDialog();
   return (
@@ -239,9 +253,17 @@ export const AlertDialogAction: React.FC<
   );
 };
 
-export const AlertDialogCancel: React.FC<
-  PressableProps & { children: ReactNode }
-> = ({ children, style, onPress, ...props }) => {
+interface AlertDialogCancelProps extends Omit<PressableProps, 'style'> {
+  children: ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+export const AlertDialogCancel: React.FC<AlertDialogCancelProps> = ({
+  children,
+  style,
+  onPress,
+  ...props
+}) => {
   const { colors, spacing, radius, type } = useTheme();
   const { setOpen } = useAlertDialog();
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@types/react':
         specifier: ^19.1.12
         version: 19.1.12
+      react-native-safe-area-context:
+        specifier: 5.4.0
+        version: 5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
 
 packages:
 
@@ -12421,6 +12424,11 @@ snapshots:
     dependencies:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   react-native-web@0.21.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:

--- a/tests/react-native.d.ts
+++ b/tests/react-native.d.ts
@@ -5,15 +5,38 @@ declare module 'react-native' {
   export const Text: React.FC<any>;
   export const Image: React.FC<any>;
   export const Pressable: React.FC<any>;
+  export const Modal: React.FC<any>;
   export const Animated: any;
-  export const StyleSheet: { create: (styles: any) => any };
+  export const StyleSheet: {
+    create: (styles: any) => any;
+    absoluteFillObject: any;
+  };
   export type StyleProp<T> = any;
   export interface ViewStyle {}
   export interface TextStyle {}
-  export interface ViewProps {}
-  export interface PressableProps {
-    disabled?: boolean;
+  export interface ViewProps {
+    style?: any;
     [key: string]: any;
   }
+  export interface TextProps {
+    style?: any;
+    [key: string]: any;
+  }
+  export interface PressableProps {
+    disabled?: boolean;
+    onPress?: (e: any) => void;
+    style?: any;
+    [key: string]: any;
+  }
+  export interface GestureResponderEvent {}
   export function useColorScheme(): 'light' | 'dark';
+}
+
+declare module 'react-native-safe-area-context' {
+  export const useSafeAreaInsets: () => {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+  };
 }


### PR DESCRIPTION
## Summary
- add themed AlertDialog React Native component using Modal and safe area insets
- cover AlertDialog with unit tests and Storybook stories

## Testing
- `pnpm test packages/ui-components/src/alert-dialog.test.tsx`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bd8fa4c4832f848ddf515d245705