### PR TITLE
feat: add alert component

### DIFF
--- a/apps/storybook/storybook/stories/alert.stories.tsx
+++ b/apps/storybook/storybook/stories/alert.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { Text } from 'react-native';
+import {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+  type AlertProps,
+} from '@hum/ui-components';
+
+const ExampleAlert: React.FC<AlertProps> = (props) => (
+  <Alert {...props}>
+    <AlertTitle>
+      <Text>Heads up!</Text>
+    </AlertTitle>
+    <AlertDescription>
+      <Text>This is an alert.</Text>
+    </AlertDescription>
+  </Alert>
+);
+
+const meta: Meta<typeof ExampleAlert> = {
+  title: 'Components/Alert',
+  component: ExampleAlert,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'destructive'],
+    },
+  },
+  args: { variant: 'default' },
+};
+export default meta;
+
+type Story = StoryObj<typeof ExampleAlert>;
+
+export const Basic: Story = {};
+export const Destructive: Story = { args: { variant: 'destructive' } };
+export const WithIcon: Story = {
+  render: (args) => (
+    <Alert {...args}>
+      <Text>⚠️</Text>
+      <AlertTitle>
+        <Text>Heads up!</Text>
+      </AlertTitle>
+      <AlertDescription>
+        <Text>This alert has an icon.</Text>
+      </AlertDescription>
+    </Alert>
+  ),
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.34.0",
+    "@testing-library/jest-native": "5.4.3",
+    "@testing-library/react-native": "13.3.3",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.12",
     "@types/react-native": "0.73.0",
@@ -54,6 +56,7 @@
     "react-dom": "^19.1.1",
     "react-native": "0.75.4",
     "react-native-web": "~0.21.1",
+    "react-test-renderer": "19.1.1",
     "ts-jest": "^29.1.1",
     "typescript": "^5.6.3"
   },

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -7,3 +7,5 @@ export {
   AccordionContent,
 } from './src/accordion';
 export type { AccordionProps } from './src/accordion';
+export { Alert, AlertTitle, AlertDescription } from './src/alert';
+export type { AlertProps, AlertVariant } from './src/alert';

--- a/packages/ui-components/src/__snapshots__/alert.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/alert.test.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Alert renders default and matches snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1habvwh r-borderWidth-rs99b7 r-flexDirection-18u37iz r-width-13qz1uu"
+      data-testid="alert"
+      role="alert"
+      style="background-color: rgb(255, 255, 255); border-top-color: rgba(0, 0, 0, 0.1); border-right-color: rgba(0, 0, 0, 0.1); border-bottom-color: rgba(0, 0, 0, 0.1); border-left-color: rgba(0, 0, 0, 0.1); padding: 8px 12px 8px 12px; border-top-left-radius: 12px; border-top-right-radius: 12px; border-bottom-right-radius: 12px; border-bottom-left-radius: 12px;"
+      tabindex="0"
+    >
+      <div
+        class="css-view-g5y9jx r-flex-13awgt0"
+      >
+        <div
+          class="css-text-146c3p1 r-marginBottom-15zivkp"
+          data-testid="title"
+          dir="auto"
+          style="color: rgb(10, 10, 10); font-size: 16px; font-weight: 500;"
+        >
+          Title
+        </div>
+        <div
+          class="css-text-146c3p1 r-marginTop-1bymd8e"
+          data-testid="description"
+          dir="auto"
+          style="color: rgb(113, 113, 130); font-size: 14px; line-height: 24px;"
+        >
+          Description
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/ui-components/src/alert.test.tsx
+++ b/packages/ui-components/src/alert.test.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable react-native/no-raw-text */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { Alert, AlertTitle, AlertDescription, type AlertProps } from './alert';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+// Temporary workaround for missing Jest DOM matcher typings
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const expectAny = expect as any;
+
+function renderAlert(
+  scheme: 'light' | 'dark' = 'light',
+  props?: Partial<AlertProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <Alert testID="alert" {...props}>
+        <AlertTitle testID="title">Title</AlertTitle>
+        <AlertDescription testID="description">Description</AlertDescription>
+      </Alert>
+    </ThemeProvider>,
+  );
+}
+
+describe('Alert', () => {
+  it('renders default and matches snapshot', () => {
+    const { baseElement } = renderAlert();
+    expectAny(screen.getByTestId('title')).toBeInTheDocument();
+    expectAny(baseElement).toMatchSnapshot();
+  });
+
+  it('supports destructive variant', () => {
+    renderAlert('light', { variant: 'destructive' });
+    expectAny(screen.getByTestId('title')).toHaveStyle({
+      color: colors.light.destructive,
+    });
+  });
+
+  it('calls onPress when provided', () => {
+    const onPress = jest.fn();
+    renderAlert('light', { onPress });
+    fireEvent.click(screen.getByTestId('alert'));
+    expectAny(onPress).toHaveBeenCalled();
+  });
+
+  it('applies theme colors', () => {
+    const { unmount } = renderAlert('light');
+    expectAny(screen.getByTestId('title')).toHaveStyle({
+      color: colors.light.cardForeground,
+    });
+    unmount();
+    renderAlert('dark');
+    expectAny(screen.getByTestId('title')).toHaveStyle({
+      color: colors.dark.cardForeground,
+    });
+  });
+});

