### PR TITLE
feat: add ChatView screen and message bubble component

### DIFF
--- a/apps/storybook/storybook/stories/ChatView.stories.tsx
+++ b/apps/storybook/storybook/stories/ChatView.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ChatView } from '@hum/ui-screens';
+
+const meta: Meta<typeof ChatView> = {
+  title: 'Screens/ChatView',
+  component: ChatView,
+  args: {
+    chatName: 'Jane Doe',
+    chatAvatar: 'https://placekitten.com/200/200',
+    onBack: () => {},
+  },
+  argTypes: {
+    onBack: { action: 'back' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ChatView>;
+
+export const Basic: Story = {};
+export const Empty: Story = {
+  args: { messages: [] },
+};

--- a/apps/storybook/storybook/stories/MessageBubble.stories.tsx
+++ b/apps/storybook/storybook/stories/MessageBubble.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MessageBubble } from '@hum/ui-components';
+
+const meta: Meta<typeof MessageBubble> = {
+  title: 'Components/MessageBubble',
+  component: MessageBubble,
+  args: {
+    text: 'Hello there!',
+    time: '14:00',
+    isOutgoing: false,
+  },
+  argTypes: {
+    isOutgoing: { control: 'boolean' },
+    isRead: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageBubble>;
+
+export const Incoming: Story = {};
+export const OutgoingRead: Story = {
+  args: { isOutgoing: true, isRead: true },
+};

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -34,3 +34,5 @@ export { Badge } from './src/badge';
 export type { BadgeProps, BadgeVariant } from './src/badge';
 export { AspectRatio } from './src/aspect-ratio';
 export type { AspectRatioProps } from './src/aspect-ratio';
+export { MessageBubble } from './src/message-bubble';
+export type { MessageBubbleProps } from './src/message-bubble';

--- a/packages/ui-components/src/message-bubble.test.tsx
+++ b/packages/ui-components/src/message-bubble.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { MessageBubble, type MessageBubbleProps } from './message-bubble';
+import { ThemeProvider } from './theme/ThemeProvider';
+
+function renderBubble(
+  scheme: 'light' | 'dark' = 'light',
+  props?: Partial<MessageBubbleProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <MessageBubble
+        testID="bubble"
+        text="Hello"
+        time="10:00"
+        isOutgoing={false}
+        {...props}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe('MessageBubble', () => {
+  it('renders component', () => {
+    renderBubble();
+    expect(screen.getByTestId('bubble')).toBeInTheDocument();
+  });
+
+  it('shows read indicator for outgoing read messages', () => {
+    renderBubble('light', { isOutgoing: true, isRead: true });
+    expect(screen.getByText('✓✓')).toBeInTheDocument();
+  });
+
+  it('supports dark mode', () => {
+    const { rerender } = renderBubble('light');
+    rerender(
+      <ThemeProvider forcedScheme="dark">
+        <MessageBubble
+          testID="bubble"
+          text="Hello"
+          time="10:00"
+          isOutgoing={false}
+        />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId('bubble')).toBeInTheDocument();
+  });
+});

--- a/packages/ui-components/src/message-bubble.tsx
+++ b/packages/ui-components/src/message-bubble.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { View, Text, StyleSheet, ViewStyle, TextStyle } from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export interface MessageBubbleProps {
+  text: string;
+  time: string;
+  isOutgoing: boolean;
+  isRead?: boolean;
+  testID?: string;
+}
+
+export const MessageBubble: React.FC<MessageBubbleProps> = ({
+  text,
+  time,
+  isOutgoing,
+  isRead,
+  testID,
+}) => {
+  const { colors, spacing, radius, type } = useTheme();
+
+  const containerStyle = React.useMemo<ViewStyle>(
+    () => ({
+      justifyContent: isOutgoing ? 'flex-end' : 'flex-start',
+      marginBottom: spacing.md,
+    }),
+    [isOutgoing, spacing],
+  );
+
+  const bubbleStyle = React.useMemo<ViewStyle>(
+    () => ({
+      backgroundColor: isOutgoing ? colors.humPrimary : colors.muted,
+      paddingHorizontal: spacing.lg,
+      paddingVertical: spacing.sm,
+      borderRadius: radius.xl,
+      maxWidth: '80%',
+    }),
+    [isOutgoing, colors, spacing, radius],
+  );
+
+  const metaStyle = React.useMemo<ViewStyle>(
+    () => ({ marginTop: spacing.xs, opacity: isOutgoing ? 0.7 : 1 }),
+    [spacing, isOutgoing],
+  );
+
+  const messageTextStyle = React.useMemo<TextStyle>(
+    () => ({
+      fontSize: type.size.base,
+      color: isOutgoing ? colors.humPrimaryForeground : colors.foreground,
+    }),
+    [isOutgoing, colors, type],
+  );
+
+  const timeTextStyle = React.useMemo<TextStyle>(
+    () => ({
+      fontSize: type.size.sm,
+      color: isOutgoing ? colors.humPrimaryForeground : colors.mutedForeground,
+    }),
+    [isOutgoing, colors, type],
+  );
+
+  const checkStyle = React.useMemo<TextStyle>(
+    () => ({
+      marginLeft: spacing.xs,
+      fontSize: type.size.sm,
+      color: colors.humPrimaryForeground,
+    }),
+    [spacing, type, colors],
+  );
+
+  return (
+    <View
+      style={[styles.container, containerStyle]}
+      {...(testID ? { testID, 'data-testid': testID } : {})}
+    >
+      <View style={[styles.bubble, bubbleStyle]}>
+        <Text style={messageTextStyle}>{text}</Text>
+        <View style={[styles.meta, metaStyle]}>
+          <Text style={timeTextStyle}>{time}</Text>
+          {isOutgoing && isRead && <Text style={checkStyle}>✓✓</Text>}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+  },
+  bubble: {
+    flexShrink: 1,
+  },
+  meta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+  },
+});
+
+export default MessageBubble;

--- a/packages/ui-screens/index.ts
+++ b/packages/ui-screens/index.ts
@@ -1,1 +1,3 @@
 export { DummyScreen } from './src/DummyScreen';
+export { ChatView } from './src/ChatView';
+export type { ChatViewProps } from './src/ChatView';

--- a/packages/ui-screens/package.json
+++ b/packages/ui-screens/package.json
@@ -26,6 +26,8 @@
     "react-native-safe-area-context": "5.4.0"
   },
   "dependencies": {
-    "@testing-library/jest-dom": "6.8.0"
+    "@testing-library/jest-dom": "6.8.0",
+    "@expo/vector-icons": "14.1.0",
+    "@hum/ui-components": "workspace:*"
   }
 }

--- a/packages/ui-screens/src/ChatView.test.tsx
+++ b/packages/ui-screens/src/ChatView.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider } from '@hum/ui-components';
+import { ChatView, type ChatViewProps } from './ChatView';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0 }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: Record<string, unknown>) => <span {...props} />,
+}));
+
+describe('ChatView', () => {
+  const baseProps: ChatViewProps = {
+    chatName: 'Alice',
+    chatAvatar: 'https://example.com/avatar.png',
+    onBack: jest.fn(),
+  };
+
+  function renderScreen(overrides?: Partial<ChatViewProps>) {
+    return render(
+      <ThemeProvider forcedScheme="light">
+        <ChatView {...baseProps} {...overrides} />
+      </ThemeProvider>,
+    );
+  }
+
+  it('renders messages and header', () => {
+    renderScreen();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Hey! How are you doing?')).toBeInTheDocument();
+  });
+
+  it('triggers onBack when back button pressed', () => {
+    const onBack = jest.fn();
+    renderScreen({ onBack });
+    fireEvent.click(screen.getByLabelText('Back'));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('updates input value', () => {
+    renderScreen();
+    const input = screen.getByPlaceholderText('Type a message...');
+    fireEvent.change(input, { target: { value: 'hello' } });
+    expect(input).toHaveValue('hello');
+  });
+
+  it('supports empty messages state', () => {
+    renderScreen({ messages: [] });
+    expect(screen.queryByText('Hey! How are you doing?')).toBeNull();
+  });
+});

--- a/packages/ui-screens/src/ChatView.tsx
+++ b/packages/ui-screens/src/ChatView.tsx
@@ -1,0 +1,399 @@
+import React, { useState } from 'react';
+/* eslint-disable @typescript-eslint/no-require-imports */
+import type { ViewStyle, TextStyle } from 'react-native';
+
+const {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  TextInput,
+  ImageBackground,
+} = require('react-native');
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import {
+  useTheme,
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  MessageBubble,
+} from '@hum/ui-components';
+
+interface ChatMessage {
+  id: string;
+  text: string;
+  time: string;
+  isOutgoing: boolean;
+  isRead?: boolean;
+}
+
+export interface ChatViewProps {
+  chatName: string;
+  chatAvatar: string;
+  onBack: () => void;
+  messages?: ChatMessage[];
+}
+
+const mockMessages: ChatMessage[] = [
+  {
+    id: '1',
+    text: 'Hey! How are you doing?',
+    time: '14:15',
+    isOutgoing: false,
+  },
+  {
+    id: '2',
+    text: "I'm doing great! Just finished work. What about you?",
+    time: '14:17',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '3',
+    text: 'Same here! Just wrapped up a big project',
+    time: '14:18',
+    isOutgoing: false,
+  },
+  {
+    id: '4',
+    text: "That's awesome! What kind of project was it?",
+    time: '14:20',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '5',
+    text: 'A mobile app redesign for a client. Took us 3 months but finally done!',
+    time: '14:22',
+    isOutgoing: false,
+  },
+  {
+    id: '6',
+    text: 'Wow, that sounds like a lot of work! Congratulations on finishing it 🎉',
+    time: '14:23',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '7',
+    text: 'Thanks! It was challenging but really rewarding',
+    time: '14:25',
+    isOutgoing: false,
+  },
+  {
+    id: '8',
+    text: 'Want to grab coffee later to celebrate?',
+    time: '14:27',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '9',
+    text: 'That sounds perfect! What time works for you?',
+    time: '14:28',
+    isOutgoing: false,
+  },
+  {
+    id: '10',
+    text: 'How about 4 PM at the usual place?',
+    time: '14:30',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '11',
+    text: 'Perfect! The coffee shop near the park right?',
+    time: '14:31',
+    isOutgoing: false,
+  },
+  {
+    id: '12',
+    text: 'Yes exactly! See you there 😊',
+    time: '14:32',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '13',
+    text: 'Looking forward to it! Should I bring anything?',
+    time: '14:35',
+    isOutgoing: false,
+  },
+  {
+    id: '14',
+    text: 'Just yourself! But if you want, you could bring those photos you mentioned last week',
+    time: '14:37',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '15',
+    text: 'Oh yes! The ones from the hiking trip. I almost forgot',
+    time: '14:38',
+    isOutgoing: false,
+  },
+  {
+    id: '16',
+    text: 'Of course! I have them ready on my phone',
+    time: '14:40',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '17',
+    text: "Great! Can't wait to see them. That trail looked amazing in your stories",
+    time: '14:42',
+    isOutgoing: false,
+  },
+  {
+    id: '18',
+    text: 'It really was! The sunset from the peak was incredible',
+    time: '14:44',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '19',
+    text: 'I need to plan a hiking trip soon. Work has been so stressful lately',
+    time: '14:46',
+    isOutgoing: false,
+  },
+  {
+    id: '20',
+    text: 'We should definitely plan one together! I know some great trails nearby',
+    time: '14:48',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '21',
+    text: 'That would be amazing! I could really use some time in nature',
+    time: '14:50',
+    isOutgoing: false,
+  },
+  {
+    id: '22',
+    text: "Let's discuss it over coffee today. I have some ideas 🏔️",
+    time: '14:52',
+    isOutgoing: true,
+    isRead: false,
+  },
+];
+
+export const ChatView: React.FC<ChatViewProps> = ({
+  chatName,
+  chatAvatar,
+  onBack,
+  messages = mockMessages,
+}) => {
+  const { colors, spacing, radius, type } = useTheme();
+  const insets = useSafeAreaInsets();
+  const [text, setText] = useState('');
+
+  const backButtonStyle = React.useMemo<ViewStyle>(
+    () => ({ marginRight: spacing.md }),
+    [spacing],
+  );
+  const nameContainerStyle = React.useMemo<ViewStyle>(
+    () => ({ marginLeft: spacing.md }),
+    [spacing],
+  );
+  const headerIconStyle = React.useMemo<ViewStyle>(
+    () => ({ marginLeft: spacing.lg }),
+    [spacing],
+  );
+  const imageRepeatStyle = React.useMemo(() => ({ resizeMode: 'repeat' }), []);
+  const scrollContentStyle = React.useMemo<ViewStyle>(
+    () => ({ paddingHorizontal: spacing.lg, paddingVertical: spacing.lg }),
+    [spacing],
+  );
+  const inputWrapperStyle = React.useMemo<ViewStyle>(
+    () => ({
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.muted,
+      borderRadius: radius.xl,
+      paddingHorizontal: spacing.lg,
+      paddingVertical: spacing.sm,
+      marginHorizontal: spacing.md,
+    }),
+    [colors.muted, radius.xl, spacing.lg, spacing.sm, spacing.md],
+  );
+  const textInputStyle = React.useMemo<TextStyle>(
+    () => ({
+      flex: 1,
+      color: colors.foreground,
+      fontSize: type.size.base,
+      padding: 0,
+    }),
+    [colors.foreground, type.size.base],
+  );
+  const micStyle = React.useMemo<ViewStyle>(
+    () => ({ marginLeft: spacing.md }),
+    [spacing],
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      {/* Header */}
+      <View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top + spacing.md,
+            borderBottomColor: colors.border,
+            backgroundColor: colors.background,
+          },
+        ]}
+      >
+        <View style={styles.headerLeft}>
+          <Pressable
+            onPress={onBack}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+            style={backButtonStyle}
+          >
+            <Ionicons name="arrow-back" size={24} color={colors.foreground} />
+          </Pressable>
+          <Avatar size={40}>
+            <AvatarImage source={{ uri: chatAvatar }} />
+            <AvatarFallback>{chatName.charAt(0)}</AvatarFallback>
+          </Avatar>
+          <View style={nameContainerStyle}>
+            <Text
+              style={{
+                color: colors.foreground,
+                fontSize: type.size.md,
+                fontWeight: type.weight.medium,
+              }}
+            >
+              {chatName}
+            </Text>
+            <Text
+              style={{ fontSize: type.size.sm, color: colors.mutedForeground }}
+            >
+              online
+            </Text>
+          </View>
+        </View>
+        <View style={styles.headerActions}>
+          <Ionicons
+            name="videocam"
+            size={24}
+            color={colors.foreground}
+            style={headerIconStyle}
+          />
+          <Ionicons
+            name="call"
+            size={24}
+            color={colors.foreground}
+            style={headerIconStyle}
+          />
+          <Ionicons
+            name="ellipsis-vertical"
+            size={24}
+            color={colors.foreground}
+            style={headerIconStyle}
+          />
+        </View>
+      </View>
+
+      {/* Messages */}
+      <ImageBackground
+        source={{
+          uri: "data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23666' fill-opacity='0.03'%3E%3Cpath d='M20 20c0-5.5-4.5-10-10-10s-10 4.5-10 10 4.5 10 10 10 10-4.5 10-10zm10 0c0-5.5-4.5-10-10-10s-10 4.5-10 10 4.5 10 10 10 10-4.5 10-10z'/%3E%3C/g%3E%3C/svg%3E",
+        }}
+        style={styles.messages}
+        imageStyle={imageRepeatStyle}
+      >
+        <ScrollView contentContainerStyle={scrollContentStyle}>
+          {messages.map((m) => (
+            <MessageBubble
+              key={m.id}
+              text={m.text}
+              time={m.time}
+              isOutgoing={m.isOutgoing}
+              isRead={m.isRead}
+            />
+          ))}
+        </ScrollView>
+      </ImageBackground>
+
+      {/* Input Area */}
+      <View
+        style={[
+          styles.inputArea,
+          {
+            paddingBottom: insets.bottom + spacing.sm,
+            borderTopColor: colors.border,
+            backgroundColor: colors.background,
+          },
+        ]}
+      >
+        <View style={styles.inputRow}>
+          <Ionicons name="add" size={24} color={colors.mutedForeground} />
+          <View style={inputWrapperStyle}>
+            <TextInput
+              style={textInputStyle}
+              placeholder="Type a message..."
+              placeholderTextColor={colors.mutedForeground}
+              value={text}
+              onChangeText={setText}
+              accessibilityLabel="Message input"
+            />
+            <Ionicons
+              name="happy-outline"
+              size={20}
+              color={colors.mutedForeground}
+            />
+          </View>
+          <Ionicons name="camera" size={24} color={colors.mutedForeground} />
+          <Ionicons
+            name="mic"
+            size={24}
+            color={colors.mutedForeground}
+            style={micStyle}
+          />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: 1,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexShrink: 1,
+  },
+  headerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  messages: {
+    flex: 1,
+  },
+  inputArea: {
+    borderTopWidth: 1,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});
+
+export default ChatView;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,12 @@ importers:
 
   packages/ui-screens:
     dependencies:
