### PR TITLE
feat: add avatar component

### DIFF
--- a/apps/storybook/storybook/stories/avatar.stories.tsx
+++ b/apps/storybook/storybook/stories/avatar.stories.tsx
@@ -13,7 +13,7 @@ interface ExampleAvatarProps extends AvatarProps {
 }
 
 const ExampleAvatar: React.FC<ExampleAvatarProps> = ({
-  uri = 'https://placekitten.com/200/200',
+  uri = 'https://picsum.photos/200/200',
   ...props
 }) => (
   <Avatar {...props}>
@@ -31,7 +31,7 @@ const meta: Meta<typeof ExampleAvatar> = {
     size: { control: { type: 'number' } },
     uri: { control: 'text' },
   },
-  args: { size: 40, uri: 'https://placekitten.com/200/200' },
+  args: { size: 40, uri: 'https://picsum.photos/200/200' },
 };
 export default meta;
 

--- a/apps/storybook/storybook/stories/avatar.stories.tsx
+++ b/apps/storybook/storybook/stories/avatar.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { Text } from 'react-native';
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  type AvatarProps,
+} from '@hum/ui-components';
+
+interface ExampleAvatarProps extends AvatarProps {
+  uri?: string;
+}
+
+const ExampleAvatar: React.FC<ExampleAvatarProps> = ({
+  uri = 'https://placekitten.com/200/200',
+  ...props
+}) => (
+  <Avatar {...props}>
+    <AvatarImage source={{ uri }} />
+    <AvatarFallback>
+      <Text>AB</Text>
+    </AvatarFallback>
+  </Avatar>
+);
+
+const meta: Meta<typeof ExampleAvatar> = {
+  title: 'Components/Avatar',
+  component: ExampleAvatar,
+  argTypes: {
+    size: { control: { type: 'number' } },
+    uri: { control: 'text' },
+  },
+  args: { size: 40, uri: 'https://placekitten.com/200/200' },
+};
+export default meta;
+
+type Story = StoryObj<typeof ExampleAvatar>;
+
+export const Basic: Story = {};
+
+export const Fallback: Story = {
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarFallback>
+        <Text>AB</Text>
+      </AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const Large: Story = { args: { size: 80 } };

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -9,3 +9,9 @@ export {
 export type { AccordionProps } from './src/accordion';
 export { Alert, AlertTitle, AlertDescription } from './src/alert';
 export type { AlertProps, AlertVariant } from './src/alert';
+export { Avatar, AvatarImage, AvatarFallback } from './src/avatar';
+export type {
+  AvatarProps,
+  AvatarImageProps,
+  AvatarFallbackProps,
+} from './src/avatar';

--- a/packages/ui-components/src/__snapshots__/avatar.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/avatar.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Avatar renders fallback and matches snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-justifyContent-1777fci r-overflow-1udh08x"
+      data-testid="avatar"
+      role="img"
+      style="width: 40px; height: 40px; border-top-left-radius: 20px; border-top-right-radius: 20px; border-bottom-right-radius: 20px; border-bottom-left-radius: 20px;"
+      tabindex="0"
+    >
+      <div
+        class="css-view-g5y9jx r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci"
+        data-testid="fallback"
+        style="background-color: rgb(236, 236, 240);"
+      >
+        <div
+          class="css-text-146c3p1 r-textAlign-q4m81j"
+          dir="auto"
+          style="color: rgb(113, 113, 130); font-size: 16px; font-weight: 500;"
+        >
+          AB
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/ui-components/src/avatar.test.tsx
+++ b/packages/ui-components/src/avatar.test.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable react-native/no-raw-text */
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+// Temporary workaround for missing Jest Native matcher typings
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const expectAny = expect as any;
+
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  type AvatarProps,
+} from './avatar';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+function renderAvatar(
+  scheme: 'light' | 'dark' = 'light',
+  props?: Partial<AvatarProps>,
+  withImage = false,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <Avatar testID="avatar" {...props}>
+        {withImage && (
+          <AvatarImage
+            testID="image"
+            source={{ uri: 'https://example.com/avatar.png' }}
+          />
+        )}
+        <AvatarFallback testID="fallback">AB</AvatarFallback>
+      </Avatar>
+    </ThemeProvider>,
+  );
+}
+
+describe('Avatar', () => {
+  it('renders fallback and matches snapshot', () => {
+    const { baseElement } = renderAvatar();
+    expectAny(screen.getByTestId('fallback')).toBeInTheDocument();
+    expectAny(baseElement).toMatchSnapshot();
+  });
+
+  it('supports custom size', () => {
+    renderAvatar('light', { size: 80 });
+    expectAny(screen.getByTestId('avatar')).toHaveStyle({
+      width: '80px',
+      height: '80px',
+    });
+  });
+
+  it('shows fallback when image fails to load', () => {
+    renderAvatar('light', undefined, true);
+    const img = screen.getByAltText('');
+    fireEvent.error(img);
+    expectAny(screen.getByTestId('fallback')).toBeInTheDocument();
+  });
+
+  it('calls onPress when provided', () => {
+    const onPress = jest.fn();
+    renderAvatar('light', { onPress }, true);
+    fireEvent.click(screen.getByTestId('avatar'));
+    expectAny(onPress).toHaveBeenCalled();
+  });
+
+  it('applies theme colors', () => {
+    const { unmount } = renderAvatar('light');
+    expectAny(screen.getByTestId('fallback')).toHaveStyle({
+      backgroundColor: colors.light.muted,
+    });
+    unmount();
+    renderAvatar('dark');
+    expectAny(screen.getByTestId('fallback')).toHaveStyle({
+      backgroundColor: colors.dark.muted,
+    });
+  });
+
+  it('has appropriate accessibility role', () => {
+    renderAvatar();
+    expectAny(screen.getByTestId('avatar')).toHaveAttribute('role', 'img');
+  });
+});

