### PR TITLE
feat: add aspect ratio component

### DIFF
--- a/apps/storybook/storybook/stories/aspect-ratio.stories.tsx
+++ b/apps/storybook/storybook/stories/aspect-ratio.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { AspectRatio } from '@hum/ui-components';
+import type { AspectRatioProps } from '@hum/ui-components';
+
+const styles = StyleSheet.create({
+  box: { flex: 1, backgroundColor: '#FECA1A' },
+});
+
+const Box: React.FC = () => <View style={styles.box} />;
+
+const ExampleAspectRatio: React.FC<AspectRatioProps> = (props) => (
+  <AspectRatio {...props}>
+    <Box />
+  </AspectRatio>
+);
+
+const meta: Meta<typeof ExampleAspectRatio> = {
+  title: 'Components/AspectRatio',
+  component: ExampleAspectRatio,
+  argTypes: {
+    ratio: { control: 'number' },
+  },
+  args: { ratio: 1 },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ExampleAspectRatio>;
+
+export const Basic: Story = {};
+export const Wide: Story = { args: { ratio: 16 / 9 } };
+export const Tall: Story = { args: { ratio: 9 / 16 } };

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -9,3 +9,5 @@ export {
 export type { AccordionProps } from './src/accordion';
 export { Alert, AlertTitle, AlertDescription } from './src/alert';
 export type { AlertProps, AlertVariant } from './src/alert';
+export { AspectRatio } from './src/aspect-ratio';
+export type { AspectRatioProps } from './src/aspect-ratio';

--- a/packages/ui-components/jest.setup.ts
+++ b/packages/ui-components/jest.setup.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import '@testing-library/jest-native/extend-expect';

--- a/packages/ui-components/src/__snapshots__/aspect-ratio.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/aspect-ratio.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`AspectRatio renders with default ratio and matches snapshot 1`] = `
+<div
+  className="css-view-g5y9jx r-overflow-1udh08x r-width-13qz1uu"
+  data-testid="ratio"
+  dir={null}
+  ref={[Function]}
+  style={
+    {
+      "aspectRatio": "1",
+      "backgroundColor": "rgba(255,255,255,1.00)",
+    }
+  }
+>
+  <div
+    className="css-view-g5y9jx"
+    data-testid="inner"
+    dir={null}
+    ref={[Function]}
+  />
+</div>
+`;

--- a/packages/ui-components/src/aspect-ratio.test.tsx
+++ b/packages/ui-components/src/aspect-ratio.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { View } from 'react-native';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+
+import { AspectRatio, type AspectRatioProps } from './aspect-ratio';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+const hexToRgba = (hex: string) => {
+  const bigint = parseInt(hex.slice(1), 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r},${g},${b},1.00)`;
+};
+
+function renderAspectRatio(
+  scheme: 'light' | 'dark' = 'light',
+  props?: AspectRatioProps,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <AspectRatio testID="ratio" {...props}>
+        <View testID="inner" />
+      </AspectRatio>
+    </ThemeProvider>,
+  );
+}
+
+describe('AspectRatio', () => {
+  it('renders with default ratio and matches snapshot', () => {
+    const { toJSON } = renderAspectRatio();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('applies custom ratio', () => {
+    renderAspectRatio('light', { ratio: 16 / 9, accessibilityLabel: 'ratio' });
+    expect(screen.getByLabelText('ratio')).toHaveStyle({
+      aspectRatio: `${16 / 9}`,
+    });
+  });
+
+  it('fires onLayout callback', () => {
+    const onLayout = jest.fn();
+    renderAspectRatio('light', { onLayout, accessibilityLabel: 'ratio' });
+    fireEvent(screen.getByLabelText('ratio'), 'layout', {
+      nativeEvent: { layout: { width: 100, height: 100, x: 0, y: 0 } },
+    });
+    expect(onLayout).toHaveBeenCalled();
+  });
+
+  it('supports accessibility props and testID', () => {
+    const { toJSON } = renderAspectRatio('light', {
+      accessible: true,
+      accessibilityLabel: 'media',
+      testID: 'ratio',
+    });
+    expect(screen.getByLabelText('media')).toBeTruthy();
+    expect(toJSON()?.props['data-testid']).toBe('ratio');
+  });
+
+  it('applies theme colors', () => {
+    const { unmount } = renderAspectRatio('light', {
+      accessibilityLabel: 'ratio',
+    });
+    expect(screen.getByLabelText('ratio')).toHaveStyle({
+      backgroundColor: hexToRgba(colors.light.background),
+    });
+    unmount();
+    renderAspectRatio('dark', { accessibilityLabel: 'ratio' });
+    expect(screen.getByLabelText('ratio')).toHaveStyle({
+      backgroundColor: hexToRgba(colors.dark.background),
+    });
+  });
+});

--- a/packages/ui-components/src/aspect-ratio.tsx
+++ b/packages/ui-components/src/aspect-ratio.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export interface AspectRatioProps extends React.ComponentProps<typeof View> {
+  ratio?: number;
+}
+
+export const AspectRatio: React.FC<AspectRatioProps> = ({
+  ratio = 1,
+  style,
+  children,
+  testID,
+  ...props
+}) => {
+  const { colors } = useTheme();
+  return (
+    <View
+      testID={testID}
+      style={[
+        styles.container,
+        { aspectRatio: ratio, backgroundColor: colors.background },
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    overflow: 'hidden',
+  },
+});
+
+export default AspectRatio;


### PR DESCRIPTION
## Summary
- add React Native AspectRatio component with theming
- cover AspectRatio with unit tests and storybook stories
- include jest-native matchers for better RN testing

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ce787434832f8d33a6555ec949cc