### PR TITLE
feat: add TopBar screen

### DIFF
--- a/apps/storybook/assets-registry.ts
+++ b/apps/storybook/assets-registry.ts
@@ -1,0 +1,13 @@
+export const registerAsset = () => 0;
+export const getAssetByID = () => ({
+  __packager_asset: true,
+  fileSystemLocation: '',
+  httpServerLocation: '',
+  width: 0,
+  height: 0,
+  scales: [1],
+  hash: '',
+  name: '',
+  type: '',
+});
+export default { registerAsset, getAssetByID };

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "start": "storybook dev -p 7007",
+    "start": "storybook dev -p 7007 --no-open",
     "ios": "expo run:ios",
     "android": "expo run:android"
   },

--- a/apps/storybook/storybook/stories/TopBar.stories.tsx
+++ b/apps/storybook/storybook/stories/TopBar.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TopBar } from '@hum/ui-screens';
+
+const meta: Meta<typeof TopBar> = {
+  title: 'Screens/TopBar',
+  component: TopBar,
+  argTypes: {
+    onMorePress: { action: 'morePress' },
+    onCameraPress: { action: 'cameraPress' },
+    onAddPress: { action: 'addPress' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TopBar>;
+
+export const Basic: Story = {};
+
+export const CustomStyled: Story = {
+  args: {
+    style: { backgroundColor: '#EEE' },
+  },
+};

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -21,11 +21,18 @@ export default defineConfig({
       'react-native-safe-area-context': r(
         './react-native-safe-area-context.tsx',
       ),
+      '@react-native/assets-registry/registry': r('./assets-registry.ts'),
+      '@react-native/assets-registry': r('./assets-registry.ts'),
     },
   },
   optimizeDeps: {
     exclude: ['storybook', '@storybook/*'],
     include: ['react', 'react-dom', 'react-native-web'],
+    esbuildOptions: {
+      loader: {
+        '.js': 'tsx',
+      },
+    },
   },
   ssr: {
     noExternal: ['storybook', '@storybook/*'],

--- a/packages/ui-screens/index.ts
+++ b/packages/ui-screens/index.ts
@@ -1,1 +1,2 @@
 export { DummyScreen } from './src/DummyScreen';
+export { TopBar } from './src/TopBar';

--- a/packages/ui-screens/package.json
+++ b/packages/ui-screens/package.json
@@ -23,9 +23,12 @@
   },
   "devDependencies": {
     "@types/react": "^19.1.12",
+    "@types/react-native": "0.73.0",
     "react-native-safe-area-context": "5.4.0"
   },
   "dependencies": {
-    "@testing-library/jest-dom": "6.8.0"
+    "@testing-library/jest-dom": "6.8.0",
+    "@hum/ui-components": "workspace:*",
+    "@expo/vector-icons": "14.1.0"
   }
 }

--- a/packages/ui-screens/src/TopBar.test.tsx
+++ b/packages/ui-screens/src/TopBar.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react-native';
+import { ThemeProvider } from '@hum/ui-components';
+import { colors } from '../../ui-components/src/theme/colors';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Feather: () => null,
+}));
+import { TopBar, type TopBarProps } from './TopBar';
+
+const hexToRgba = (hex: string) => {
+  const bigint = parseInt(hex.slice(1), 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r},${g},${b},1.00)`;
+};
+
+function renderTopBar(
+  scheme: 'light' | 'dark' = 'light',
+  props?: Partial<TopBarProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <TopBar {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('TopBar', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderTopBar();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('handles button presses', () => {
+    const more = jest.fn();
+    const camera = jest.fn();
+    const add = jest.fn();
+    renderTopBar('light', {
+      onMorePress: more,
+      onCameraPress: camera,
+      onAddPress: add,
+    });
+    fireEvent.press(screen.getByLabelText('More options'));
+    fireEvent.press(screen.getByLabelText('Open camera'));
+    fireEvent.press(screen.getByLabelText('Add'));
+    expect(more).toHaveBeenCalled();
+    expect(camera).toHaveBeenCalled();
+    expect(add).toHaveBeenCalled();
+  });
+
+  it('applies theme colors', () => {
+    const { unmount, toJSON } = renderTopBar('light');
+    const root = toJSON() as { props: { style: Record<string, unknown> } };
+    expect(root.props.style).toMatchObject({
+      backgroundColor: hexToRgba(colors.light.background),
+    });
+    unmount();
+    const darkRender = renderTopBar('dark');
+    const darkRoot = darkRender.toJSON() as {
+      props: { style: Record<string, unknown> };
+    };
+    expect(darkRoot.props.style).toMatchObject({
+      backgroundColor: hexToRgba(colors.dark.background),
+    });
+  });
+});

--- a/packages/ui-screens/src/TopBar.tsx
+++ b/packages/ui-screens/src/TopBar.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { View, Pressable, StyleSheet, ViewProps } from 'react-native';
+import { useTheme } from '@hum/ui-components';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Feather } from '@expo/vector-icons';
+
+export interface TopBarProps extends ViewProps {
+  onMorePress?: () => void;
+  onCameraPress?: () => void;
+  onAddPress?: () => void;
+}
+
+export const TopBar: React.FC<TopBarProps> = ({
+  onMorePress,
+  onCameraPress,
+  onAddPress,
+  style,
+  ...rest
+}) => {
+  const { colors, spacing } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          paddingTop: insets.top + spacing.lg,
+          paddingBottom: spacing.lg,
+          paddingHorizontal: spacing.lg,
+        },
+        style,
+      ]}
+      {...rest}
+    >
+      <Pressable
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel="More options"
+        onPress={onMorePress}
+        hitSlop={8}
+        style={styles.iconButton}
+      >
+        <Feather name="more-horizontal" size={24} color={colors.foreground} />
+      </Pressable>
+
+      <View style={styles.rightGroup}>
+        <Pressable
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Open camera"
+          onPress={onCameraPress}
+          hitSlop={8}
+          style={[styles.iconButton, { marginRight: spacing.lg }]}
+        >
+          <Feather name="camera" size={24} color={colors.foreground} />
+        </Pressable>
+
+        <Pressable
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Add"
+          onPress={onAddPress}
+          hitSlop={8}
+          style={[styles.addButton, { backgroundColor: colors.humPrimary }]}
+        >
+          <Feather name="plus" size={24} color={colors.humPrimaryForeground} />
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  rightGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  iconButton: {
+    width: 24,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addButton: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default TopBar;

--- a/packages/ui-screens/src/__snapshots__/TopBar.test.tsx.snap
+++ b/packages/ui-screens/src/__snapshots__/TopBar.test.tsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`TopBar renders and matches snapshot 1`] = `
+<div
+  className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+  dir={null}
+  ref={[Function]}
+  style={
+    {
+      "backgroundColor": "rgba(255,255,255,1.00)",
+      "paddingBottom": "16px",
+      "paddingLeft": "16px",
+      "paddingRight": "16px",
+      "paddingTop": "16px",
+    }
+  }
+>
+  <button
+    aria-label="More options"
+    className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-height-1472mwg r-justifyContent-1777fci r-width-lrsllp"
+    dir={null}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    ref={[Function]}
+    role="button"
+    tabIndex={0}
+    type="button"
+  />
+  <div
+    className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+    dir={null}
+    ref={[Function]}
+  >
+    <button
+      aria-label="Open camera"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-height-1472mwg r-justifyContent-1777fci r-width-lrsllp"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "marginRight": "16px",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    />
+    <button
+      aria-label="Add"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-borderRadius-a1yn9n r-height-1mwlp6a r-justifyContent-1777fci r-width-18tzken"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "backgroundColor": "rgba(254,202,26,1.00)",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    />
+  </div>
+</div>
+`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,12 @@ importers:
 
   packages/ui-screens:
     dependencies:
+      '@expo/vector-icons':
+        specifier: 14.1.0
+        version: 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      '@hum/ui-components':
+        specifier: workspace:*
+        version: link:../ui-components
       '@testing-library/jest-dom':
         specifier: 6.8.0
         version: 6.8.0
@@ -229,6 +235,9 @@ importers:
       '@types/react':
         specifier: ^19.1.12
         version: 19.1.12
+      '@types/react-native':
+        specifier: 0.73.0
+        version: 0.73.0(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
       react-native-safe-area-context:
         specifier: 5.4.0
         version: 5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
@@ -7734,6 +7743,12 @@ snapshots:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
 
+  '@expo/vector-icons@14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+
   '@expo/ws-tunnel@1.0.6': {}
 
   '@expo/xcpretty@4.3.2':
@@ -9004,6 +9019,18 @@ snapshots:
   '@types/node@24.3.0':
     dependencies:
       undici-types: 7.10.0
+
+  '@types/react-native@0.73.0(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)':
+    dependencies:
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-community/cli'
+      - '@types/react'
+      - bufferutil
+      - react
+      - supports-color
+      - utf-8-validate
 
   '@types/react-native@0.73.0(@babel/core@7.28.3)(@types/react@19.1.12)(react@19.1.1)':
     dependencies:
@@ -10458,6 +10485,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-asset@11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@expo/image-utils': 0.7.6
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)):
     dependencies:
       '@expo/config': 11.0.13
@@ -10467,10 +10504,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)):
+    dependencies:
+      '@expo/config': 11.0.13
+      '@expo/env': 1.0.7
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)):
     dependencies:
       expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -10478,9 +10529,20 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 19.1.1
 
+  expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      fontfaceobserver: 2.3.0
+      react: 19.1.1
+
   expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
       expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+
+  expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       react: 19.1.1
 
   expo-modules-autolinking@2.1.14:
@@ -10517,6 +10579,35 @@ snapshots:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
       react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      whatwg-url-without-unicode: 8.0.0-3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - graphql
+      - supports-color
+      - utf-8-validate
+
+  expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@expo/cli': 0.24.21
+      '@expo/config': 11.0.13
+      '@expo/config-plugins': 10.1.2
+      '@expo/fingerprint': 0.13.4
+      '@expo/metro-config': 0.20.17
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      babel-preset-expo: 13.2.4(@babel/core@7.28.3)
+      expo-asset: 11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      expo-file-system: 18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-keep-awake: 14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-modules-autolinking: 2.1.14
+      expo-modules-core: 2.5.0
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+      react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
       - '@babel/core'
@@ -12719,6 +12810,11 @@ snapshots:
     dependencies:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  react-native-edge-to-edge@1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add TopBar screen with brand-colored action button and icon presses
- include tests and storybook stories

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e7deca30832fb968ec6e43171b78