### PR TITLE
feat: add Card component

### DIFF
--- a/apps/storybook/storybook/stories/card.stories.tsx
+++ b/apps/storybook/storybook/stories/card.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { Text, Pressable, StyleSheet } from 'react-native';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+  CardAction,
+} from '@hum/ui-components';
+
+interface ExampleCardProps {
+  title: string;
+  description: string;
+  content: string;
+}
+
+const ExampleCard: React.FC<ExampleCardProps> = ({
+  title,
+  description,
+  content,
+}) => (
+  <Card>
+    <CardHeader>
+      <CardTitle>
+        <Text>{title}</Text>
+      </CardTitle>
+      <CardDescription>
+        <Text>{description}</Text>
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Text>{content}</Text>
+    </CardContent>
+  </Card>
+);
+
+const meta: Meta<typeof ExampleCard> = {
+  title: 'Components/Card',
+  component: ExampleCard,
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    content: { control: 'text' },
+  },
+  args: {
+    title: 'Card Title',
+    description: 'Card Description',
+    content: 'This is some card content.',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ExampleCard>;
+
+export const Basic: Story = {};
+
+export const WithAction: Story = {
+  render: (args) => (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Text>{args.title}</Text>
+        </CardTitle>
+        <CardDescription>
+          <Text>{args.description}</Text>
+        </CardDescription>
+        <CardAction>
+          <Pressable
+            onPress={() => console.log('Pressed')}
+            accessibilityRole="button"
+          >
+            <Text>Action</Text>
+          </Pressable>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        <Text>{args.content}</Text>
+      </CardContent>
+      <CardFooter>
+        <Text>Footer</Text>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+export const CustomStyle: Story = {
+  render: (args) => (
+    <Card style={styles.custom}>
+      <CardHeader>
+        <CardTitle>
+          <Text>{args.title}</Text>
+        </CardTitle>
+        <CardDescription>
+          <Text>{args.description}</Text>
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Text>{args.content}</Text>
+      </CardContent>
+    </Card>
+  ),
+};
+
+const styles = StyleSheet.create({
+  custom: { borderWidth: 2 },
+});

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -25,3 +25,12 @@ export { Alert, AlertTitle, AlertDescription } from './src/alert';
 export type { AlertProps, AlertVariant } from './src/alert';
 export { AspectRatio } from './src/aspect-ratio';
 export type { AspectRatioProps } from './src/aspect-ratio';
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+} from './src/card';

--- a/packages/ui-components/src/__snapshots__/card.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/card.test.tsx.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Card renders and matches snapshot 1`] = `
+<body>
+  <div>
+    <section
+      class="css-view-g5y9jx r-borderWidth-rs99b7 r-flexDirection-eqz5dr"
+      data-testid="card"
+      role="region"
+      style="background-color: rgb(255, 255, 255); border-top-color: rgba(0, 0, 0, 0.1); border-right-color: rgba(0, 0, 0, 0.1); border-bottom-color: rgba(0, 0, 0, 0.1); border-left-color: rgba(0, 0, 0, 0.1); border-top-left-radius: 16px; border-top-right-radius: 16px; border-bottom-right-radius: 16px; border-bottom-left-radius: 16px;"
+    >
+      <div
+        class="css-view-g5y9jx r-alignItems-1habvwh r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+        style="padding-right: 24px; padding-left: 24px; padding-top: 24px;"
+      >
+        <div
+          class="css-view-g5y9jx r-flex-13awgt0"
+        >
+          <h1
+            class="css-text-146c3p1 r-marginBottom-15zivkp"
+            data-testid="title"
+            dir="auto"
+            role="heading"
+            style="color: rgb(10, 10, 10); font-size: 18px; font-weight: 700;"
+          >
+            Title
+          </h1>
+          <div
+            class="css-text-146c3p1 r-marginTop-1bymd8e"
+            data-testid="description"
+            dir="auto"
+            style="color: rgb(113, 113, 130); font-size: 14px; line-height: 24px;"
+          >
+            Description
+          </div>
+        </div>
+        <div
+          class="css-view-g5y9jx r-alignSelf-k200y"
+        >
+          <button
+            class="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73"
+            data-testid="action"
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="css-text-146c3p1"
+              dir="auto"
+            >
+              Action
+            </div>
+          </button>
+        </div>
+      </div>
+      <div
+        class="css-view-g5y9jx"
+        style="padding-right: 24px; padding-left: 24px; padding-bottom: 24px;"
+      >
+        <div
+          class="css-text-146c3p1"
+          data-testid="content"
+          dir="auto"
+        >
+          Content
+        </div>
+      </div>
+      <div
+        class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+        style="padding-right: 24px; padding-left: 24px; padding-bottom: 24px;"
+      >
+        <div
+          class="css-text-146c3p1"
+          data-testid="footer"
+          dir="auto"
+        >
+          Footer
+        </div>
+      </div>
+    </section>
+  </div>
+</body>
+`;

--- a/packages/ui-components/src/card.test.tsx
+++ b/packages/ui-components/src/card.test.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable react-native/no-raw-text */
+import React from 'react';
+import { Text, Pressable } from 'react-native';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardAction,
+  CardContent,
+  CardFooter,
+} from './card';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+// Temporary workaround for missing Jest matcher typings
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const expectAny = expect as any;
+
+function renderCard(scheme: 'light' | 'dark' = 'light', onAction?: () => void) {
+  const onPress = onAction ?? jest.fn();
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <Card testID="card">
+        <CardHeader>
+          <CardTitle testID="title">Title</CardTitle>
+          <CardDescription testID="description">Description</CardDescription>
+          <CardAction>
+            <Pressable
+              onPress={onPress}
+              accessibilityRole="button"
+              testID="action"
+            >
+              <Text>Action</Text>
+            </Pressable>
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <Text testID="content">Content</Text>
+        </CardContent>
+        <CardFooter>
+          <Text testID="footer">Footer</Text>
+        </CardFooter>
+      </Card>
+    </ThemeProvider>,
+  );
+}
+
+describe('Card', () => {
+  it('renders and matches snapshot', () => {
+    const { baseElement } = renderCard();
+    expectAny(screen.getByText('Title')).toBeInTheDocument();
+    expectAny(baseElement).toMatchSnapshot();
+  });
+
+  it('handles action press', () => {
+    const onPress = jest.fn();
+    renderCard('light', onPress);
+    fireEvent.click(screen.getByRole('button'));
+    expectAny(onPress).toHaveBeenCalled();
+  });
+
+  it('applies theme colors', () => {
+    const { unmount } = renderCard('light');
+    expectAny(screen.getByText('Title')).toHaveStyle({
+      color: colors.light.cardForeground,
+    });
+    unmount();
+    renderCard('dark');
+    expectAny(screen.getByText('Title')).toHaveStyle({
+      color: colors.dark.cardForeground,
+    });
+  });
+
+  it('provides accessibility role for action', () => {
+    renderCard();
+    const action = screen.getByRole('button');
+    expectAny(action).toBeInTheDocument();
+    expectAny(action).toHaveAttribute('data-testid', 'action');
+  });
+});

--- a/packages/ui-components/src/card.tsx
+++ b/packages/ui-components/src/card.tsx
@@ -1,0 +1,252 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ViewProps,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+} from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export interface CardProps extends ViewProps {
+  style?: StyleProp<ViewStyle>;
+  children: React.ReactNode;
+  testID?: string;
+}
+
+export const Card: React.FC<CardProps> = ({
+  style,
+  children,
+  testID,
+  ...props
+}) => {
+  const { colors, radius } = useTheme();
+  return (
+    <View
+      accessibilityRole="summary"
+      testID={testID}
+      style={[
+        styles.card,
+        {
+          backgroundColor: colors.card,
+          borderColor: colors.border,
+          borderRadius: radius.xl,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </View>
+  );
+};
+
+export interface CardHeaderProps extends ViewProps {
+  style?: StyleProp<ViewStyle>;
+  children: React.ReactNode;
+  testID?: string;
+}
+
+export const CardHeader: React.FC<CardHeaderProps> = ({
+  style,
+  children,
+  testID,
+  ...props
+}) => {
+  const { spacing } = useTheme();
+  const childrenArray = React.Children.toArray(
+    children,
+  ) as React.ReactElement[];
+  const actionChild = childrenArray.find(
+    (child) => React.isValidElement(child) && child.type === CardAction,
+  );
+  const contentChildren = childrenArray.filter(
+    (child) => child !== actionChild,
+  );
+
+  return (
+    <View
+      testID={testID}
+      style={[
+        styles.header,
+        { paddingHorizontal: spacing.xl, paddingTop: spacing.xl },
+        style,
+      ]}
+      {...props}
+    >
+      <View style={styles.headerContent}>{contentChildren}</View>
+      {actionChild}
+    </View>
+  );
+};
+
+export interface CardTitleProps extends React.ComponentProps<typeof Text> {
+  style?: StyleProp<TextStyle>;
+  testID?: string;
+  children?: React.ReactNode;
+}
+
+export const CardTitle: React.FC<CardTitleProps> = ({
+  style,
+  children,
+  testID,
+  ...props
+}) => {
+  const { colors, type } = useTheme();
+  return (
+    <Text
+      testID={testID}
+      accessibilityRole="header"
+      style={[
+        styles.title,
+        {
+          color: colors.cardForeground,
+          fontSize: type.size.lg,
+          fontWeight: type.weight.bold,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </Text>
+  );
+};
+
+export interface CardDescriptionProps
+  extends React.ComponentProps<typeof Text> {
+  style?: StyleProp<TextStyle>;
+  testID?: string;
+  children?: React.ReactNode;
+}
+
+export const CardDescription: React.FC<CardDescriptionProps> = ({
+  style,
+  children,
+  testID,
+  ...props
+}) => {
+  const { colors, type } = useTheme();
+  return (
+    <Text
+      testID={testID}
+      style={[
+        styles.description,
+        {
+          color: colors.mutedForeground,
+          fontSize: type.size.base,
+          lineHeight: type.lineHeight.relaxed,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </Text>
+  );
+};
+
+export interface CardActionProps extends ViewProps {
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+  children?: React.ReactNode;
+}
+
+export const CardAction: React.FC<CardActionProps> = ({
+  style,
+  children,
+  testID,
+  ...props
+}) => {
+  return (
+    <View testID={testID} style={[styles.action, style]} {...props}>
+      {children}
+    </View>
+  );
+};
+
+export interface CardContentProps extends ViewProps {
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+  children?: React.ReactNode;
+}
+
+export const CardContent: React.FC<CardContentProps> = ({
+  style,
+  children,
+  testID,
+  ...props
+}) => {
+  const { spacing } = useTheme();
+  return (
+    <View
+      testID={testID}
+      style={[
+        { paddingHorizontal: spacing.xl, paddingBottom: spacing.xl },
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </View>
+  );
+};
+
+export interface CardFooterProps extends ViewProps {
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+  children?: React.ReactNode;
+}
+
+export const CardFooter: React.FC<CardFooterProps> = ({
+  style,
+  children,
+  testID,
+  ...props
+}) => {
+  const { spacing } = useTheme();
+  return (
+    <View
+      testID={testID}
+      style={[
+        styles.footer,
+        { paddingHorizontal: spacing.xl, paddingBottom: spacing.xl },
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    flexDirection: 'column',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  headerContent: {
+    flex: 1,
+  },
+  title: {
+    marginBottom: 4,
+  },
+  description: {
+    marginTop: 2,
+  },
+  action: {
+    alignSelf: 'flex-start',
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});
+export default Card;


### PR DESCRIPTION
## Summary
- add themed Card primitives for mobile
- document card variants in Storybook
- test card interactions and theme

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find module 'react-native' or its type declarations)*
- `pnpm build` *(fails: Cannot find module 'react-native' or its type declarations)*
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d426047c832f87e5853c938bbde8