### PR TITLE
feat: add ChatItem screen with tests and story

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -11,6 +11,7 @@
     "@babel/runtime": "7.28.3",
     "@hum/ui-components": "workspace:*",
     "@hum/ui-screens": "workspace:*",
+    "expo": "~53.0.22",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-native-web": "~0.21.1",

--- a/apps/storybook/storybook/stories/ChatItem.stories.tsx
+++ b/apps/storybook/storybook/stories/ChatItem.stories.tsx
@@ -11,13 +11,13 @@ const meta: Meta<typeof ChatItem> = {
   },
   args: {
     name: 'Alice',
-    message: 'Hello there',
+    message: 'Hello there. My Name is Alice. Do you know me?',
     time: '09:41',
-    avatar: 'https://placekitten.com/100/100',
+    avatar: 'https://picsum.photos/200/200',
     unreadCount: 2,
-    isRead: true,
-    hasHeart: true,
-    hasLocation: true,
+    isRead: false,
+    hasHeart: false,
+    hasLocation: false,
   },
 };
 

--- a/apps/storybook/storybook/stories/ChatItem.stories.tsx
+++ b/apps/storybook/storybook/stories/ChatItem.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ChatItem } from '@hum/ui-screens';
+
+type Story = StoryObj<typeof ChatItem>;
+
+const meta: Meta<typeof ChatItem> = {
+  title: 'Screens/ChatItem',
+  component: ChatItem,
+  argTypes: {
+    onPress: { action: 'pressed' },
+  },
+  args: {
+    name: 'Alice',
+    message: 'Hello there',
+    time: '09:41',
+    avatar: 'https://placekitten.com/100/100',
+    unreadCount: 2,
+    isRead: true,
+    hasHeart: true,
+    hasLocation: true,
+  },
+};
+
+export default meta;
+
+export const Basic: Story = {};
+export const Unread: Story = {
+  args: { unreadCount: 5, isRead: false },
+};
+export const NoIcons: Story = {
+  args: { hasHeart: false, hasLocation: false },
+};

--- a/packages/ui-screens/index.ts
+++ b/packages/ui-screens/index.ts
@@ -1,1 +1,2 @@
 export { DummyScreen } from './src/DummyScreen';
+export { ChatItem } from './src/ChatItem';

