### PR TITLE
feat: add react-native carousel component

### DIFF
--- a/apps/storybook/storybook/stories/carousel.stories.tsx
+++ b/apps/storybook/storybook/stories/carousel.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from '@hum/ui-components';
+import type { CarouselProps } from '@hum/ui-components';
+
+const styles = StyleSheet.create({
+  slide: {
+    height: 200,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FECA1A',
+    borderRadius: 8,
+    margin: 8,
+  },
+});
+
+const Slide: React.FC<{ label: string }> = ({ label }) => (
+  <View style={styles.slide}>
+    <Text>{label}</Text>
+  </View>
+);
+
+const ExampleCarousel: React.FC<CarouselProps> = (props) => (
+  <Carousel {...props}>
+    <CarouselContent>
+      <CarouselItem>
+        <Slide label="Slide 1" />
+      </CarouselItem>
+      <CarouselItem>
+        <Slide label="Slide 2" />
+      </CarouselItem>
+      <CarouselItem>
+        <Slide label="Slide 3" />
+      </CarouselItem>
+    </CarouselContent>
+    <CarouselPrevious />
+    <CarouselNext />
+  </Carousel>
+);
+
+const meta: Meta<typeof ExampleCarousel> = {
+  title: 'Components/Carousel',
+  component: ExampleCarousel,
+  argTypes: {
+    orientation: { control: 'select', options: ['horizontal', 'vertical'] },
+  },
+  args: { orientation: 'horizontal' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ExampleCarousel>;
+
+export const Basic: Story = {};
+export const Vertical: Story = { args: { orientation: 'vertical' } };

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -25,3 +25,11 @@ export { Alert, AlertTitle, AlertDescription } from './src/alert';
 export type { AlertProps, AlertVariant } from './src/alert';
 export { AspectRatio } from './src/aspect-ratio';
 export type { AspectRatioProps } from './src/aspect-ratio';
+export {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from './src/carousel';
+export type { CarouselApi, CarouselProps } from './src/carousel';

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.12",
+    "@types/react-native": "0.73.0",
     "react-native-safe-area-context": "5.4.0"
   },
   "dependencies": {

--- a/packages/ui-components/src/__snapshots__/carousel.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/carousel.test.tsx.snap
@@ -1,0 +1,154 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Carousel renders and matches snapshot 1`] = `
+<div
+  className="css-view-g5y9jx r-overflow-1udh08x r-position-bnwqim"
+  dir={null}
+  ref={[Function]}
+  role="slider"
+>
+  <div
+    className="css-view-g5y9jx r-WebkitOverflowScrolling-150rngu r-flexDirection-18u37iz r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-lltvgl r-overflowY-buy8e9 r-transform-agouwx r-scrollSnapType-mfh4gg r-scrollbarWidth-2eszeu"
+    dir={null}
+    onScroll={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    onWheel={[Function]}
+    ref={[Function]}
+  >
+    <div
+      className="css-view-g5y9jx r-flexDirection-18u37iz"
+      dir={null}
+      ref={[Function]}
+    >
+      <div
+        className="css-view-g5y9jx r-scrollSnapAlign-cpa5s6"
+        dir={null}
+        ref={[Function]}
+      >
+        <div
+          className="css-view-g5y9jx"
+          dir={null}
+          ref={[Function]}
+          style={
+            {
+              "width": "0px",
+            }
+          }
+        >
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+          >
+            Slide 1
+          </div>
+        </div>
+      </div>
+      <div
+        className="css-view-g5y9jx r-scrollSnapAlign-cpa5s6"
+        dir={null}
+        ref={[Function]}
+      >
+        <div
+          className="css-view-g5y9jx"
+          dir={null}
+          ref={[Function]}
+          style={
+            {
+              "width": "0px",
+            }
+          }
+        >
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+          >
+            Slide 2
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    aria-disabled={true}
+    aria-label="Previous slide"
+    className="css-view-g5y9jx r-pointerEvents-12vffkv r-alignItems-1awozwy r-height-mabqd8 r-justifyContent-1777fci r-position-u8s1d r-width-1yvhtrz r-opacity-icoktb"
+    dir={null}
+    disabled={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    ref={[Function]}
+    role="button"
+    style={
+      {
+        "backgroundColor": "rgba(254,202,26,1.00)",
+        "borderBottomLeftRadius": "10px",
+        "borderBottomRightRadius": "10px",
+        "borderTopLeftRadius": "10px",
+        "borderTopRightRadius": "10px",
+        "bottom": "12px",
+        "left": "12px",
+      }
+    }
+    tabIndex={-1}
+    type="button"
+  >
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(0,0,0,1.00)",
+        }
+      }
+    >
+      ←
+    </div>
+  </button>
+  <button
+    aria-label="Next slide"
+    className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-height-mabqd8 r-justifyContent-1777fci r-position-u8s1d r-width-1yvhtrz"
+    dir={null}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    ref={[Function]}
+    role="button"
+    style={
+      {
+        "backgroundColor": "rgba(254,202,26,1.00)",
+        "borderBottomLeftRadius": "10px",
+        "borderBottomRightRadius": "10px",
+        "borderTopLeftRadius": "10px",
+        "borderTopRightRadius": "10px",
+        "bottom": "12px",
+        "right": "12px",
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(0,0,0,1.00)",
+        }
+      }
+    >
+      →
+    </div>
+  </button>
+</div>
+`;

--- a/packages/ui-components/src/carousel.test.tsx
+++ b/packages/ui-components/src/carousel.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Text, PressableProps } from 'react-native';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+  type CarouselProps,
+  type CarouselApi,
+} from './carousel';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+const hexToRgba = (hex: string) => {
+  const bigint = parseInt(hex.slice(1), 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r},${g},${b},1.00)`;
+};
+
+function renderCarousel(
+  scheme: 'light' | 'dark' = 'light',
+  props?: Partial<CarouselProps>,
+  nextProps?: Partial<PressableProps>,
+  prevProps?: Partial<PressableProps>,
+) {
+  let api: CarouselApi | undefined;
+  const setApi = (a: CarouselApi) => {
+    api = a;
+  };
+  const utils = render(
+    <ThemeProvider forcedScheme={scheme}>
+      <Carousel setApi={setApi} {...props}>
+        <CarouselContent>
+          <CarouselItem>
+            <Text>Slide 1</Text>
+          </CarouselItem>
+          <CarouselItem>
+            <Text>Slide 2</Text>
+          </CarouselItem>
+        </CarouselContent>
+        <CarouselPrevious {...prevProps} />
+        <CarouselNext {...nextProps} />
+      </Carousel>
+    </ThemeProvider>,
+  );
+  return { ...utils, api: api! };
+}
+
+describe('Carousel', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderCarousel();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('next button triggers onPress callback', () => {
+    const onPress = jest.fn();
+    renderCarousel('light', {}, { onPress });
+    fireEvent.press(screen.getByLabelText('Next slide'));
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  it('previous button disabled initially', () => {
+    renderCarousel();
+    const prev = screen.getByLabelText('Previous slide');
+    expect(prev).toBeDisabled();
+  });
+
+  it('applies theme colors', () => {
+    const { unmount } = renderCarousel('light');
+    expect(screen.getByLabelText('Next slide')).toHaveStyle({
+      backgroundColor: hexToRgba(colors.light.humPrimary),
+    });
+    unmount();
+    renderCarousel('dark');
+    expect(screen.getByLabelText('Next slide')).toHaveStyle({
+      backgroundColor: hexToRgba(colors.dark.humPrimary),
+    });
+  });
+});

--- a/packages/ui-components/src/carousel.tsx
+++ b/packages/ui-components/src/carousel.tsx
@@ -1,0 +1,318 @@
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  createContext,
+  useContext,
+  ReactNode,
+} from 'react';
+import {
+  View,
+  // @ts-expect-error react-native-web lacks type exports
+  ScrollView,
+  Pressable,
+  StyleSheet,
+  ViewProps,
+  PressableProps,
+  StyleProp,
+  ViewStyle,
+  // @ts-expect-error react-native-web lacks type exports
+  LayoutChangeEvent,
+  // @ts-expect-error react-native-web lacks type exports
+  NativeScrollEvent,
+  // @ts-expect-error react-native-web lacks type exports
+  NativeSyntheticEvent,
+  Text,
+  GestureResponderEvent,
+} from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export interface CarouselApi {
+  scrollNext: () => void;
+  scrollPrev: () => void;
+  scrollTo: (index: number) => void;
+  selectedIndex: number;
+  canScrollPrev: () => boolean;
+  canScrollNext: () => boolean;
+}
+
+export interface CarouselProps extends ViewProps {
+  children: ReactNode;
+  orientation?: 'horizontal' | 'vertical';
+  setApi?: (api: CarouselApi) => void;
+}
+
+interface CarouselContextValue {
+  orientation: 'horizontal' | 'vertical';
+  scrollRef: React.RefObject<ScrollView | null>;
+  size: { width: number; height: number };
+  setSize: (w: number, h: number) => void;
+  totalItems: number;
+  setTotalItems: (n: number) => void;
+  currentIndex: number;
+  setCurrentIndex: (i: number) => void;
+  scrollNext: () => void;
+  scrollPrev: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+}
+
+const CarouselContext = createContext<CarouselContextValue | null>(null);
+
+export const useCarousel = () => {
+  const ctx = useContext(CarouselContext);
+  if (!ctx) throw new Error('useCarousel must be used within Carousel');
+  return ctx;
+};
+
+export const Carousel: React.FC<CarouselProps> = ({
+  children,
+  orientation = 'horizontal',
+  setApi,
+  style,
+  ...props
+}) => {
+  const scrollRef = useRef<ScrollView | null>(null);
+  const [size, setSizeState] = useState({ width: 0, height: 0 });
+  const [totalItems, setTotalItems] = useState(0);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const scrollTo = useCallback(
+    (index: number) => {
+      if (orientation === 'horizontal') {
+        scrollRef.current?.scrollTo?.({
+          x: size.width * index,
+          animated: true,
+        });
+      } else {
+        scrollRef.current?.scrollTo?.({
+          y: size.height * index,
+          animated: true,
+        });
+      }
+      setCurrentIndex(index);
+    },
+    [orientation, size.height, size.width],
+  );
+
+  const scrollNext = useCallback(() => {
+    if (currentIndex < totalItems - 1) {
+      scrollTo(currentIndex + 1);
+    }
+  }, [currentIndex, totalItems, scrollTo]);
+
+  const scrollPrev = useCallback(() => {
+    if (currentIndex > 0) {
+      scrollTo(currentIndex - 1);
+    }
+  }, [currentIndex, scrollTo]);
+
+  const api = React.useMemo<CarouselApi>(
+    () => ({
+      scrollNext,
+      scrollPrev,
+      scrollTo,
+      selectedIndex: currentIndex,
+      canScrollPrev: () => currentIndex > 0,
+      canScrollNext: () => currentIndex < totalItems - 1,
+    }),
+    [scrollNext, scrollPrev, scrollTo, currentIndex, totalItems],
+  );
+
+  useEffect(() => {
+    setApi?.(api);
+  }, [api, setApi]);
+
+  const setSize = useCallback((w: number, h: number) => {
+    setSizeState({ width: w, height: h });
+  }, []);
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        orientation,
+        scrollRef,
+        size,
+        setSize,
+        totalItems,
+        setTotalItems,
+        currentIndex,
+        setCurrentIndex,
+        scrollNext,
+        scrollPrev,
+        canScrollPrev: currentIndex > 0,
+        canScrollNext: currentIndex < totalItems - 1,
+      }}
+    >
+      <View
+        style={[styles.root, style]}
+        accessibilityRole="adjustable"
+        {...props}
+      >
+        {children}
+      </View>
+    </CarouselContext.Provider>
+  );
+};
+
+export const CarouselContent: React.FC<ViewProps> = ({
+  children,
+  style,
+  ...props
+}) => {
+  const { orientation, scrollRef, setSize, setTotalItems, setCurrentIndex } =
+    useCarousel();
+
+  useEffect(() => {
+    setTotalItems(React.Children.count(children));
+  }, [children, setTotalItems]);
+
+  const handleLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    setSize(width, height);
+  };
+
+  const handleMomentumEnd = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const offset =
+      orientation === 'horizontal'
+        ? e.nativeEvent.contentOffset.x
+        : e.nativeEvent.contentOffset.y;
+    const measurement =
+      orientation === 'horizontal'
+        ? e.nativeEvent.layoutMeasurement.width
+        : e.nativeEvent.layoutMeasurement.height;
+    const index = measurement ? Math.round(offset / measurement) : 0;
+    setCurrentIndex(index);
+  };
+
+  return (
+    <ScrollView
+      ref={scrollRef}
+      horizontal={orientation === 'horizontal'}
+      pagingEnabled
+      showsHorizontalScrollIndicator={false}
+      showsVerticalScrollIndicator={false}
+      onLayout={handleLayout}
+      onMomentumScrollEnd={handleMomentumEnd}
+      contentContainerStyle={[
+        orientation === 'horizontal' ? styles.horizontal : undefined,
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </ScrollView>
+  );
+};
+
+export const CarouselItem: React.FC<ViewProps> = ({
+  children,
+  style,
+  ...props
+}) => {
+  const { orientation, size } = useCarousel();
+  const itemStyle =
+    orientation === 'horizontal'
+      ? { width: size.width }
+      : { height: size.height };
+  return (
+    <View style={[itemStyle, style]} {...props}>
+      {typeof children === 'string' ? <Text>{children}</Text> : children}
+    </View>
+  );
+};
+
+interface CarouselButtonProps extends PressableProps {
+  style?: StyleProp<ViewStyle>;
+}
+
+export const CarouselPrevious: React.FC<CarouselButtonProps> = ({
+  style,
+  onPress,
+  ...props
+}) => {
+  const { colors, radius, spacing } = useTheme();
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+  const position: ViewStyle =
+    orientation === 'horizontal'
+      ? { left: spacing.md, bottom: spacing.md }
+      : { top: spacing.md, left: '50%', marginLeft: -16 };
+  const icon = orientation === 'horizontal' ? '←' : '↑';
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Previous slide"
+      onPress={(e: GestureResponderEvent) => {
+        scrollPrev();
+        onPress?.(e);
+      }}
+      disabled={!canScrollPrev}
+      style={[
+        styles.navButton,
+        {
+          backgroundColor: colors.humPrimary,
+          borderRadius: radius.md,
+        },
+        position,
+        !canScrollPrev && styles.disabled,
+        style,
+      ]}
+      {...props}
+    >
+      <Text style={{ color: colors.humPrimaryForeground }}>{icon}</Text>
+    </Pressable>
+  );
+};
+
+export const CarouselNext: React.FC<CarouselButtonProps> = ({
+  style,
+  onPress,
+  ...props
+}) => {
+  const { colors, radius, spacing } = useTheme();
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+  const position: ViewStyle =
+    orientation === 'horizontal'
+      ? { right: spacing.md, bottom: spacing.md }
+      : { bottom: spacing.md, left: '50%', marginLeft: -16 };
+  const icon = orientation === 'horizontal' ? '→' : '↓';
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Next slide"
+      onPress={(e: GestureResponderEvent) => {
+        scrollNext();
+        onPress?.(e);
+      }}
+      disabled={!canScrollNext}
+      style={[
+        styles.navButton,
+        {
+          backgroundColor: colors.humPrimary,
+          borderRadius: radius.md,
+        },
+        position,
+        !canScrollNext && styles.disabled,
+        style,
+      ]}
+      {...props}
+    >
+      <Text style={{ color: colors.humPrimaryForeground }}>{icon}</Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: { position: 'relative', overflow: 'hidden' },
+  horizontal: { flexDirection: 'row' },
+  navButton: {
+    position: 'absolute',
+    width: 32,
+    height: 32,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  disabled: { opacity: 0.5 },
+});
+export default Carousel;

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
-    "types": ["jest"]
+    "types": ["react", "react-native", "jest"]
   },
   "include": ["src", "**/*.ts", "**/*.tsx"],
   "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@types/react':
         specifier: ^19.1.12
         version: 19.1.12
+      '@types/react-native':
+        specifier: 0.73.0
+        version: 0.73.0(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
       react-native-safe-area-context:
         specifier: 5.4.0
         version: 5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
@@ -8869,6 +8872,18 @@ snapshots:
   '@types/node@24.3.0':
     dependencies:
       undici-types: 7.10.0
+
+  '@types/react-native@0.73.0(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-community/cli'
+      - '@types/react'
+      - bufferutil
+      - react
+      - supports-color
+      - utf-8-validate
 
   '@types/react-native@0.73.0(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)':
     dependencies:

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -4,7 +4,9 @@
     "types": [
       "jest",
       "@testing-library/jest-dom",
-      "@testing-library/jest-native"
+      "@testing-library/jest-native",
+      "react",
+      "react-native"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add themed Carousel components with prev/next controls
- document Carousel in Storybook
- test Carousel interactions and theming

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:start`


------
https://chatgpt.com/codex/tasks/task_e_68b2d42b57ac832f8900e2cf8711c61a