+      '@expo/vector-icons':
+        specifier: 14.1.0
+        version: 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      '@hum/ui-components':
+        specifier: workspace:*
+        version: link:../ui-components
       '@testing-library/jest-dom':
         specifier: 6.8.0
         version: 6.8.0
@@ -7734,6 +7740,12 @@ snapshots:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
 
+  '@expo/vector-icons@14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+
   '@expo/ws-tunnel@1.0.6': {}
 
   '@expo/xcpretty@4.3.2':
@@ -10458,6 +10470,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-asset@11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@expo/image-utils': 0.7.6
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)):
     dependencies:
       '@expo/config': 11.0.13
@@ -10467,10 +10489,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)):
+    dependencies:
+      '@expo/config': 11.0.13
+      '@expo/env': 1.0.7
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)):
     dependencies:
       expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -10478,9 +10514,20 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 19.1.1
 
+  expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      fontfaceobserver: 2.3.0
+      react: 19.1.1
+
   expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
       expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+
+  expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       react: 19.1.1
 
   expo-modules-autolinking@2.1.14:
@@ -10517,6 +10564,35 @@ snapshots:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
       react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      whatwg-url-without-unicode: 8.0.0-3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - graphql
+      - supports-color
+      - utf-8-validate
+
+  expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@expo/cli': 0.24.21
+      '@expo/config': 11.0.13
+      '@expo/config-plugins': 10.1.2
+      '@expo/fingerprint': 0.13.4
+      '@expo/metro-config': 0.20.17
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      babel-preset-expo: 13.2.4(@babel/core@7.28.3)
+      expo-asset: 11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      expo-file-system: 18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-keep-awake: 14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-modules-autolinking: 2.1.14
+      expo-modules-core: 2.5.0
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+      react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
       - '@babel/core'
@@ -12719,6 +12795,11 @@ snapshots:
     dependencies:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  react-native-edge-to-edge@1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add reusable MessageBubble component
- implement ChatView screen with header, message list and input
- add stories and tests for new components and screen

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:start` *(fails: exit 143 after spawn xdg-open, but build started)*


------
https://chatgpt.com/codex/tasks/task_e_68b2f24af16c832fb7dc97910c33a763