### PR TITLE
feat(ui): add React Native calendar component

### DIFF
--- a/apps/storybook/storybook/stories/calendar.stories.tsx
+++ b/apps/storybook/storybook/stories/calendar.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { Calendar, type CalendarProps } from '@hum/ui-components';
+
+const meta: Meta<typeof Calendar> = {
+  title: 'Components/Calendar',
+  component: Calendar,
+  argTypes: {
+    mode: { control: 'select', options: ['single', 'range'] },
+    showOutsideDays: { control: 'boolean' },
+  },
+  args: { mode: 'single', showOutsideDays: true },
+};
+export default meta;
+
+type Story = StoryObj<typeof Calendar>;
+
+export const Basic: Story = {};
+export const Range: Story = { args: { mode: 'range' } };
+export const Controlled: Story = {
+  render: (args: CalendarProps) => {
+    const ControlledExample: React.FC = () => {
+      const [value, setValue] = React.useState<
+        Date | { start?: Date; end?: Date }
+      >();
+      return <Calendar {...args} selected={value} onSelect={setValue} />;
+    };
+    return <ControlledExample />;
+  },
+};

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -25,3 +25,5 @@ export { Alert, AlertTitle, AlertDescription } from './src/alert';
 export type { AlertProps, AlertVariant } from './src/alert';
 export { AspectRatio } from './src/aspect-ratio';
 export type { AspectRatioProps } from './src/aspect-ratio';
+export { Calendar } from './src/calendar';
+export type { CalendarProps, Range } from './src/calendar';