--- a/packages/ui-components/src/alert.tsx
+++ b/packages/ui-components/src/alert.tsx
@@ -1,0 +1,153 @@
+import React, { createContext, useContext } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+  PressableProps,
+} from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+// Context to share variant with subcomponents
+const AlertContext = createContext<{ variant: AlertVariant }>({
+  variant: 'default',
+});
+const useAlert = () => useContext(AlertContext);
+
+export type AlertVariant = 'default' | 'destructive';
+
+export interface AlertProps extends PressableProps {
+  variant?: AlertVariant;
+  style?: StyleProp<ViewStyle>;
+  children: React.ReactNode;
+}
+
+export const Alert: React.FC<AlertProps> = ({
+  variant = 'default',
+  style,
+  children,
+  ...props
+}) => {
+  const { colors, spacing, radius } = useTheme();
+  const childrenArray = React.Children.toArray(children);
+
+  const hasIcon =
+    React.isValidElement(childrenArray[0]) &&
+    (childrenArray[0] as React.ReactElement).type !== AlertTitle &&
+    (childrenArray[0] as React.ReactElement).type !== AlertDescription;
+
+  const icon = hasIcon ? childrenArray[0] : null;
+  const content = hasIcon ? childrenArray.slice(1) : childrenArray;
+
+  return (
+    <AlertContext.Provider value={{ variant }}>
+      <Pressable
+        accessibilityRole="alert"
+        style={[
+          styles.container,
+          {
+            backgroundColor: colors.card,
+            borderColor: colors.border,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+            borderRadius: radius.lg,
+          },
+          style,
+        ]}
+        {...props}
+      >
+        {icon && <View style={{ marginRight: spacing.sm }}>{icon}</View>}
+        <View style={styles.content}>{content}</View>
+      </Pressable>
+    </AlertContext.Provider>
+  );
+};
+
+type RNTextProps = React.ComponentProps<typeof Text>;
+
+export interface AlertTitleProps extends RNTextProps {
+  children: React.ReactNode;
+  style?: StyleProp<TextStyle>;
+  testID?: string;
+}
+
+export const AlertTitle: React.FC<AlertTitleProps> = ({
+  children,
+  style,
+  ...props
+}) => {
+  const { colors, type } = useTheme();
+  const { variant } = useAlert();
+  const color =
+    variant === 'destructive' ? colors.destructive : colors.cardForeground;
+  return (
+    <Text
+      style={[
+        styles.title,
+        {
+          color,
+          fontSize: type.size.md,
+          fontWeight: type.weight.medium,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </Text>
+  );
+};
+
+export interface AlertDescriptionProps extends RNTextProps {
+  children: React.ReactNode;
+  style?: StyleProp<TextStyle>;
+  testID?: string;
+}
+
+export const AlertDescription: React.FC<AlertDescriptionProps> = ({
+  children,
+  style,
+  ...props
+}) => {
+  const { colors, type } = useTheme();
+  const { variant } = useAlert();
+  const color =
+    variant === 'destructive' ? colors.destructive : colors.mutedForeground;
+  return (
+    <Text
+      style={[
+        styles.description,
+        {
+          color,
+          fontSize: type.size.base,
+          lineHeight: type.lineHeight.relaxed,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </Text>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    borderWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+  },
+  content: {
+    flex: 1,
+  },
+  title: {
+    marginBottom: 4,
+  },
+  description: {
+    marginTop: 2,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,12 @@ importers:
       '@eslint/js':
         specifier: ^9.34.0
         version: 9.34.0
+      '@testing-library/jest-native':
+        specifier: 5.4.3
+        version: 5.4.3(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react-test-renderer@19.1.1(react@19.1.1))(react@19.1.1)
+      '@testing-library/react-native':
+        specifier: 13.3.3
+        version: 13.3.3(jest@30.0.5(@types/node@24.3.0)(esbuild-register@3.6.0(esbuild@0.25.9)))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react-test-renderer@19.1.1(react@19.1.1))(react@19.1.1)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -75,6 +81,9 @@ importers:
       react-native-web:
         specifier: ~0.21.1
         version: 0.21.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react-test-renderer:
+        specifier: 19.1.1
+        version: 19.1.1(react@19.1.1)
       ts-jest:
         specifier: ^29.1.1
         version: 29.4.1(@babel/core@7.28.3)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.28.3))(esbuild@0.25.9)(jest-util@30.0.5)(jest@30.0.5(@types/node@24.3.0)(esbuild-register@3.6.0(esbuild@0.25.9)))(typescript@5.8.3)
@@ -2070,6 +2079,30 @@ packages:
     resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
+  '@testing-library/jest-native@5.4.3':
+    resolution: {integrity: sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==}
+    deprecated: |-
+      DEPRECATED: This package is no longer maintained.
+      Please use the built-in Jest matchers available in @testing-library/react-native v12.4+.
+
+      See migration guide: https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers
+    peerDependencies:
+      react: '>=16.0.0'
+      react-native: '>=0.59'
+      react-test-renderer: '>=16.0.0'
+
+  '@testing-library/react-native@13.3.3':
+    resolution: {integrity: sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      jest: '>=29.0.0'
+      react: '>=18.2.0'
+      react-native: '>=0.71'
+      react-test-renderer: '>=18.2.0'
+    peerDependenciesMeta:
+      jest:
+        optional: true
+
   '@testing-library/react@16.3.0':
     resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
     engines: {node: '>=18'}
@@ -3046,6 +3079,10 @@ packages:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
 
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -3974,6 +4011,10 @@ packages:
       ts-node:
         optional: true
 
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-diff@30.0.5:
     resolution: {integrity: sha512-1UIqE9PoEKaHcIKvq2vbibrCog4Y8G0zmOxgQUVEiTqwR5hJVMCoDsN1vFvI5JvwD37hjueZ1C4l2FyGnfpE0A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -4018,6 +4059,10 @@ packages:
   jest-leak-detector@30.0.5:
     resolution: {integrity: sha512-3Uxr5uP8jmHMcsOtYMRB/zf1gXN3yUIc+iPorhNETG54gErFIiUhLvyY/OggYpSMOEYqsmRxmuU4ZOoX5jpRFg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-matcher-utils@30.0.5:
     resolution: {integrity: sha512-uQgGWt7GOrRLP1P7IwNWwK1WAQbq+m//ZY0yXygyfWp0rJlksMSLQAA4wYQC3b6wl3zfnchyTx+k3HZ5aPtCbQ==}
@@ -5045,6 +5090,9 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-is@19.1.1:
+    resolution: {integrity: sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==}
+
   react-native-edge-to-edge@1.6.0:
     resolution: {integrity: sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==}
     peerDependencies:
@@ -5092,6 +5140,11 @@ packages:
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
+
+  react-test-renderer@19.1.1:
+    resolution: {integrity: sha512-aGRXI+zcBTtg0diHofc7+Vy97nomBs9WHHFY1Csl3iV0x6xucjNYZZAkiVKGiNYUv23ecOex5jE67t8ZzqYObA==}
+    peerDependencies:
+      react: ^19.1.1
 
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
@@ -8698,6 +8751,29 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
+  '@testing-library/jest-native@5.4.3(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react-test-renderer@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-matcher-utils: 29.7.0
+      pretty-format: 29.7.0
+      react: 19.1.1
+      react-native: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
+      react-test-renderer: 19.1.1(react@19.1.1)
+      redent: 3.0.0
+
+  '@testing-library/react-native@13.3.3(jest@30.0.5(@types/node@24.3.0)(esbuild-register@3.6.0(esbuild@0.25.9)))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react-test-renderer@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      jest-matcher-utils: 30.0.5
+      picocolors: 1.1.1
+      pretty-format: 30.0.5
+      react: 19.1.1
+      react-native: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
+      react-test-renderer: 19.1.1(react@19.1.1)
+      redent: 3.0.0
+    optionalDependencies:
+      jest: 30.0.5(@types/node@24.3.0)(esbuild-register@3.6.0(esbuild@0.25.9))
+
   '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.3
@@ -9800,6 +9876,8 @@ snapshots:
   detect-libc@1.0.3: {}
 
   detect-newline@3.1.0: {}
+
+  diff-sequences@29.6.3: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -10943,6 +11021,13 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
   jest-diff@30.0.5:
     dependencies:
       '@jest/diff-sequences': 30.0.1
@@ -11030,6 +11115,13 @@ snapshots:
     dependencies:
       '@jest/get-type': 30.0.1
       pretty-format: 30.0.5
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
 
   jest-matcher-utils@30.0.5:
     dependencies:
@@ -12412,6 +12504,8 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-is@19.1.1: {}
+
   react-native-edge-to-edge@1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
     dependencies:
       react: 19.1.1
@@ -12637,6 +12731,12 @@ snapshots:
   react-refresh@0.14.2: {}
 
   react-refresh@0.17.0: {}
+
+  react-test-renderer@19.1.1(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-is: 19.1.1
+      scheduler: 0.26.0
 
   react@19.1.1: {}
 

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,6 +1,10 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "types": ["jest", "@testing-library/jest-dom"]
+    "types": [
+      "jest",
+      "@testing-library/jest-dom",
+      "@testing-library/jest-native"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add React Native Alert component with title and description helpers
- document Alert in Storybook with default, destructive, and icon variants
- test Alert variants and theming support

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `cd apps/storybook && pnpm start` *(fails: unable to find package.json for @hum/ui-components / spawn xdg-open)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c28d913c832fadd32d52c895b472