### PR TITLE
feat: add bottom navigation screen

### DIFF
--- a/apps/storybook/storybook/stories/BottomNavigation.stories.tsx
+++ b/apps/storybook/storybook/stories/BottomNavigation.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { BottomNavigation } from '@hum/ui-screens';
+
+const meta: Meta<typeof BottomNavigation> = {
+  title: 'Screens/BottomNavigation',
+  component: BottomNavigation,
+  argTypes: {
+    activeTab: {
+      control: 'select',
+      options: ['chats', 'lightning', 'settings'],
+    },
+    chatsBadgeCount: { control: { type: 'number' } },
+  },
+  args: {
+    activeTab: 'chats',
+    chatsBadgeCount: 0,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof BottomNavigation>;
+
+export const Default: Story = {};
+export const WithBadge: Story = { args: { chatsBadgeCount: 12 } };
+export const LightningActive: Story = { args: { activeTab: 'lightning' } };

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -26,6 +26,14 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['storybook', '@storybook/*'],
     include: ['react', 'react-dom', 'react-native-web'],
+    esbuildOptions: {
+      loader: {
+        '.js': 'tsx',
+      },
+    },
+  },
+  esbuild: {
+    loader: 'tsx',
   },
   ssr: {
     noExternal: ['storybook', '@storybook/*'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,5 +13,6 @@ module.exports = {
   },
   moduleNameMapper: {
     '^react-native$': 'react-native-web',
+    '^@hum/(.*)$': '<rootDir>/packages/$1/src',
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,8 @@ module.exports = {
   },
   moduleNameMapper: {
     '^react-native$': 'react-native-web',
+    '@hum/ui-components': '<rootDir>/packages/ui-components/index.ts',
+    '@hum/ui-screens': '<rootDir>/packages/ui-screens/index.ts',
     '^@hum/(.*)$': '<rootDir>/packages/$1/src',
   },
 };

--- a/packages/ui-screens/index.ts
+++ b/packages/ui-screens/index.ts
@@ -1,1 +1,3 @@
 export { DummyScreen } from './src/DummyScreen';
+export { BottomNavigation } from './src/BottomNavigation';
+export type { BottomNavigationProps } from './src/BottomNavigation';

--- a/packages/ui-screens/package.json
+++ b/packages/ui-screens/package.json
@@ -19,11 +19,15 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-native": ">=0.75",
-    "react-native-safe-area-context": ">=5.4.0"
+    "react-native-safe-area-context": ">=5.4.0",
+    "@expo/vector-icons": "^14.1.0",
+    "@hum/ui-components": "^0.1.0"
   },
   "devDependencies": {
     "@types/react": "^19.1.12",
-    "react-native-safe-area-context": "5.4.0"
+    "react-native-safe-area-context": "5.4.0",
+    "@expo/vector-icons": "14.1.0",
+    "@hum/ui-components": "workspace:*"
   },
   "dependencies": {
     "@testing-library/jest-dom": "6.8.0"

--- a/packages/ui-screens/src/BottomNavigation.test.tsx
+++ b/packages/ui-screens/src/BottomNavigation.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import '@testing-library/jest-native/extend-expect';
+
+import { ThemeProvider } from '@hum/ui-components';
+import { BottomNavigation, BottomNavigationProps } from './BottomNavigation';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+import { Text } from 'react-native';
+
+jest.mock('@expo/vector-icons', () => ({
+  Feather: ({ name }: { name: string }) => <Text>{name}</Text>,
+}));
+
+type Scheme = 'light' | 'dark';
+
+function renderBottomNav(
+  scheme: Scheme = 'light',
+  props?: Partial<BottomNavigationProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <BottomNavigation {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('BottomNavigation', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderBottomNav();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('triggers onTabChange when a tab is pressed', () => {
+    const onTabChange = jest.fn();
+    const { getByLabelText } = renderBottomNav('light', { onTabChange });
+    fireEvent(getByLabelText('Lightning'), 'press');
+    expect(onTabChange).toHaveBeenCalledWith('lightning');
+  });
+
+  it('shows badge count and applies theme colors', () => {
+    const { toJSON, rerender } = renderBottomNav('light', {
+      chatsBadgeCount: 12,
+      activeTab: 'chats',
+    });
+    expect(JSON.stringify(toJSON())).toContain('9+');
+
+    rerender(
+      <ThemeProvider forcedScheme="dark">
+        <BottomNavigation activeTab="settings" />
+      </ThemeProvider>,
+    );
+    const tree = toJSON() as {
+      props: { style: { backgroundColor: string } };
+    } | null;
+    expect(tree?.props.style.backgroundColor).toBe('rgba(0,0,0,1.00)');
+  });
+
+  it('has accessible labels', () => {
+    const { getByLabelText } = renderBottomNav();
+    expect(getByLabelText('Settings')).toBeTruthy();
+  });
+});

--- a/packages/ui-screens/src/BottomNavigation.tsx
+++ b/packages/ui-screens/src/BottomNavigation.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { View, Pressable, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@hum/ui-components';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Feather } from '@expo/vector-icons';
+
+export interface BottomNavigationProps {
+  activeTab?: string;
+  onTabChange?: (tab: string) => void;
+  chatsBadgeCount?: number;
+}
+
+interface NavItem {
+  id: string;
+  icon: React.ComponentProps<typeof Feather>['name'];
+  label: string;
+  badgeCount?: number;
+}
+
+const NavItem: React.FC<{
+  item: NavItem;
+  isActive: boolean;
+  onPress: () => void;
+}> = ({ item, isActive, onPress }) => {
+  const { colors, spacing, type } = useTheme();
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.navItem,
+        { paddingVertical: spacing.md, paddingHorizontal: spacing.sm },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={item.label}
+      testID={`nav-item-${item.id}`}
+    >
+      <View style={styles.iconWrapper}>
+        <Feather
+          name={item.icon}
+          size={24}
+          color={isActive ? colors.humPrimary : colors.mutedForeground}
+        />
+        {item.badgeCount && item.badgeCount > 0 && (
+          <View
+            testID={`badge-${item.id}`}
+            style={[
+              styles.badge,
+              {
+                backgroundColor: colors.humPrimary,
+              },
+            ]}
+          >
+            <Text
+              testID={`badge-text-${item.id}`}
+              style={[
+                styles.badgeText,
+                {
+                  color: colors.humPrimaryForeground,
+                  fontSize: type.size.sm - 2,
+                },
+              ]}
+            >
+              {item.badgeCount > 9 ? '9+' : item.badgeCount}
+            </Text>
+          </View>
+        )}
+      </View>
+      <Text
+        style={[
+          styles.label,
+          {
+            marginTop: spacing.xs,
+            color: isActive ? colors.humPrimary : colors.mutedForeground,
+            fontSize: type.size.sm,
+            fontWeight: type.weight.medium,
+          },
+        ]}
+      >
+        {item.label}
+      </Text>
+    </Pressable>
+  );
+};
+
+export const BottomNavigation: React.FC<BottomNavigationProps> = ({
+  activeTab = 'chats',
+  onTabChange,
+  chatsBadgeCount = 0,
+}) => {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const navItems: NavItem[] = [
+    {
+      id: 'chats',
+      icon: 'message-circle',
+      label: 'Chats',
+      badgeCount: chatsBadgeCount,
+    },
+    { id: 'lightning', icon: 'zap', label: 'Lightning' },
+    { id: 'settings', icon: 'settings', label: 'Settings' },
+  ];
+
+  return (
+    <View
+      testID="bottom-navigation"
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          borderTopColor: colors.border,
+          paddingBottom: insets.bottom,
+        },
+      ]}
+    >
+      {navItems.map((item) => (
+        <NavItem
+          key={item.id}
+          item={item}
+          isActive={activeTab === item.id}
+          onPress={() => onTabChange?.(item.id)}
+        />
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+  },
+  navItem: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 60,
+  },
+  iconWrapper: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  label: {},
+  badge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeText: {
+    fontWeight: '700',
+  },
+});
+
+export default BottomNavigation;

--- a/packages/ui-screens/src/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/packages/ui-screens/src/__snapshots__/BottomNavigation.test.tsx.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`BottomNavigation renders and matches snapshot 1`] = `
+<div
+  className="css-view-g5y9jx r-borderTopWidth-5kkj8d r-flexDirection-18u37iz"
+  data-testid="bottom-navigation"
+  dir={null}
+  ref={[Function]}
+  style={
+    {
+      "backgroundColor": "rgba(255,255,255,1.00)",
+      "borderTopColor": "rgba(0,0,0,0.10)",
+      "paddingBottom": "0px",
+    }
+  }
+>
+  <button
+    aria-label="Chats"
+    className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci r-minHeight-h10h58"
+    data-testid="nav-item-chats"
+    dir={null}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    ref={[Function]}
+    role="button"
+    style={
+      {
+        "paddingBottom": "12px",
+        "paddingLeft": "8px",
+        "paddingRight": "8px",
+        "paddingTop": "12px",
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <div
+      className="css-view-g5y9jx r-alignItems-1awozwy r-justifyContent-1777fci"
+      dir={null}
+      ref={[Function]}
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+      >
+        message-circle
+      </div>
+      0
+    </div>
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(254,202,26,1.00)",
+          "fontSize": "12px",
+          "fontWeight": "500",
+          "marginTop": "4px",
+        }
+      }
+    >
+      Chats
+    </div>
+  </button>
+  <button
+    aria-label="Lightning"
+    className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci r-minHeight-h10h58"
+    data-testid="nav-item-lightning"
+    dir={null}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    ref={[Function]}
+    role="button"
+    style={
+      {
+        "paddingBottom": "12px",
+        "paddingLeft": "8px",
+        "paddingRight": "8px",
+        "paddingTop": "12px",
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <div
+      className="css-view-g5y9jx r-alignItems-1awozwy r-justifyContent-1777fci"
+      dir={null}
+      ref={[Function]}
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+      >
+        zap
+      </div>
+    </div>
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "fontSize": "12px",
+          "fontWeight": "500",
+          "marginTop": "4px",
+        }
+      }
+    >
+      Lightning
+    </div>
+  </button>
+  <button
+    aria-label="Settings"
+    className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci r-minHeight-h10h58"
+    data-testid="nav-item-settings"
+    dir={null}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    ref={[Function]}
+    role="button"
+    style={
+      {
+        "paddingBottom": "12px",
+        "paddingLeft": "8px",
+        "paddingRight": "8px",
+        "paddingTop": "12px",
+      }
+    }
+    tabIndex={0}
+    type="button"
+  >
+    <div
+      className="css-view-g5y9jx r-alignItems-1awozwy r-justifyContent-1777fci"
+      dir={null}
+      ref={[Function]}
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+      >
+        settings
+      </div>
+    </div>
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "fontSize": "12px",
+          "fontWeight": "500",
+          "marginTop": "4px",
+        }
+      }
+    >
+      Settings
+    </div>
+  </button>
+</div>
+`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,12 @@ importers:
         specifier: '>=0.75'
         version: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
     devDependencies:
+      '@expo/vector-icons':
+        specifier: 14.1.0
+        version: 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      '@hum/ui-components':
+        specifier: workspace:*
+        version: link:../ui-components
       '@types/react':
         specifier: ^19.1.12
         version: 19.1.12
@@ -7734,6 +7740,12 @@ snapshots:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
 
+  '@expo/vector-icons@14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+
   '@expo/ws-tunnel@1.0.6': {}
 
   '@expo/xcpretty@4.3.2':
@@ -10458,6 +10470,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-asset@11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@expo/image-utils': 0.7.6
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)):
     dependencies:
       '@expo/config': 11.0.13
