### PR TITLE
feat: add react native chart component

### DIFF
--- a/apps/storybook/storybook/stories/chart.stories.tsx
+++ b/apps/storybook/storybook/stories/chart.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { View } from 'react-native';
+import {
+  ChartContainer,
+  ChartTooltipContent,
+  ChartLegendContent,
+  type ChartConfig,
+} from '@hum/ui-components';
+
+const config: ChartConfig = {
+  visitors: { label: 'Visitors', color: '#FECA1A' },
+};
+
+const tooltipPayload = [
+  {
+    dataKey: 'visitors',
+    name: 'Visitors',
+    value: 100,
+    color: '#FECA1A',
+    payload: { visitors: 'visitors' },
+  },
+];
+
+const legendPayload = [
+  { dataKey: 'visitors', value: 'Visitors', color: '#FECA1A' },
+];
+
+const ExampleChart: React.FC<{
+  indicator?: 'dot' | 'line' | 'dashed';
+  hideLabel?: boolean;
+}> = ({ indicator = 'dot', hideLabel = false }) => (
+  <ChartContainer
+    config={config}
+    // eslint-disable-next-line react-native/no-inline-styles
+    style={{ width: 300, height: 200 }}
+  >
+    {/* eslint-disable-next-line react-native/no-inline-styles */}
+    <View style={{ flex: 1 }} />
+    <ChartTooltipContent
+      active
+      payload={tooltipPayload}
+      indicator={indicator}
+      hideLabel={hideLabel}
+    />
+    <ChartLegendContent payload={legendPayload} />
+  </ChartContainer>
+);
+
+const meta: Meta<typeof ExampleChart> = {
+  title: 'Components/Chart',
+  component: ExampleChart,
+  argTypes: {
+    indicator: { control: 'select', options: ['dot', 'line', 'dashed'] },
+    hideLabel: { control: 'boolean' },
+  },
+  args: {
+    indicator: 'dot',
+    hideLabel: false,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ExampleChart>;
+
+export const Default: Story = {};
+export const LineIndicator: Story = { args: { indicator: 'line' } };
+export const DashedIndicator: Story = { args: { indicator: 'dashed' } };

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-native": "0.75.4",
+    "react-native-safe-area-context": "4.10.5",
     "react-native-web": "~0.21.1",
     "react-test-renderer": "19.1.1",
     "ts-jest": "^29.1.1",

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -25,3 +25,12 @@ export { Alert, AlertTitle, AlertDescription } from './src/alert';
 export type { AlertProps, AlertVariant } from './src/alert';
 export { AspectRatio } from './src/aspect-ratio';
 export type { AspectRatioProps } from './src/aspect-ratio';
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+} from './src/chart';
+export type { ChartConfig } from './src/chart';

--- a/packages/ui-components/src/__snapshots__/chart.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/chart.test.tsx.snap
@@ -1,0 +1,120 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ChartTooltipContent renders and matches snapshot 1`] = `
+<div
+  aria-label="chart-«r0»"
+  className="css-view-g5y9jx r-aspectRatio-1ts5s6y r-flex-13awgt0 r-justifyContent-1777fci"
+  dir={null}
+  ref={[Function]}
+>
+  <div
+    aria-label="tooltip"
+    className="css-view-g5y9jx r-borderWidth-rs99b7 r-boxShadow-1yv2962"
+    data-testid="tooltip"
+    dir={null}
+    ref={[Function]}
+    style={
+      {
+        "backgroundColor": "rgba(255,255,255,1.00)",
+        "borderBottomColor": "rgba(0,0,0,0.10)",
+        "borderBottomLeftRadius": "10px",
+        "borderBottomRightRadius": "10px",
+        "borderLeftColor": "rgba(0,0,0,0.10)",
+        "borderRightColor": "rgba(0,0,0,0.10)",
+        "borderTopColor": "rgba(0,0,0,0.10)",
+        "borderTopLeftRadius": "10px",
+        "borderTopRightRadius": "10px",
+        "paddingBottom": "4px",
+        "paddingLeft": "8px",
+        "paddingRight": "8px",
+        "paddingTop": "4px",
+      }
+    }
+  >
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "fontWeight": "500",
+        }
+      }
+    >
+      Visitors
+    </div>
+    <div
+      className="css-view-g5y9jx"
+      dir={null}
+      ref={[Function]}
+      style={
+        {
+          "marginTop": "4px",
+        }
+      }
+    >
+      <div
+        className="css-view-g5y9jx r-flexDirection-18u37iz r-marginBottom-15zivkp r-alignItems-1awozwy"
+        dir={null}
+        ref={[Function]}
+      >
+        <div
+          aria-label="indicator-0"
+          className="css-view-g5y9jx r-borderRadius-1jkafct r-borderWidth-rs99b7 r-height-1or9b2r r-marginRight-1kb76zh r-width-5soawk"
+          dir={null}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(254,202,26,1.00)",
+              "borderBottomColor": "rgba(254,202,26,1.00)",
+              "borderLeftColor": "rgba(254,202,26,1.00)",
+              "borderRightColor": "rgba(254,202,26,1.00)",
+              "borderTopColor": "rgba(254,202,26,1.00)",
+            }
+          }
+        />
+        <div
+          className="css-view-g5y9jx r-alignItems-1awozwy r-flex-13awgt0 r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          ref={[Function]}
+        >
+          <div
+            className="css-view-g5y9jx r-flexShrink-1wbh5a2"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-text-146c3p1"
+              dir="auto"
+              ref={[Function]}
+              style={
+                {
+                  "color": "rgba(113,113,130,1.00)",
+                  "fontSize": "12px",
+                }
+              }
+            >
+              Visitors
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(10,10,10,1.00)",
+                "fontFamily": "monospace,monospace",
+                "fontSize": "12px",
+                "fontWeight": "500",
+              }
+            }
+          >
+            100
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/ui-components/src/chart.test.tsx
+++ b/packages/ui-components/src/chart.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { Text, Pressable } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import '@testing-library/jest-native/extend-expect';
+
+import {
+  ChartContainer,
+  ChartTooltipContent,
+  ChartLegendContent,
+  type ChartConfig,
+} from './chart';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+const config: ChartConfig = {
+  visitors: { label: 'Visitors', color: colors.light.humPrimary },
+};
+
+const tooltipPayload = [
+  {
+    dataKey: 'visitors',
+    name: 'Visitors',
+    value: 100,
+    color: colors.light.humPrimary,
+    payload: { visitors: 'visitors' },
+  },
+];
+
+const legendPayload = [
+  { dataKey: 'visitors', value: 'Visitors', color: colors.light.humPrimary },
+];
+
+function renderTooltip(
+  scheme: 'light' | 'dark' = 'light',
+  props: Partial<React.ComponentProps<typeof ChartTooltipContent>> = {},
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <ChartContainer config={config}>
+        <ChartTooltipContent
+          active
+          payload={tooltipPayload}
+          testID="tooltip"
+          {...props}
+        />
+      </ChartContainer>
+    </ThemeProvider>,
+  );
+}
+
+describe('ChartTooltipContent', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderTooltip();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('supports indicator variants', () => {
+    const { getByLabelText, unmount } = renderTooltip('light', {
+      indicator: 'line',
+    });
+    expect(getByLabelText('indicator-0')).toBeTruthy();
+    unmount();
+    const { getByLabelText: getByLabelText2 } = renderTooltip('light', {
+      indicator: 'dashed',
+    });
+    expect(getByLabelText2('indicator-0')).toBeTruthy();
+  });
+
+  it('fires callbacks from formatter content', () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = renderTooltip('light', {
+      formatter: (value) => (
+        <Pressable onPress={() => onPress(value)} accessibilityLabel="custom">
+          <Text>{value}</Text>
+        </Pressable>
+      ),
+    });
+    fireEvent.press(getByLabelText('custom'));
+    expect(onPress).toHaveBeenCalledWith(100);
+  });
+
+  it('is accessible and adapts to theme', () => {
+    const { unmount, getByLabelText } = renderTooltip('light', {
+      accessibilityLabel: 'tooltip',
+    });
+    const lightBg = getByLabelText('tooltip').props.style.backgroundColor;
+    unmount();
+    const { getByLabelText: getByLabelTextDark } = renderTooltip('dark', {
+      accessibilityLabel: 'tooltip',
+    });
+    const darkBg = getByLabelTextDark('tooltip').props.style.backgroundColor;
+    expect(lightBg).not.toBe(darkBg);
+  });
+});
+
+describe('ChartLegendContent', () => {
+  it('renders legend labels', () => {
+    const { getByLabelText } = render(
+      <ThemeProvider forcedScheme="light">
+        <ChartContainer config={config}>
+          <ChartLegendContent
+            payload={legendPayload}
+            accessibilityLabel="legend"
+          />
+        </ChartContainer>
+      </ThemeProvider>,
+    );
+    expect(getByLabelText('legend')).toBeTruthy();
+  });
+});

