### PR TITLE
feat: add React Native button component

### DIFF
--- a/apps/storybook/storybook/stories/button.stories.tsx
+++ b/apps/storybook/storybook/stories/button.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '@hum/ui-components';
+
+const meta: Meta<typeof Button> = {
+  title: 'Components/Button',
+  component: Button,
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: [
+        'default',
+        'destructive',
+        'outline',
+        'secondary',
+        'ghost',
+        'link',
+      ],
+    },
+    size: {
+      control: 'select',
+      options: ['default', 'sm', 'lg', 'icon'],
+    },
+    disabled: { control: 'boolean' },
+  },
+  args: {
+    children: 'Press me',
+    variant: 'default',
+    size: 'default',
+    disabled: false,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Basic: Story = {};
+export const Destructive: Story = {
+  args: { variant: 'destructive', children: 'Delete' },
+};
+export const Large: Story = { args: { size: 'lg', children: 'Large Button' } };

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -9,3 +9,5 @@ export {
 export type { AccordionProps } from './src/accordion';
 export { Alert, AlertTitle, AlertDescription } from './src/alert';
 export type { AlertProps, AlertVariant } from './src/alert';
+export { Button } from './src/button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './src/button';

--- a/packages/ui-components/jest.setup.ts
+++ b/packages/ui-components/jest.setup.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import '@testing-library/jest-native/extend-expect';

--- a/packages/ui-components/src/__snapshots__/button.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/button.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Button renders and matches snapshot 1`] = `
+<DocumentFragment>
+  <button
+    class="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1777fci"
+    role="button"
+    style="height: 36px; padding: 8px 16px 8px 16px; border-top-left-radius: 10px; border-top-right-radius: 10px; border-bottom-right-radius: 10px; border-bottom-left-radius: 10px; background-color: rgb(254, 202, 26); opacity: 1;"
+    tabindex="0"
+    type="button"
+  >
+    <div
+      class="css-text-146c3p1"
+      dir="auto"
+      style="font-size: 14px; font-weight: 500; color: rgb(0, 0, 0);"
+    >
+      Press me
+    </div>
+  </button>
+</DocumentFragment>
+`;

--- a/packages/ui-components/src/button.test.tsx
+++ b/packages/ui-components/src/button.test.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable react-native/no-raw-text */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+// Temporary workaround for missing Jest DOM matcher typings
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const expectAny = expect as any;
+
+import { Button, type ButtonProps } from './button';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+type Scheme = 'light' | 'dark';
+
+function renderButton(scheme: Scheme = 'light', props?: Partial<ButtonProps>) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <Button {...props}>Press me</Button>
+    </ThemeProvider>,
+  );
+}
+
+describe('Button', () => {
+  it('renders and matches snapshot', () => {
+    const { asFragment } = renderButton();
+    expectAny(asFragment()).toMatchSnapshot();
+  });
+
+  it('handles variant and size styles', () => {
+    renderButton('light', { variant: 'destructive', size: 'lg' });
+    const button = screen.getByRole('button');
+    expectAny(button).toHaveStyle({
+      backgroundColor: colors.light.destructive,
+      height: '40px',
+    });
+  });
+
+  it('calls onPress and respects disabled', () => {
+    const onPress = jest.fn();
+    const { rerender } = renderButton('light', { onPress });
+    fireEvent.click(screen.getByRole('button'));
+    expectAny(onPress).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ThemeProvider forcedScheme="light">
+        <Button onPress={onPress} disabled>
+          Press me
+        </Button>
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expectAny(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies accessibility props', () => {
+    renderButton('light', { testID: 'btn', accessibilityLabel: 'test button' });
+    const button = screen.getByTestId('btn');
+    expectAny(button).toHaveAttribute('aria-label', 'test button');
+  });
+});

--- a/packages/ui-components/src/button.tsx
+++ b/packages/ui-components/src/button.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import {
+  Pressable,
+  Text,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+  PressableProps,
+} from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export type ButtonVariant =
+  | 'default'
+  | 'destructive'
+  | 'outline'
+  | 'secondary'
+  | 'ghost'
+  | 'link';
+export type ButtonSize = 'default' | 'sm' | 'lg' | 'icon';
+
+export interface ButtonProps extends PressableProps {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  asChild?: boolean;
+  style?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
+  children: React.ReactNode;
+}
+
+export const buttonVariants = {
+  variants: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+  sizes: ['default', 'sm', 'lg', 'icon'],
+} as const;
+
+export const Button: React.FC<ButtonProps> = ({
+  variant = 'default',
+  size = 'default',
+  asChild = false,
+  style,
+  textStyle,
+  children,
+  disabled,
+  ...props
+}) => {
+  const { colors, spacing, radius, type } = useTheme();
+
+  const variantStyle = React.useMemo(() => {
+    switch (variant) {
+      case 'destructive':
+        return {
+          container: { backgroundColor: colors.destructive },
+          text: { color: colors.destructiveForeground },
+          pressed: { opacity: 0.9 },
+        } as const;
+      case 'outline':
+        return {
+          container: {
+            backgroundColor: colors.background,
+            borderColor: colors.border,
+            borderWidth: 1,
+          },
+          text: { color: colors.foreground },
+          pressed: { backgroundColor: colors.accent },
+        } as const;
+      case 'secondary':
+        return {
+          container: { backgroundColor: colors.secondary },
+          text: { color: colors.secondaryForeground },
+          pressed: { opacity: 0.8 },
+        } as const;
+      case 'ghost':
+        return {
+          container: { backgroundColor: 'transparent' },
+          text: { color: colors.foreground },
+          pressed: { backgroundColor: colors.accent },
+        } as const;
+      case 'link':
+        return {
+          container: { backgroundColor: 'transparent' },
+          text: {
+            color: colors.humPrimary,
+            textDecorationLine: 'underline',
+          },
+          pressed: { opacity: 0.8 },
+        } as const;
+      case 'default':
+      default:
+        return {
+          container: { backgroundColor: colors.humPrimary },
+          text: { color: colors.humPrimaryForeground },
+          pressed: { opacity: 0.9 },
+        } as const;
+    }
+  }, [variant, colors]);
+
+  const sizeStyle = React.useMemo<ViewStyle>(() => {
+    switch (size) {
+      case 'sm':
+        return {
+          height: 32,
+          paddingHorizontal: spacing.md,
+          borderRadius: radius.md,
+        };
+      case 'lg':
+        return {
+          height: 40,
+          paddingHorizontal: spacing.xl,
+          borderRadius: radius.md,
+        };
+      case 'icon':
+        return {
+          width: 36,
+          height: 36,
+          borderRadius: radius.md,
+        };
+      case 'default':
+      default:
+        return {
+          height: 36,
+          paddingHorizontal: spacing.lg,
+          paddingVertical: spacing.sm,
+          borderRadius: radius.md,
+        };
+    }
+  }, [size, spacing, radius]);
+
+  const baseStyle = [
+    styles.base,
+    sizeStyle,
+    variantStyle.container,
+    { opacity: disabled ? 0.5 : 1 },
+    style,
+  ];
+
+  const textStyles = [
+    { fontSize: type.size.base, fontWeight: type.weight.medium },
+    variantStyle.text,
+    textStyle,
+  ];
+
+  const content =
+    typeof children === 'string' ? (
+      <Text style={textStyles}>{children}</Text>
+    ) : (
+      children
+    );
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(
+      children as React.ReactElement<Record<string, unknown>>,
+      {
+        ...(props as Record<string, unknown>),
+        disabled,
+        style: [baseStyle, (children.props as Record<string, unknown>)?.style],
+      },
+    );
+  }
+
+  return (
+    <Pressable
+      accessible
+      accessibilityRole="button"
+      disabled={disabled}
+      style={({ pressed }: { pressed: boolean }) => [
+        baseStyle,
+        pressed && variantStyle.pressed,
+      ]}
+      {...props}
+    >
+      {content}
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  base: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default Button;

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
-    "types": ["jest"]
+    "types": ["jest", "react", "react-native"]
   },
   "include": ["src", "**/*.ts", "**/*.tsx"],
   "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]


### PR DESCRIPTION
## Summary
- implement themed React Native button component
- add Storybook stories for button variants
- cover button behaviors with tests

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:start` *(fails: unable to find package.json for @hum/ui-components)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ce8b47c0832fb880116a73246286