### PR TITLE
feat: add React Native breadcrumb

### DIFF
--- a/apps/storybook/storybook/stories/breadcrumb.stories.tsx
+++ b/apps/storybook/storybook/stories/breadcrumb.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+} from '@hum/ui-components';
+import { Text } from 'react-native';
+
+interface ExampleProps {
+  secondLabel: string;
+}
+
+const ExampleBreadcrumb: React.FC<ExampleProps> = ({ secondLabel }) => (
+  <Breadcrumb>
+    <BreadcrumbList>
+      <BreadcrumbItem>
+        <BreadcrumbLink onPress={() => {}}>
+          <Text>Home</Text>
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbLink onPress={() => {}}>
+          <Text>{secondLabel}</Text>
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbPage>
+          <Text>Current</Text>
+        </BreadcrumbPage>
+      </BreadcrumbItem>
+    </BreadcrumbList>
+  </Breadcrumb>
+);
+
+const meta: Meta<typeof ExampleBreadcrumb> = {
+  title: 'Components/Breadcrumb',
+  component: ExampleBreadcrumb,
+  argTypes: {
+    secondLabel: { control: 'text' },
+  },
+  args: {
+    secondLabel: 'Projects',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ExampleBreadcrumb>;
+
+export const Basic: Story = {};
+
+export const WithEllipsis: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink onPress={() => {}}>
+            <Text>Home</Text>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbEllipsis />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>
+            <Text>Current</Text>
+          </BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+export const CustomSeparator: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink onPress={() => {}}>
+            <Text>Home</Text>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>
+          <Text>/</Text>
+        </BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbLink onPress={() => {}}>
+            <Text>Library</Text>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>
+          <Text>/</Text>
+        </BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbPage>
+            <Text>Page</Text>
+          </BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -25,3 +25,21 @@ export { Alert, AlertTitle, AlertDescription } from './src/alert';
 export type { AlertProps, AlertVariant } from './src/alert';
 export { AspectRatio } from './src/aspect-ratio';
 export type { AspectRatioProps } from './src/aspect-ratio';
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+} from './src/breadcrumb';
+export type {
+  BreadcrumbProps,
+  BreadcrumbListProps,
+  BreadcrumbItemProps,
+  BreadcrumbLinkProps,
+  BreadcrumbPageProps,
+  BreadcrumbSeparatorProps,
+  BreadcrumbEllipsisProps,
+} from './src/breadcrumb';

--- a/packages/ui-components/src/__snapshots__/breadcrumb.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/breadcrumb.test.tsx.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Breadcrumb renders and matches snapshot 1`] = `
+<div
+  aria-label="breadcrumb"
+  className="css-view-g5y9jx"
+  data-testid="nav"
+  dir={null}
+  ref={[Function]}
+>
+  <div
+    className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-flexWrap-1w6e6rj"
+    dir={null}
+    ref={[Function]}
+  >
+    <div
+      className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+      dir={null}
+      ref={[Function]}
+      style={
+        {
+          "marginRight": "4px",
+        }
+      }
+    >
+      <div
+        aria-label="home"
+        className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73"
+        dir={null}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        ref={[Function]}
+        role="link"
+        tabIndex={0}
+      >
+        <div
+          className="css-text-146c3p1"
+          dir="auto"
+          ref={[Function]}
+        >
+          Home
+        </div>
+      </div>
+    </div>
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "fontSize": "12px",
+          "marginLeft": "4px",
+          "marginRight": "4px",
+        }
+      }
+    >
+      ›
+    </div>
+    <div
+      className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+      dir={null}
+      ref={[Function]}
+      style={
+        {
+          "marginRight": "4px",
+        }
+      }
+    >
+      <div
+        aria-label="current"
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        <span
+          className="css-textHasAncestor-1jxf684"
+          dir={null}
+          ref={[Function]}
+        >
+          Library
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/ui-components/src/breadcrumb.test.tsx
+++ b/packages/ui-components/src/breadcrumb.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import '@testing-library/jest-native/extend-expect';
+// Temporary workaround for missing Jest Native matcher typings
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const expectAny = expect as any;
+
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+} from './breadcrumb';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+const hexToRgba = (hex: string) => {
+  const bigint = parseInt(hex.slice(1), 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r},${g},${b},1.00)`;
+};
+
+function renderBreadcrumb(scheme: 'light' | 'dark' = 'light') {
+  const onPress = jest.fn();
+  const result = render(
+    <ThemeProvider forcedScheme={scheme}>
+      <Breadcrumb accessibilityLabel="breadcrumb" testID="nav">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink onPress={onPress} accessibilityLabel="home">
+              <Text>Home</Text>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage accessibilityLabel="current">
+              <Text>Library</Text>
+            </BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+    </ThemeProvider>,
+  );
+  return { onPress, ...result };
+}
+
+describe('Breadcrumb', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderBreadcrumb();
+    expectAny(toJSON()).toMatchSnapshot();
+  });
+
+  it('handles press events', () => {
+    const { onPress } = renderBreadcrumb();
+    fireEvent.press(screen.getByLabelText('home'));
+    expectAny(onPress).toHaveBeenCalled();
+  });
+
+  it('applies theme colors', () => {
+    const { unmount } = renderBreadcrumb('light');
+    expectAny(screen.getByLabelText('current')).toHaveStyle({
+      color: hexToRgba(colors.light.foreground),
+    });
+    unmount();
+    renderBreadcrumb('dark');
+    expectAny(screen.getByLabelText('current')).toHaveStyle({
+      color: hexToRgba(colors.dark.foreground),
+    });
+  });
+
+  it('supports accessibility props', () => {
+    renderBreadcrumb();
+    expectAny(screen.getByLabelText('home')).toBeTruthy();
+  });
+
+  it('renders ellipsis with label', () => {
+    render(
+      <ThemeProvider forcedScheme="light">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbEllipsis accessibilityLabel="more" />
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </ThemeProvider>,
+    );
+    expectAny(screen.getByLabelText('more')).toBeTruthy();
+  });
+});

--- a/packages/ui-components/src/breadcrumb.tsx
+++ b/packages/ui-components/src/breadcrumb.tsx
@@ -1,0 +1,175 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  ViewProps,
+  TextProps,
+  PressableProps,
+  StyleProp,
+  TextStyle,
+} from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export type BreadcrumbProps = ViewProps;
+
+export const Breadcrumb: React.FC<BreadcrumbProps> = ({ style, ...props }) => (
+  <View accessibilityLabel="breadcrumb" style={style} {...props} />
+);
+
+export type BreadcrumbListProps = ViewProps;
+export const BreadcrumbList: React.FC<BreadcrumbListProps> = ({
+  style,
+  ...props
+}) => {
+  return <View style={[styles.list, style]} {...props} />;
+};
+
+export type BreadcrumbItemProps = ViewProps;
+export const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({
+  style,
+  ...props
+}) => {
+  const { spacing } = useTheme();
+  return (
+    <View
+      style={[styles.item, { marginRight: spacing.xs }, style]}
+      {...props}
+    />
+  );
+};
+
+export interface BreadcrumbLinkProps extends Omit<PressableProps, 'children'> {
+  asChild?: boolean;
+  textStyle?: StyleProp<TextStyle>;
+  children: React.ReactNode;
+}
+
+export const BreadcrumbLink: React.FC<BreadcrumbLinkProps> = ({
+  asChild,
+  children,
+  textStyle,
+  style,
+  ...props
+}) => {
+  const { colors, type } = useTheme();
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children as React.ReactElement, props);
+  }
+
+  return (
+    <Pressable accessibilityRole="link" style={style} {...props}>
+      {({ pressed }: { pressed: boolean }) =>
+        typeof children === 'string' ? (
+          <Text
+            style={[
+              styles.linkText,
+              {
+                color: pressed ? colors.foreground : colors.humPrimary,
+                fontSize: type.size.sm,
+              },
+              textStyle,
+            ]}
+          >
+            {children}
+          </Text>
+        ) : (
+          children
+        )
+      }
+    </Pressable>
+  );
+};
+
+export type BreadcrumbPageProps = TextProps;
+export const BreadcrumbPage: React.FC<BreadcrumbPageProps> = ({
+  style,
+  ...props
+}) => {
+  const { colors, type } = useTheme();
+  return (
+    <Text
+      accessibilityRole="text"
+      accessibilityState={{ disabled: true }}
+      style={[
+        {
+          color: colors.foreground,
+          fontSize: type.size.sm,
+          fontWeight: type.weight.normal,
+        },
+        style,
+      ]}
+      {...props}
+    />
+  );
+};
+
+export type BreadcrumbSeparatorProps = TextProps;
+export const BreadcrumbSeparator: React.FC<BreadcrumbSeparatorProps> = ({
+  children,
+  style,
+  ...props
+}) => {
+  const { colors, type, spacing } = useTheme();
+  return (
+    <Text
+      accessibilityElementsHidden
+      importantForAccessibility="no"
+      style={[
+        {
+          color: colors.mutedForeground,
+          marginHorizontal: spacing.xs,
+          fontSize: type.size.sm,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      {children ?? '›'}
+    </Text>
+  );
+};
+
+export type BreadcrumbEllipsisProps = TextProps;
+export const BreadcrumbEllipsis: React.FC<BreadcrumbEllipsisProps> = ({
+  style,
+  ...props
+}) => {
+  const { colors, type, spacing } = useTheme();
+  return (
+    <Text
+      accessibilityLabel="More"
+      style={[
+        {
+          color: colors.mutedForeground,
+          marginHorizontal: spacing.xs,
+          fontSize: type.size.sm,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      …
+    </Text>
+  );
+};
+
+const styles = StyleSheet.create({
+  list: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  linkText: {
+    textDecorationLine: 'none',
+  },
+});
+
+export default Breadcrumb;


### PR DESCRIPTION
## Summary
- add themable React Native `Breadcrumb` component and exports
- document Breadcrumb variants in Storybook
- cover breadcrumb interactions and theming with @testing-library/react-native tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `CI=true pnpm storybook:start`

------
https://chatgpt.com/codex/tasks/task_e_68b2ce86e2b4832fb5e7ea29c23e427f