--- a/packages/ui-screens/src/ChatItem.test.tsx
+++ b/packages/ui-screens/src/ChatItem.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ChatItem, type ChatItemProps } from './ChatItem';
+import { ThemeProvider } from '../../ui-components/src/theme/ThemeProvider';
+
+type Scheme = 'light' | 'dark';
+
+const baseProps: ChatItemProps = {
+  name: 'Alice',
+  message: 'Hello there',
+  time: '09:41',
+  avatar: 'https://example.com/avatar.png',
+};
+
+function renderChatItem(
+  scheme: Scheme = 'light',
+  props?: Partial<ChatItemProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <ChatItem {...baseProps} {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('ChatItem Screen', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderChatItem();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('calls onPress when pressed', () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = renderChatItem('light', { onPress });
+    fireEvent.press(getByLabelText('Chat with Alice'));
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  it('shows unread badge', () => {
+    const { getByLabelText } = renderChatItem('light', {
+      unreadCount: 2,
+      isRead: true,
+    });
+    expect(getByLabelText('2 unread messages')).toBeTruthy();
+  });
+
+  it('applies theme colors', () => {
+    const { getByLabelText, rerender } = renderChatItem('light', {
+      unreadCount: 1,
+    });
+    expect(getByLabelText('1 unread messages')).toHaveStyle({
+      backgroundColor: 'rgba(254,202,26,1.00)',
+    });
+    rerender(
+      <ThemeProvider forcedScheme="dark">
+        <ChatItem {...baseProps} unreadCount={1} />
+      </ThemeProvider>,
+    );
+    expect(getByLabelText('1 unread messages')).toHaveStyle({
+      backgroundColor: 'rgba(254,202,26,1.00)',
+    });
+  });
+});

--- a/packages/ui-screens/src/ChatItem.tsx
+++ b/packages/ui-screens/src/ChatItem.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { Avatar, AvatarImage } from '../../ui-components/src/avatar';
+import { useTheme } from '../../ui-components/src/theme/ThemeProvider';
+
+export interface ChatItemProps {
+  name: string;
+  message: string;
+  time: string;
+  avatar: string;
+  isRead?: boolean;
+  isGroup?: boolean;
+  hasLocation?: boolean;
+  hasHeart?: boolean;
+  unreadCount?: number;
+  onPress?: () => void;
+}
+
+export const ChatItem: React.FC<ChatItemProps> = ({
+  name,
+  message,
+  time,
+  avatar,
+  isRead = false,
+  hasLocation = false,
+  hasHeart = false,
+  unreadCount = 0,
+  onPress,
+}) => {
+  const { colors, spacing, type } = useTheme();
+
+  return (
+    <Pressable
+      accessibilityRole={onPress ? 'button' : 'none'}
+      accessibilityLabel={`Chat with ${name}`}
+      onPress={onPress}
+      style={({ pressed }: { pressed: boolean }) => [
+        styles.container,
+        {
+          paddingHorizontal: spacing.md,
+          paddingVertical: spacing.sm,
+          backgroundColor: pressed ? colors.muted : 'transparent',
+        },
+      ]}
+    >
+      <View style={{ marginRight: spacing.md }}>
+        <Avatar size={48}>
+          <AvatarImage
+            source={{ uri: avatar }}
+            accessibilityLabel={`${name} avatar`}
+          />
+        </Avatar>
+        {unreadCount > 0 && (
+          <View
+            testID="unread-badge"
+            dataSet={{ testid: 'unread-badge' }}
+            style={[styles.unreadBadge, { backgroundColor: colors.humPrimary }]}
+            accessible
+            accessibilityLabel={`${unreadCount} unread messages`}
+          >
+            <Text
+              style={[
+                styles.unreadText,
+                {
+                  color: colors.humPrimaryForeground,
+                  fontSize: type.size.sm,
+                  fontWeight: type.weight.bold,
+                },
+              ]}
+            >
+              {unreadCount}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      <View style={styles.content}>
+        <View style={styles.headerRow}>
+          <View style={styles.nameRow}>
+            <Text
+              style={[
+                styles.name,
+                {
+                  color: colors.foreground,
+                  fontSize: type.size.md,
+                  fontWeight: type.weight.medium,
+                },
+              ]}
+              numberOfLines={1}
+            >
+              {name}
+            </Text>
+            {hasHeart && <Text style={styles.icon}>❤️</Text>}
+            {hasLocation && <Text style={styles.icon}>📍</Text>}
+          </View>
+          <Text
+            style={[
+              styles.time,
+              { color: colors.mutedForeground, fontSize: type.size.sm },
+            ]}
+          >
+            {time}
+          </Text>
+        </View>
+
+        <View style={styles.messageRow}>
+          {isRead && (
+            <Text style={[styles.icon, { marginRight: spacing.xs }]}>✓✓</Text>
+          )}
+          <Text
+            style={[
+              styles.message,
+              { color: colors.mutedForeground, fontSize: type.size.sm },
+            ]}
+            numberOfLines={1}
+          >
+            {message}
+          </Text>
+        </View>
+      </View>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  content: {
+    flex: 1,
+    minWidth: 0,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 2,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  name: {
+    marginRight: 4,
+  },
+  icon: {
+    marginLeft: 4,
+  },
+  time: {
+    flexShrink: 0,
+  },
+  messageRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  message: {
+    flexShrink: 1,
+  },
+  unreadBadge: {
+    position: 'absolute',
+    bottom: -2,
+    right: -2,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  unreadText: {
+    textAlign: 'center',
+  },
+});
+
+export default ChatItem;

--- a/packages/ui-screens/src/ChatItem.tsx
+++ b/packages/ui-screens/src/ChatItem.tsx
@@ -53,7 +53,6 @@ export const ChatItem: React.FC<ChatItemProps> = ({
         {unreadCount > 0 && (
           <View
             testID="unread-badge"
-            dataSet={{ testid: 'unread-badge' }}
             style={[styles.unreadBadge, { backgroundColor: colors.humPrimary }]}
             accessible
             accessibilityLabel={`${unreadCount} unread messages`}

--- a/packages/ui-screens/src/__snapshots__/ChatItem.test.tsx.snap
+++ b/packages/ui-screens/src/__snapshots__/ChatItem.test.tsx.snap
@@ -1,0 +1,154 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ChatItem Screen renders and matches snapshot 1`] = `
+<div
+  aria-label="Chat with Alice"
+  className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz"
+  dir={null}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  ref={[Function]}
+  role="presentation"
+  style={
+    {
+      "backgroundColor": "rgba(0,0,0,0.00)",
+      "paddingBottom": "8px",
+      "paddingLeft": "12px",
+      "paddingRight": "12px",
+      "paddingTop": "8px",
+    }
+  }
+  tabIndex={0}
+>
+  <div
+    className="css-view-g5y9jx"
+    dir={null}
+    ref={[Function]}
+    style={
+      {
+        "marginRight": "12px",
+      }
+    }
+  >
+    <div
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-justifyContent-1777fci r-overflow-1udh08x"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="img"
+      style={
+        {
+          "borderBottomLeftRadius": "24px",
+          "borderBottomRightRadius": "24px",
+          "borderTopLeftRadius": "24px",
+          "borderTopRightRadius": "24px",
+          "height": "48px",
+          "width": "48px",
+        }
+      }
+      tabIndex={0}
+    >
+      <div
+        aria-label="Alice avatar"
+        className="css-view-g5y9jx r-flexBasis-1mlwlqe r-overflow-1udh08x r-zIndex-417010 r-height-1pi2tsx r-width-13qz1uu"
+        dir={null}
+        ref={[Function]}
+      >
+        <div
+          className="css-view-g5y9jx r-backgroundColor-1niwhzg r-backgroundPosition-vvn4in r-backgroundRepeat-u6sd8q r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-zIndex-1wyyakw r-backgroundSize-4gszlv"
+          dir={null}
+          ref={[Function]}
+          style={
+            {
+              "backgroundImage": "url("https://example.com/avatar.png")",
+            }
+          }
+          suppressHydrationWarning={true}
+        />
+        <img
+          alt="Alice avatar"
+          className="css-accessibilityImage-9pa8cd"
+          draggable={false}
+          ref={
+            {
+              "current": null,
+            }
+          }
+          src="https://example.com/avatar.png"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-view-g5y9jx r-flex-13awgt0 r-minWidth-bcqeeo"
+    dir={null}
+    ref={[Function]}
+  >
+    <div
+      className="css-view-g5y9jx r-flexDirection-18u37iz r-justifyContent-1wtj0ep r-marginBottom-zl2h9q"
+      dir={null}
+      ref={[Function]}
+    >
+      <div
+        className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+        dir={null}
+        ref={[Function]}
+      >
+        <div
+          className="css-text-146c3p1 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-marginRight-1d4mawv"
+          dir="auto"
+          ref={[Function]}
+          style={
+            {
+              "color": "rgba(10,10,10,1.00)",
+              "fontSize": "16px",
+              "fontWeight": "500",
+            }
+          }
+        >
+          Alice
+        </div>
+      </div>
+      <div
+        className="css-text-146c3p1 r-flexShrink-1q142lx"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+          }
+        }
+      >
+        09:41
+      </div>
+    </div>
+    <div
+      className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+      dir={null}
+      ref={[Function]}
+    >
+      <div
+        className="css-text-146c3p1 r-maxWidth-dnmrzs r-overflow-1udh08x r-textOverflow-1udbk01 r-whiteSpace-3s2u2q r-wordWrap-1iln25a r-flexShrink-1wbh5a2"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+          }
+        }
+      >
+        Hello there
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/ui-screens/tsconfig.json
+++ b/packages/ui-screens/tsconfig.json
@@ -2,12 +2,18 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "declaration": true,
-    "rootDir": ".",
+    "rootDir": "..",
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
     "types": ["jest", "react", "react-native"]
   },
-  "include": ["src", "**/*.ts", "**/*.tsx"],
-  "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]
+  "include": ["src", "../ui-components/src/**/*", "**/*.ts", "**/*.tsx"],
+  "exclude": [
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "../ui-components/src/**/*.test.ts",
+    "../ui-components/src/**/*.test.tsx"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       '@hum/ui-screens':
         specifier: workspace:*
         version: link:../../packages/ui-screens
+      expo:
+        specifier: ~53.0.22
+        version: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       react:
         specifier: ^19.0.0
         version: 19.1.1
@@ -7734,6 +7737,12 @@ snapshots:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
 
+  '@expo/vector-icons@14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+
   '@expo/ws-tunnel@1.0.6': {}
 
   '@expo/xcpretty@4.3.2':
@@ -10458,6 +10467,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-asset@11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@expo/image-utils': 0.7.6
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)):
     dependencies:
       '@expo/config': 11.0.13
@@ -10467,10 +10486,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)):
+    dependencies:
+      '@expo/config': 11.0.13
+      '@expo/env': 1.0.7
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)):
     dependencies:
       expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -10478,9 +10511,20 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 19.1.1
 
+  expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      fontfaceobserver: 2.3.0
+      react: 19.1.1
+
   expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
       expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+
+  expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       react: 19.1.1
 
   expo-modules-autolinking@2.1.14:
@@ -10517,6 +10561,35 @@ snapshots:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
       react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      whatwg-url-without-unicode: 8.0.0-3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - graphql
+      - supports-color
+      - utf-8-validate
+
+  expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@expo/cli': 0.24.21
+      '@expo/config': 11.0.13
+      '@expo/config-plugins': 10.1.2
+      '@expo/fingerprint': 0.13.4
+      '@expo/metro-config': 0.20.17
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      babel-preset-expo: 13.2.4(@babel/core@7.28.3)
+      expo-asset: 11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      expo-file-system: 18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-keep-awake: 14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-modules-autolinking: 2.1.14
+      expo-modules-core: 2.5.0
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+      react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
       - '@babel/core'
@@ -12719,6 +12792,11 @@ snapshots:
     dependencies:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  react-native-edge-to-edge@1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add ChatItem screen leveraging shared Avatar component
- cover ChatItem screen with unit tests and Storybook stories

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e77f743c832f833ad9876e1ed7f7