--- a/packages/ui-components/src/__snapshots__/calendar.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/calendar.test.tsx.snap
@@ -1,0 +1,1942 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Calendar renders default state and matches snapshot 1`] = `
+<div
+  className="css-view-g5y9jx r-width-13qz1uu"
+  dir={null}
+  ref={[Function]}
+>
+  <div
+    className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+    dir={null}
+    ref={[Function]}
+    style={
+      {
+        "marginBottom": "8px",
+      }
+    }
+  >
+    <button
+      aria-label="Previous month"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-justifyContent-1777fci"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "paddingBottom": "4px",
+          "paddingLeft": "4px",
+          "paddingRight": "4px",
+          "paddingTop": "4px",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "16px",
+          }
+        }
+      >
+        ‹
+      </div>
+    </button>
+    <div
+      className="css-text-146c3p1"
+      data-testid="month-label"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(10,10,10,1.00)",
+          "fontSize": "16px",
+          "fontWeight": "500",
+        }
+      }
+    >
+      August 2025
+    </div>
+    <button
+      aria-label="Next month"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-justifyContent-1777fci"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "paddingBottom": "4px",
+          "paddingLeft": "4px",
+          "paddingRight": "4px",
+          "paddingTop": "4px",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "16px",
+          }
+        }
+      >
+        ›
+      </div>
+    </button>
+  </div>
+  <div
+    className="css-view-g5y9jx r-flexDirection-18u37iz"
+    dir={null}
+    ref={[Function]}
+  >
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "flex": 1,
+          "fontSize": "12px",
+          "marginBottom": "4px",
+          "textAlign": "center",
+        }
+      }
+    >
+      Su
+    </div>
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "flex": 1,
+          "fontSize": "12px",
+          "marginBottom": "4px",
+          "textAlign": "center",
+        }
+      }
+    >
+      Mo
+    </div>
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "flex": 1,
+          "fontSize": "12px",
+          "marginBottom": "4px",
+          "textAlign": "center",
+        }
+      }
+    >
+      Tu
+    </div>
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "flex": 1,
+          "fontSize": "12px",
+          "marginBottom": "4px",
+          "textAlign": "center",
+        }
+      }
+    >
+      We
+    </div>
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "flex": 1,
+          "fontSize": "12px",
+          "marginBottom": "4px",
+          "textAlign": "center",
+        }
+      }
+    >
+      Th
+    </div>
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "flex": 1,
+          "fontSize": "12px",
+          "marginBottom": "4px",
+          "textAlign": "center",
+        }
+      }
+    >
+      Fr
+    </div>
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "flex": 1,
+          "fontSize": "12px",
+          "marginBottom": "4px",
+          "textAlign": "center",
+        }
+      }
+    >
+      Sa
+    </div>
+  </div>
+  <div
+    className="css-view-g5y9jx r-flexDirection-18u37iz"
+    dir={null}
+    ref={[Function]}
+  >
+    <button
+      aria-label="Select 27"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-27"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        27
+      </div>
+    </button>
+    <button
+      aria-label="Select 28"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-28"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        28
+      </div>
+    </button>
+    <button
+      aria-label="Select 29"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-29"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        29
+      </div>
+    </button>
+    <button
+      aria-label="Select 30"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-30"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        30
+      </div>
+    </button>
+    <button
+      aria-label="Select 31"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-31"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        31
+      </div>
+    </button>
+    <button
+      aria-label="Select 1"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-1"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        1
+      </div>
+    </button>
+    <button
+      aria-label="Select 2"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-2"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        2
+      </div>
+    </button>
+  </div>
+  <div
+    className="css-view-g5y9jx r-flexDirection-18u37iz"
+    dir={null}
+    ref={[Function]}
+  >
+    <button
+      aria-label="Select 3"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-3"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        3
+      </div>
+    </button>
+    <button
+      aria-label="Select 4"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-4"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        4
+      </div>
+    </button>
+    <button
+      aria-label="Select 5"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-5"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        5
+      </div>
+    </button>
+    <button
+      aria-label="Select 6"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-6"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        6
+      </div>
+    </button>
+    <button
+      aria-label="Select 7"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-7"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        7
+      </div>
+    </button>
+    <button
+      aria-label="Select 8"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-8"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        8
+      </div>
+    </button>
+    <button
+      aria-label="Select 9"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-9"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        9
+      </div>
+    </button>
+  </div>
+  <div
+    className="css-view-g5y9jx r-flexDirection-18u37iz"
+    dir={null}
+    ref={[Function]}
+  >
+    <button
+      aria-label="Select 10"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-10"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        10
+      </div>
+    </button>
+    <button
+      aria-label="Select 11"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-11"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        11
+      </div>
+    </button>
+    <button
+      aria-label="Select 12"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-12"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        12
+      </div>
+    </button>
+    <button
+      aria-label="Select 13"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-13"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        13
+      </div>
+    </button>
+    <button
+      aria-label="Select 14"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-14"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        14
+      </div>
+    </button>
+    <button
+      aria-label="Select 15"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-15"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        15
+      </div>
+    </button>
+    <button
+      aria-label="Select 16"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-16"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        16
+      </div>
+    </button>
+  </div>
+  <div
+    className="css-view-g5y9jx r-flexDirection-18u37iz"
+    dir={null}
+    ref={[Function]}
+  >
+    <button
+      aria-label="Select 17"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-17"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        17
+      </div>
+    </button>
+    <button
+      aria-label="Select 18"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-18"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        18
+      </div>
+    </button>
+    <button
+      aria-label="Select 19"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-19"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        19
+      </div>
+    </button>
+    <button
+      aria-label="Select 20"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-20"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        20
+      </div>
+    </button>
+    <button
+      aria-label="Select 21"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-21"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        21
+      </div>
+    </button>
+    <button
+      aria-label="Select 22"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-22"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        22
+      </div>
+    </button>
+    <button
+      aria-label="Select 23"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-23"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        23
+      </div>
+    </button>
+  </div>
+  <div
+    className="css-view-g5y9jx r-flexDirection-18u37iz"
+    dir={null}
+    ref={[Function]}
+  >
+    <button
+      aria-label="Select 24"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-24"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        24
+      </div>
+    </button>
+    <button
+      aria-label="Select 25"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-25"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        25
+      </div>
+    </button>
+    <button
+      aria-label="Select 26"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-26"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        26
+      </div>
+    </button>
+    <button
+      aria-label="Select 27"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-27"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        27
+      </div>
+    </button>
+    <button
+      aria-label="Select 28"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-28"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        28
+      </div>
+    </button>
+    <button
+      aria-label="Select 29"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-29"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        29
+      </div>
+    </button>
+    <button
+      aria-label="Select 30"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-30"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        30
+      </div>
+    </button>
+  </div>
+  <div
+    className="css-view-g5y9jx r-flexDirection-18u37iz"
+    dir={null}
+    ref={[Function]}
+  >
+    <button
+      aria-label="Select 31"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-31"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 1,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        31
+      </div>
+    </button>
+    <button
+      aria-label="Select 1"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-1"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        1
+      </div>
+    </button>
+    <button
+      aria-label="Select 2"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-2"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        2
+      </div>
+    </button>
+    <button
+      aria-label="Select 3"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-3"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        3
+      </div>
+    </button>
+    <button
+      aria-label="Select 4"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-4"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        4
+      </div>
+    </button>
+    <button
+      aria-label="Select 5"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-5"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        5
+      </div>
+    </button>
+    <button
+      aria-label="Select 6"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-height-mabqd8 r-justifyContent-1777fci r-margin-1un5n4g"
+      data-testid="day-6"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(0,0,0,0.00)",
+          "borderBottomLeftRadius": "6px",
+          "borderBottomRightRadius": "6px",
+          "borderTopLeftRadius": "6px",
+          "borderTopRightRadius": "6px",
+          "opacity": 0.4,
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "fontWeight": "400",
+          }
+        }
+      >
+        6
+      </div>
+    </button>
+  </div>
+</div>
+`;

--- a/packages/ui-components/src/calendar.test.tsx
+++ b/packages/ui-components/src/calendar.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import '@testing-library/jest-native/extend-expect';
+
+import { Calendar, type CalendarProps } from './calendar';
+import { ThemeProvider } from './theme/ThemeProvider';
+
+// Temporary workaround for missing Jest Native matcher typings
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const expectAny = expect as any;
+
+function renderCalendar(
+  scheme: 'light' | 'dark' = 'light',
+  props?: Partial<CalendarProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <Calendar {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('Calendar', () => {
+  it('renders default state and matches snapshot', () => {
+    const { toJSON } = renderCalendar();
+    expectAny(toJSON()).toMatchSnapshot();
+  });
+
+  it('selects a day and triggers onSelect', () => {
+    const onSelect = jest.fn();
+    renderCalendar('light', { onSelect });
+    const day = screen.getByLabelText('Select 15');
+    fireEvent.press(day);
+    expectAny(onSelect).toHaveBeenCalled();
+  });
+
+  it('supports range selection', () => {
+    const onSelect = jest.fn();
+    renderCalendar('light', { mode: 'range', onSelect });
+    fireEvent.press(screen.getByLabelText('Select 10'));
+    fireEvent.press(screen.getByLabelText('Select 12'));
+    expectAny(onSelect).toHaveBeenCalledTimes(2);
+  });
+
+  it('exposes navigation buttons for accessibility', () => {
+    renderCalendar();
+    expectAny(screen.getByLabelText('Previous month')).toBeOnTheScreen();
+    expectAny(screen.getByLabelText('Next month')).toBeOnTheScreen();
+  });
+
+  it('applies theme colors', () => {
+    const { toJSON, unmount } = renderCalendar('light');
+    const lightTree = JSON.stringify(toJSON());
+    unmount();
+    const { toJSON: toJSONDark } = renderCalendar('dark');
+    const darkTree = JSON.stringify(toJSONDark());
+    expectAny(lightTree).not.toEqual(darkTree);
+  });
+});

--- a/packages/ui-components/src/calendar.tsx
+++ b/packages/ui-components/src/calendar.tsx
@@ -1,0 +1,288 @@
+import React, { useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+} from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export interface Range {
+  start?: Date;
+  end?: Date;
+}
+
+export interface CalendarProps {
+  mode?: 'single' | 'range';
+  selected?: Date | Range;
+  onSelect?: (value: Date | Range) => void;
+  showOutsideDays?: boolean;
+  style?: StyleProp<ViewStyle>;
+  dayTextStyle?: StyleProp<TextStyle>;
+  testID?: string;
+}
+
+interface DayInfo {
+  date: Date | null;
+  currentMonth: boolean;
+}
+
+const daysOfWeek = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+export const Calendar: React.FC<CalendarProps> = ({
+  mode = 'single',
+  selected,
+  onSelect,
+  showOutsideDays = true,
+  style,
+  dayTextStyle,
+  testID,
+}) => {
+  const { colors, spacing, radius, type } = useTheme();
+  const today = useMemo(() => new Date(), []);
+  const [month, setMonth] = useState<Date>(
+    selected instanceof Date ? selected : today,
+  );
+
+  const isControlled = selected !== undefined;
+  const [internalSelected, setInternalSelected] = useState<
+    Date | Range | undefined
+  >();
+  const current = (isControlled ? selected : internalSelected) as
+    | Date
+    | Range
+    | undefined;
+
+  const handleSelect = (date: Date) => {
+    let next: Date | Range;
+    if (mode === 'range') {
+      const range = (current as Range) || {};
+      if (!range.start || (range.start && range.end)) {
+        next = { start: date };
+      } else {
+        next =
+          date < range.start
+            ? { start: date, end: range.start }
+            : { start: range.start, end: date };
+      }
+    } else {
+      next = date;
+    }
+    if (!isControlled) setInternalSelected(next);
+    onSelect?.(next);
+  };
+
+  const days = useMemo(
+    () => buildCalendar(month, showOutsideDays),
+    [month, showOutsideDays],
+  );
+
+  const renderDay = (d: DayInfo, index: number) => {
+    if (!d.date) {
+      return <View key={index} style={styles.dayCell} />;
+    }
+    const out = !d.currentMonth;
+    const sel =
+      mode === 'range'
+        ? isInRange(d.date, current as Range | undefined)
+        : isSameDay(d.date, current as Date | undefined);
+    const bg = sel ? colors.humPrimary : 'transparent';
+    const textColor = sel
+      ? colors.humPrimaryForeground
+      : out
+        ? colors.mutedForeground
+        : colors.foreground;
+    return (
+      <Pressable
+        key={index}
+        onPress={() => handleSelect(d.date!)}
+        accessibilityRole="button"
+        accessibilityLabel={`Select ${d.date.getDate()}`}
+        style={[
+          styles.dayCell,
+          // eslint-disable-next-line react-native/no-inline-styles
+          {
+            backgroundColor: bg,
+            borderRadius: radius.sm,
+            opacity: out ? 0.4 : 1,
+          },
+        ]}
+        testID={`day-${d.date.getDate()}`}
+      >
+        <Text
+          style={[
+            {
+              color: textColor,
+              fontSize: type.size.sm,
+              fontWeight: type.weight.normal,
+            },
+            dayTextStyle,
+          ]}
+        >
+          {String(d.date.getDate())}
+        </Text>
+      </Pressable>
+    );
+  };
+
+  return (
+    <View style={[styles.container, style]} testID={testID}>
+      <View style={[styles.header, { marginBottom: spacing.sm }]}>
+        <Pressable
+          onPress={() => setMonth(addMonths(month, -1))}
+          accessibilityRole="button"
+          accessibilityLabel="Previous month"
+          style={[styles.navButton, { padding: spacing.xs }]}
+        >
+          <Text style={{ color: colors.foreground, fontSize: type.size.md }}>
+            {'\u2039'}
+          </Text>
+        </Pressable>
+        <Text
+          testID="month-label"
+          style={{
+            color: colors.foreground,
+            fontSize: type.size.md,
+            fontWeight: type.weight.medium,
+          }}
+        >
+          {formatMonth(month)}
+        </Text>
+        <Pressable
+          onPress={() => setMonth(addMonths(month, 1))}
+          accessibilityRole="button"
+          accessibilityLabel="Next month"
+          style={[styles.navButton, { padding: spacing.xs }]}
+        >
+          <Text style={{ color: colors.foreground, fontSize: type.size.md }}>
+            {'\u203A'}
+          </Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.weekHeader}>
+        {daysOfWeek.map((d) => (
+          <Text
+            key={d}
+            // eslint-disable-next-line react-native/no-inline-styles
+            style={{
+              flex: 1,
+              textAlign: 'center',
+              color: colors.mutedForeground,
+              fontSize: type.size.sm,
+              marginBottom: spacing.xs,
+            }}
+          >
+            {d}
+          </Text>
+        ))}
+      </View>
+
+      {chunk(days, 7).map((week, idx) => (
+        <View key={idx} style={styles.weekRow}>
+          {week.map(renderDay)}
+        </View>
+      ))}
+    </View>
+  );
+};
+
+function buildCalendar(month: Date, showOutside: boolean): DayInfo[] {
+  const year = month.getFullYear();
+  const m = month.getMonth();
+  const first = new Date(year, m, 1);
+  const firstDay = first.getDay();
+  const days: DayInfo[] = [];
+  const prevDays = new Date(year, m, 0).getDate();
+
+  for (let i = 0; i < firstDay; i++) {
+    if (showOutside) {
+      days.push({
+        date: new Date(year, m - 1, prevDays - firstDay + i + 1),
+        currentMonth: false,
+      });
+    } else {
+      days.push({ date: null, currentMonth: false });
+    }
+  }
+
+  const monthDays = new Date(year, m + 1, 0).getDate();
+  for (let i = 1; i <= monthDays; i++) {
+    days.push({ date: new Date(year, m, i), currentMonth: true });
+  }
+
+  const remaining = 42 - days.length;
+  for (let i = 0; i < remaining; i++) {
+    if (showOutside) {
+      days.push({ date: new Date(year, m + 1, i + 1), currentMonth: false });
+    } else {
+      days.push({ date: null, currentMonth: false });
+    }
+  }
+  return days;
+}
+
+const chunk = <T,>(arr: T[], size: number): T[][] => {
+  const res: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    res.push(arr.slice(i, i + size));
+  }
+  return res;
+};
+
+const addMonths = (date: Date, count: number) => {
+  const d = new Date(date);
+  d.setMonth(d.getMonth() + count);
+  return d;
+};
+
+const formatMonth = (date: Date) =>
+  date.toLocaleString('default', { month: 'long', year: 'numeric' });
+
+const isSameDay = (a: Date, b?: Date) =>
+  !!b &&
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate();
+
+const atMidnight = (d: Date) =>
+  new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+
+const isInRange = (d: Date, range?: Range): boolean => {
+  if (!range || !range.start) return false;
+  const start = atMidnight(range.start);
+  const end = atMidnight(range.end ?? range.start);
+  const time = atMidnight(d);
+  return time >= start && time <= end;
+};
+
+const styles = StyleSheet.create({
+  container: { width: '100%' },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  navButton: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  weekHeader: {
+    flexDirection: 'row',
+  },
+  weekRow: {
+    flexDirection: 'row',
+  },
+  dayCell: {
+    flex: 1,
+    height: 32,
+    justifyContent: 'center',
+    alignItems: 'center',
+    margin: 1,
+  },
+});
+
+export default Calendar;


### PR DESCRIPTION
## Summary
- add themed Calendar component with date and range selection
- document Calendar in Storybook with basic, range, and controlled examples
- test Calendar interactions and accessibility

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d420e1b4832faa421cc4051bce77