--- a/packages/ui-components/src/avatar.tsx
+++ b/packages/ui-components/src/avatar.tsx
@@ -1,0 +1,150 @@
+import React, { createContext, useContext, useState, useMemo } from 'react';
+import {
+  Image,
+  Pressable,
+  PressableProps,
+  StyleProp,
+  StyleSheet,
+  Text,
+  TextStyle,
+  View,
+  ViewStyle,
+} from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+interface AvatarContextValue {
+  loaded: boolean;
+  setLoaded: (v: boolean) => void;
+}
+const AvatarCtx = createContext<AvatarContextValue | null>(null);
+const useAvatarContext = () => {
+  const ctx = useContext(AvatarCtx);
+  if (!ctx) throw new Error('Avatar components must be used within Avatar');
+  return ctx;
+};
+
+export interface AvatarProps extends PressableProps {
+  size?: number;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+export const Avatar: React.FC<AvatarProps> = ({
+  size = 40,
+  style,
+  children,
+  testID,
+  accessibilityRole,
+  ...props
+}) => {
+  const [loaded, setLoaded] = useState(false);
+  const value = useMemo(() => ({ loaded, setLoaded }), [loaded]);
+  return (
+    <AvatarCtx.Provider value={value}>
+      <Pressable
+        accessibilityRole={
+          accessibilityRole ?? (props.onPress ? 'button' : 'image')
+        }
+        style={[
+          styles.root,
+          { width: size, height: size, borderRadius: size / 2 },
+          style,
+        ]}
+        {...(testID ? { testID, 'data-testid': testID } : {})}
+        {...props}
+      >
+        {children}
+      </Pressable>
+    </AvatarCtx.Provider>
+  );
+};
+
+export interface AvatarImageProps
+  extends Omit<React.ComponentProps<typeof Image>, 'style'> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  style?: StyleProp<any>;
+  testID?: string;
+}
+
+export const AvatarImage: React.FC<AvatarImageProps> = ({
+  style,
+  testID,
+  ...props
+}) => {
+  const { setLoaded } = useAvatarContext();
+  return (
+    <Image
+      onLoad={() => setLoaded(true)}
+      onError={() => setLoaded(false)}
+      style={[styles.image, style]}
+      {...(testID ? { testID, 'data-testid': testID } : {})}
+      {...props}
+    />
+  );
+};
+
+export interface AvatarFallbackProps {
+  children?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
+  testID?: string;
+}
+
+export const AvatarFallback: React.FC<AvatarFallbackProps> = ({
+  children,
+  style,
+  textStyle,
+  testID,
+  ...props
+}) => {
+  const { colors, type } = useTheme();
+  const { loaded } = useAvatarContext();
+  if (loaded) return null;
+  return (
+    <View
+      style={[styles.fallback, { backgroundColor: colors.muted }, style]}
+      {...(testID ? { testID, 'data-testid': testID } : {})}
+      {...props}
+    >
+      {typeof children === 'string' ? (
+        <Text
+          style={[
+            styles.fallbackText,
+            {
+              color: colors.mutedForeground,
+              fontSize: type.size.md,
+              fontWeight: type.weight.medium,
+            },
+            textStyle,
+          ]}
+        >
+          {children}
+        </Text>
+      ) : (
+        children
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: {
+    overflow: 'hidden',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  fallback: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fallbackText: {
+    textAlign: 'center',
+  },
+});
+
+export { Avatar as default };


### PR DESCRIPTION
## Summary
- implement React Native Avatar with image and fallback
- add Storybook examples for Avatar
- test Avatar rendering, interaction, and theming

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ce7e7574832fb39e670239353d57