--- a/packages/ui-components/src/chart.tsx
+++ b/packages/ui-components/src/chart.tsx
@@ -1,0 +1,405 @@
+/* eslint-disable react-native/no-inline-styles, @typescript-eslint/no-explicit-any */
+import React, { useContext, useMemo, useId } from 'react';
+import { View, Text, StyleSheet, ViewProps } from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export type ChartConfig = {
+  [k: string]: {
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
+    color?: string;
+  };
+};
+
+interface ChartContextProps {
+  config: ChartConfig;
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+export const useChart = () => {
+  const ctx = useContext(ChartContext);
+  if (!ctx) {
+    throw new Error('useChart must be used within a <ChartContainer />');
+  }
+  return ctx;
+};
+
+export interface ChartContainerProps extends ViewProps {
+  id?: string;
+  config: ChartConfig;
+  children: React.ReactNode;
+}
+
+export const ChartContainer: React.FC<ChartContainerProps> = ({
+  id,
+  config,
+  children,
+  style,
+  ...props
+}) => {
+  const uniqueId = useId();
+  const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`;
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <View
+        accessibilityLabel={chartId}
+        style={[styles.container, style]}
+        {...props}
+      >
+        {children}
+      </View>
+    </ChartContext.Provider>
+  );
+};
+
+export const ChartStyle: React.FC<{ id: string; config: ChartConfig }> = () =>
+  null;
+export const ChartTooltip: React.FC = () => null;
+export const ChartLegend: React.FC = () => null;
+
+export interface ChartTooltipContentProps extends ViewProps {
+  active?: boolean;
+  payload?: Array<Record<string, unknown>>;
+  indicator?: 'line' | 'dot' | 'dashed';
+  hideLabel?: boolean;
+  hideIndicator?: boolean;
+  label?: React.ReactNode;
+  labelFormatter?: (
+    label: React.ReactNode,
+    payload?: Array<Record<string, unknown>>,
+  ) => React.ReactNode;
+  formatter?: (
+    value: number,
+    name: string,
+    item: Record<string, unknown>,
+    index: number,
+    payloadItem: Record<string, unknown>,
+  ) => React.ReactNode;
+  color?: string;
+  nameKey?: string;
+  labelKey?: string;
+}
+
+export const ChartTooltipContent: React.FC<ChartTooltipContentProps> = ({
+  active,
+  payload,
+  indicator = 'dot',
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+  style,
+  ...props
+}) => {
+  const { config } = useChart();
+  const { colors, spacing, radius, type } = useTheme();
+
+  const tooltipLabel = useMemo(() => {
+    if (hideLabel || !payload?.length) return null;
+    const [item] = payload;
+    const key = `${labelKey || item?.dataKey || item?.name || 'value'}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
+    const value =
+      !labelKey && typeof label === 'string'
+        ? config[label]?.label || label
+        : itemConfig?.label;
+
+    if (!value && !labelFormatter) return null;
+    const rendered = labelFormatter ? labelFormatter(value, payload) : value;
+    return <Text style={{ fontWeight: type.weight.medium }}>{rendered}</Text>;
+  }, [
+    hideLabel,
+    payload,
+    labelKey,
+    label,
+    config,
+    labelFormatter,
+    type.weight.medium,
+  ]);
+
+  if (!active || !payload?.length) return null;
+
+  const nestLabel = payload.length === 1 && indicator !== 'dot';
+
+  return (
+    <View
+      testID={props.testID}
+      accessible
+      accessibilityRole="text"
+      accessibilityLabel={props.accessibilityLabel || props.testID}
+      style={[
+        styles.tooltipContainer,
+        {
+          backgroundColor: colors.background,
+          borderColor: colors.border,
+          paddingVertical: spacing.xs,
+          paddingHorizontal: spacing.sm,
+          borderRadius: radius.md,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      {!nestLabel && tooltipLabel}
+      <View style={{ marginTop: spacing.xs }}>
+        {payload.map((item, index) => {
+          const key = `${nameKey || (item as any).name || (item as any).dataKey || 'value'}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+          const indicatorColor =
+            color ||
+            (item as any).payload?.fill ||
+            (item as any).color ||
+            colors.humPrimary;
+          return (
+            <View
+              key={String((item as any).dataKey ?? index)}
+              style={[
+                styles.tooltipItem,
+                indicator === 'dot' && styles.tooltipItemDot,
+              ]}
+            >
+              {formatter &&
+              (item as any)?.value !== undefined &&
+              (item as any).name ? (
+                formatter(
+                  (item as any).value as number,
+                  (item as any).name as string,
+                  item as Record<string, unknown>,
+                  index,
+                  (item as any).payload as Record<string, unknown>,
+                )
+              ) : (
+                <>
+                  {itemConfig?.icon ? (
+                    <itemConfig.icon />
+                  ) : (
+                    !hideIndicator && (
+                      <View
+                        accessibilityLabel={`indicator-${index}`}
+                        style={[
+                          styles.indicator,
+                          indicator === 'line' && styles.indicatorLine,
+                          indicator === 'dashed' && styles.indicatorDashed,
+                          nestLabel &&
+                            indicator === 'dashed' && { marginVertical: 2 },
+                          {
+                            backgroundColor:
+                              indicator === 'dashed'
+                                ? 'transparent'
+                                : indicatorColor,
+                            borderColor: indicatorColor,
+                          },
+                        ]}
+                      />
+                    )
+                  )}
+                  <View
+                    style={[
+                      styles.itemContent,
+                      nestLabel && styles.itemContentNest,
+                    ]}
+                  >
+                    <View style={styles.itemLabels}>
+                      {nestLabel && tooltipLabel}
+                      <Text
+                        style={{
+                          color: colors.mutedForeground,
+                          fontSize: type.size.sm,
+                        }}
+                      >
+                        {itemConfig?.label || (item as any).name}
+                      </Text>
+                    </View>
+                    {(item as any).value !== undefined && (
+                      <Text
+                        style={{
+                          color: colors.foreground,
+                          fontSize: type.size.sm,
+                          fontWeight: type.weight.medium,
+                          fontFamily: 'monospace',
+                        }}
+                      >
+                        {typeof (item as any).value === 'number'
+                          ? ((item as any).value as number).toLocaleString()
+                          : (item as any).value}
+                      </Text>
+                    )}
+                  </View>
+                </>
+              )}
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+export interface ChartLegendContentProps extends ViewProps {
+  hideIcon?: boolean;
+  payload?: Array<Record<string, unknown>>;
+  verticalAlign?: 'top' | 'bottom';
+  nameKey?: string;
+}
+
+export const ChartLegendContent: React.FC<ChartLegendContentProps> = ({
+  hideIcon = false,
+  payload,
+  verticalAlign = 'bottom',
+  nameKey,
+  style,
+  ...props
+}) => {
+  const { config } = useChart();
+  const { colors, spacing, type } = useTheme();
+
+  if (!payload?.length) return null;
+
+  return (
+    <View
+      accessibilityLabel={props.accessibilityLabel}
+      style={[
+        styles.legendContainer,
+        verticalAlign === 'top'
+          ? { paddingBottom: spacing.md }
+          : { paddingTop: spacing.md },
+        style,
+      ]}
+      {...props}
+    >
+      {payload.map((item, index) => {
+        const key = `${nameKey || (item as any).dataKey || 'value'}`;
+        const itemConfig = getPayloadConfigFromPayload(config, item, key);
+        const itemColor =
+          typeof (item as any).color === 'string'
+            ? ((item as any).color as string)
+            : undefined;
+        return (
+          <View
+            key={String((item as any).value ?? index)}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              marginHorizontal: spacing.sm,
+            }}
+          >
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <View
+                style={[
+                  styles.legendIndicator,
+                  { backgroundColor: itemColor || colors.humPrimary },
+                ]}
+              />
+            )}
+            <Text style={{ color: colors.foreground, fontSize: type.size.sm }}>
+              {itemConfig?.label}
+            </Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+};
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string,
+) {
+  if (typeof payload !== 'object' || payload === null) {
+    return undefined;
+  }
+
+  const payloadPayload =
+    'payload' in payload && typeof (payload as any).payload === 'object'
+      ? (payload as any).payload
+      : undefined;
+
+  let configLabelKey: string = key;
+
+  if (key in (payload as any) && typeof (payload as any)[key] === 'string') {
+    configLabelKey = (payload as any)[key] as string;
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key] === 'string'
+  ) {
+    configLabelKey = payloadPayload[key];
+  }
+
+  return configLabelKey in config
+    ? (config as any)[configLabelKey]
+    : (config as any)[key];
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    aspectRatio: 16 / 9,
+    justifyContent: 'center',
+  },
+  tooltipContainer: {
+    borderWidth: 1,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  tooltipItem: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    marginBottom: 4,
+  },
+  tooltipItemDot: {
+    alignItems: 'center',
+  },
+  indicator: {
+    width: 10,
+    height: 10,
+    borderRadius: 2,
+    borderWidth: 1,
+    marginRight: 8,
+  },
+  indicatorLine: {
+    width: 4,
+  },
+  indicatorDashed: {
+    width: 0,
+    borderWidth: 1.5,
+    borderStyle: 'dashed',
+    backgroundColor: 'transparent',
+  },
+  itemContent: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  itemContentNest: {
+    alignItems: 'flex-end',
+  },
+  itemLabels: {
+    flexShrink: 1,
+  },
+  legendContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  legendIndicator: {
+    width: 8,
+    height: 8,
+    borderRadius: 2,
+    marginRight: 6,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       react-native:
         specifier: 0.75.4
         version: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
+      react-native-safe-area-context:
+        specifier: 4.10.5
+        version: 4.10.5(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)
       react-native-web:
         specifier: ~0.21.1
         version: 0.21.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -5098,6 +5101,12 @@ packages:
 
   react-native-edge-to-edge@1.6.0:
     resolution: {integrity: sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-safe-area-context@4.10.5:
+    resolution: {integrity: sha512-Wyb0Nqw2XJ6oZxW/cK8k5q7/UAhg/wbEG6UVf89rQqecDZTDA5ic//P9J6VvJRVZerzGmxWQpVuM7f+PRYUM4g==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -12513,6 +12522,11 @@ snapshots:
     dependencies:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  react-native-safe-area-context@4.10.5(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-native: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
 
   react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add React Native `ChartContainer`, `ChartTooltipContent`, and `ChartLegendContent`
- document chart usage in Storybook
- test chart rendering, variants, and interactions

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d42f557c832f8f726ec040c84d15