@@ -10467,10 +10489,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)):
+    dependencies:
+      '@expo/config': 11.0.13
+      '@expo/env': 1.0.7
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)):
     dependencies:
       expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -10478,9 +10514,20 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 19.1.1
 
+  expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      fontfaceobserver: 2.3.0
+      react: 19.1.1
+
   expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
       expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+
+  expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       react: 19.1.1
 
   expo-modules-autolinking@2.1.14:
@@ -10517,6 +10564,35 @@ snapshots:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
       react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      whatwg-url-without-unicode: 8.0.0-3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - graphql
+      - supports-color
+      - utf-8-validate
+
+  expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@expo/cli': 0.24.21
+      '@expo/config': 11.0.13
+      '@expo/config-plugins': 10.1.2
+      '@expo/fingerprint': 0.13.4
+      '@expo/metro-config': 0.20.17
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      babel-preset-expo: 13.2.4(@babel/core@7.28.3)
+      expo-asset: 11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      expo-file-system: 18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-keep-awake: 14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-modules-autolinking: 2.1.14
+      expo-modules-core: 2.5.0
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+      react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
       - '@babel/core'
@@ -12719,6 +12795,11 @@ snapshots:
     dependencies:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  react-native-edge-to-edge@1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,7 @@
       "@apps/*": ["apps/*/src"],
       "@packages/*": ["packages/*/src"],
       "@mchat/*": ["packages/*/src"],
+      "@hum/*": ["packages/*/src"],
       "@native/*": ["native/*/src"]
     }
   },


### PR DESCRIPTION
## Summary
- add BottomNavigation screen with themed tabs and badges
- include tests and storybook entry for BottomNavigation
- configure jest and tsconfig for hum imports

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e2be360c832fb0fd2dfb9d34c00e