### PR TITLE
feat: add React Native badge component

### DIFF
--- a/apps/storybook/storybook/stories/badge.stories.tsx
+++ b/apps/storybook/storybook/stories/badge.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { Text } from 'react-native';
+import { Badge, type BadgeProps } from '@hum/ui-components';
+
+const ExampleBadge: React.FC<BadgeProps> = (props) => (
+  <Badge {...props}>
+    <Text>Badge</Text>
+  </Badge>
+);
+
+const meta: Meta<typeof ExampleBadge> = {
+  title: 'Components/Badge',
+  component: ExampleBadge,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'secondary', 'destructive', 'outline'],
+    },
+  },
+  args: {
+    variant: 'default',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ExampleBadge>;
+
+export const Basic: Story = {};
+export const Secondary: Story = { args: { variant: 'secondary' } };
+export const Destructive: Story = { args: { variant: 'destructive' } };

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -9,3 +9,5 @@ export {
 export type { AccordionProps } from './src/accordion';
 export { Alert, AlertTitle, AlertDescription } from './src/alert';
 export type { AlertProps, AlertVariant } from './src/alert';
+export { Badge } from './src/badge';
+export type { BadgeProps, BadgeVariant } from './src/badge';

--- a/packages/ui-components/src/__snapshots__/badge.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/badge.test.tsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Badge renders default and matches snapshot 1`] = `
+<div
+  className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-alignSelf-k200y r-borderWidth-rs99b7 r-flexDirection-18u37iz"
+  data-testid="badge"
+  dir={null}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  ref={[Function]}
+  style={
+    {
+      "backgroundColor": "rgba(254,202,26,1.00)",
+      "borderBottomColor": "rgba(0,0,0,0.00)",
+      "borderBottomLeftRadius": "10px",
+      "borderBottomRightRadius": "10px",
+      "borderLeftColor": "rgba(0,0,0,0.00)",
+      "borderRightColor": "rgba(0,0,0,0.00)",
+      "borderTopColor": "rgba(0,0,0,0.00)",
+      "borderTopLeftRadius": "10px",
+      "borderTopRightRadius": "10px",
+      "paddingBottom": "2px",
+      "paddingLeft": "8px",
+      "paddingRight": "8px",
+      "paddingTop": "2px",
+    }
+  }
+  tabIndex={0}
+>
+  <div
+    className="css-text-146c3p1 r-flexShrink-1wbh5a2"
+    dir="auto"
+    ref={[Function]}
+    style={
+      {
+        "color": "rgba(0,0,0,1.00)",
+        "fontSize": "12px",
+        "fontWeight": "500",
+      }
+    }
+  >
+    Badge
+  </div>
+</div>
+`;

--- a/packages/ui-components/src/badge.test.tsx
+++ b/packages/ui-components/src/badge.test.tsx
@@ -1,0 +1,67 @@
+/* eslint-disable react-native/no-raw-text */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import '@testing-library/jest-native/extend-expect';
+import { Text, Pressable } from 'react-native';
+import { Badge, type BadgeProps } from './badge';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+function renderBadge(
+  scheme: 'light' | 'dark' = 'light',
+  props?: Partial<BadgeProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <Badge testID="badge" {...props}>
+        Badge
+      </Badge>
+    </ThemeProvider>,
+  );
+}
+
+describe('Badge', () => {
+  it('renders default and matches snapshot', () => {
+    const { toJSON, UNSAFE_getByType } = renderBadge();
+    expect(UNSAFE_getByType(Text).props.children).toBe('Badge');
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('supports variants', () => {
+    const { UNSAFE_getByType, rerender } = renderBadge('light', {
+      variant: 'secondary',
+    });
+    expect(UNSAFE_getByType(Text)).toHaveStyle({
+      color: colors.light.secondaryForeground,
+    });
+    rerender(
+      <ThemeProvider forcedScheme="light">
+        <Badge testID="badge" variant="destructive">
+          Badge
+        </Badge>
+      </ThemeProvider>,
+    );
+    expect(UNSAFE_getByType(Text)).toHaveStyle({
+      color: colors.light.destructiveForeground,
+    });
+  });
+
+  it('calls onPress when provided', () => {
+    const onPress = jest.fn();
+    const { UNSAFE_getByType } = renderBadge('light', { onPress });
+    fireEvent.press(UNSAFE_getByType(Pressable));
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  it('applies theme colors', () => {
+    const { UNSAFE_getByType, unmount } = renderBadge('light');
+    expect(UNSAFE_getByType(Text)).toHaveStyle({
+      color: colors.light.humPrimaryForeground,
+    });
+    unmount();
+    const { UNSAFE_getByType: getByTypeDark } = renderBadge('dark');
+    expect(getByTypeDark(Text)).toHaveStyle({
+      color: colors.dark.humPrimaryForeground,
+    });
+  });
+});

--- a/packages/ui-components/src/badge.tsx
+++ b/packages/ui-components/src/badge.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import {
+  Pressable,
+  Text,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+  PressableProps,
+} from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline';
+
+export interface BadgeProps extends PressableProps {
+  variant?: BadgeVariant;
+  asChild?: boolean;
+  style?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
+  children?: React.ReactNode;
+  testID?: string;
+}
+
+export const badgeVariants = (
+  colors: ReturnType<typeof useTheme>['colors'],
+  variant: BadgeVariant,
+) => {
+  switch (variant) {
+    case 'secondary':
+      return {
+        container: {
+          backgroundColor: colors.secondary,
+          borderColor: 'transparent',
+        },
+        text: { color: colors.secondaryForeground },
+      } as const;
+    case 'destructive':
+      return {
+        container: {
+          backgroundColor: colors.destructive,
+          borderColor: 'transparent',
+        },
+        text: { color: colors.destructiveForeground },
+      } as const;
+    case 'outline':
+      return {
+        container: {
+          backgroundColor: 'transparent',
+          borderColor: colors.border,
+        },
+        text: { color: colors.foreground },
+      } as const;
+    default:
+      return {
+        container: {
+          backgroundColor: colors.humPrimary,
+          borderColor: 'transparent',
+        },
+        text: { color: colors.humPrimaryForeground },
+      } as const;
+  }
+};
+
+export const Badge: React.FC<BadgeProps> = ({
+  variant = 'default',
+  asChild = false,
+  style,
+  textStyle,
+  children,
+  testID,
+  ...props
+}) => {
+  const { colors, spacing, radius, type } = useTheme();
+  const variantStyle = badgeVariants(colors, variant);
+
+  const content = React.Children.toArray(children);
+
+  const renderedChildren = content.map((child, index) => {
+    const isLast = index === content.length - 1;
+    if (typeof child === 'string') {
+      return (
+        <Text
+          key={index}
+          style={[
+            styles.text,
+            {
+              color: variantStyle.text.color,
+              fontSize: type.size.sm,
+              fontWeight: type.weight.medium,
+            },
+            textStyle,
+          ]}
+        >
+          {child}
+        </Text>
+      );
+    }
+    if (React.isValidElement(child)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return React.cloneElement(child as any, {
+        key: index,
+        style: [
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (child as any).props.style,
+          !isLast && { marginRight: spacing.xs },
+        ],
+      });
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return child as any;
+  });
+
+  const baseStyle = [
+    styles.container,
+    {
+      paddingHorizontal: spacing.sm,
+      paddingVertical: spacing.xs / 2,
+      borderRadius: radius.md,
+      backgroundColor: variantStyle.container.backgroundColor,
+      borderColor: variantStyle.container.borderColor,
+    },
+    style,
+  ];
+
+  if (asChild && React.isValidElement(children)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return React.cloneElement(children as any, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      style: [baseStyle, (children as any).props.style],
+      testID,
+      ...props,
+    });
+  }
+
+  return (
+    <Pressable
+      accessibilityRole={props.onPress ? 'button' : 'text'}
+      testID={testID}
+      style={baseStyle}
+      {...props}
+    >
+      {renderedChildren}
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    alignSelf: 'flex-start',
+  },
+  text: {
+    flexShrink: 1,
+  },
+});
+
+export default Badge;

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
-    "types": ["jest"]
+    "types": ["jest", "react"]
   },
   "include": ["src", "**/*.ts", "**/*.tsx"],
   "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]


### PR DESCRIPTION
## Summary
- add themed Badge component with variant support
- document Badge variants in Storybook
- test Badge rendering, variants, theming, and interactivity

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ce80b234832f8ff4249505a35537