### PR TITLE
feat: add Lightning screen with feature cards

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -11,6 +11,7 @@
     "@babel/runtime": "7.28.3",
     "@hum/ui-components": "workspace:*",
     "@hum/ui-screens": "workspace:*",
+    "@expo/vector-icons": "^15.0.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-native-web": "~0.21.1",

--- a/apps/storybook/react-native-assets-registry/index.ts
+++ b/apps/storybook/react-native-assets-registry/index.ts
@@ -1,0 +1,15 @@
+export interface PackagerAsset {
+  [key: string]: unknown;
+}
+
+const assets: PackagerAsset[] = [];
+
+export function registerAsset(asset: PackagerAsset): number {
+  return assets.push(asset);
+}
+
+export function getAssetByID(assetId: number): PackagerAsset | undefined {
+  return assets[assetId - 1];
+}
+
+export default { registerAsset, getAssetByID };

--- a/apps/storybook/react-native-assets-registry/registry.ts
+++ b/apps/storybook/react-native-assets-registry/registry.ts
@@ -1,0 +1,1 @@
+export { registerAsset, getAssetByID } from './index';

--- a/apps/storybook/storybook/stories/LightningScreen.stories.tsx
+++ b/apps/storybook/storybook/stories/LightningScreen.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { LightningScreen } from '@hum/ui-screens';
+
+const meta: Meta<typeof LightningScreen> = {
+  title: 'Screens/LightningScreen',
+  component: LightningScreen,
+  args: {
+    onBack: undefined,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LightningScreen>;
+
+export const Basic: Story = {};
+export const WithBack: Story = {
+  args: { onBack: () => console.log('back pressed') },
+};

--- a/apps/storybook/storybook/stories/feature-card.stories.tsx
+++ b/apps/storybook/storybook/stories/feature-card.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { FeatureCard } from '@hum/ui-components';
+import { Text } from 'react-native';
+
+const meta: Meta<typeof FeatureCard> = {
+  title: 'Components/FeatureCard',
+  component: FeatureCard,
+  args: {
+    icon: <Text>⚡</Text>,
+    title: 'Lightning Wallet',
+    description:
+      'Manage your Lightning Bitcoin balance and make instant payments',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FeatureCard>;
+
+export const Basic: Story = {};
+export const Another: Story = {
+  args: {
+    title: 'Send & Receive',
+    description: 'Scan QR codes or share payment links to send money instantly',
+  },
+};

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -12,7 +12,13 @@ const r = (...p: string[]) => path.resolve(__dirname, ...p);
  * pre-bundling issues.
  */
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react({
+      babel: {
+        plugins: ['@babel/plugin-transform-flow-strip-types'],
+      },
+    }),
+  ],
   resolve: {
     alias: {
       'react-native': 'react-native-web',
@@ -21,11 +27,23 @@ export default defineConfig({
       'react-native-safe-area-context': r(
         './react-native-safe-area-context.tsx',
       ),
+      '@react-native/assets-registry': r('./react-native-assets-registry'),
     },
   },
   optimizeDeps: {
     exclude: ['storybook', '@storybook/*'],
-    include: ['react', 'react-dom', 'react-native-web'],
+    include: [
+      'react',
+      'react-dom',
+      'react-native-web',
+      '@expo/vector-icons',
+      '@react-native/assets-registry',
+    ],
+    esbuildOptions: {
+      loader: {
+        '.js': 'jsx',
+      },
+    },
   },
   ssr: {
     noExternal: ['storybook', '@storybook/*'],

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "native/*"
   ],
   "devDependencies": {
+    "@babel/plugin-transform-flow-strip-types": "^7.27.1",
     "@eslint/js": "^9.34.0",
+    "@playwright/test": "^1.51.2",
     "@testing-library/jest-native": "5.4.3",
     "@testing-library/react-native": "13.3.3",
     "@types/jest": "^30.0.0",
@@ -53,8 +55,6 @@
     "husky": "^9.0.10",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.1.1",
-    "@playwright/test": "^1.51.2",
-    "start-server-and-test": "^2.0.3",
     "lint-staged": "^16.1.5",
     "prettier": "^3.3.2",
     "react": "^19.1.1",
@@ -62,6 +62,7 @@
     "react-native": "0.75.4",
     "react-native-web": "~0.21.1",
     "react-test-renderer": "19.1.1",
+    "start-server-and-test": "^2.0.3",
     "ts-jest": "^29.1.1",
     "typescript": "^5.6.3"
   },
@@ -75,6 +76,7 @@
     "@expo/metro-config": "^0.20.17"
   },
   "dependencies": {
+    "@expo/vector-icons": "^15.0.2",
     "@testing-library/react": "16.3.0"
   }
 }

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -34,3 +34,5 @@ export { Badge } from './src/badge';
 export type { BadgeProps, BadgeVariant } from './src/badge';
 export { AspectRatio } from './src/aspect-ratio';
 export type { AspectRatioProps } from './src/aspect-ratio';
+export { FeatureCard } from './src/feature-card';
+export type { FeatureCardProps } from './src/feature-card';

--- a/packages/ui-components/src/__snapshots__/feature-card.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/feature-card.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`FeatureCard renders and matches snapshot 1`] = `
+<div>
+  <div
+    class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+    data-testid="feature-card"
+  >
+    <div
+      class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+    >
+      <div
+        class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+      >
+        <div
+          class="css-text-146c3p1"
+          dir="auto"
+        >
+          ⭐
+        </div>
+      </div>
+      <div
+        class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+        dir="auto"
+      >
+        Title
+      </div>
+    </div>
+    <div
+      class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+      dir="auto"
+    >
+      Description
+    </div>
+  </div>
+</div>
+`;

--- a/packages/ui-components/src/feature-card.test.tsx
+++ b/packages/ui-components/src/feature-card.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Text } from 'react-native';
+import { FeatureCard, type FeatureCardProps } from './feature-card';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: 'Ionicons' }));
+
+type Scheme = 'light' | 'dark';
+
+function renderCard(
+  scheme: Scheme = 'light',
+  props?: Partial<FeatureCardProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <FeatureCard
+        icon={<Text>⭐</Text>}
+        title="Title"
+        description="Description"
+        {...props}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe('FeatureCard', () => {
+  it('renders and matches snapshot', () => {
+    const { container } = renderCard();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('applies theme styles', () => {
+    const { getByTestId } = renderCard('dark');
+    expect(getByTestId('feature-card')).toHaveStyle({
+      backgroundColor: colors.dark.card,
+    });
+  });
+
+  it('renders title and description', () => {
+    const { getByText } = renderCard();
+    expect(getByText('Title')).toBeTruthy();
+    expect(getByText('Description')).toBeTruthy();
+  });
+});

--- a/packages/ui-components/src/feature-card.tsx
+++ b/packages/ui-components/src/feature-card.tsx
@@ -1,0 +1,71 @@
+/* eslint-disable react-native/no-unused-styles */
+import React from 'react';
+import { View, Text, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export interface FeatureCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+export const FeatureCard: React.FC<FeatureCardProps> = ({
+  icon,
+  title,
+  description,
+  style,
+  testID = 'feature-card',
+}) => {
+  const { colors, spacing, radius, type } = useTheme();
+
+  const themedStyles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          backgroundColor: colors.card,
+          borderColor: colors.border,
+          borderWidth: 1,
+          borderRadius: radius.lg,
+          padding: spacing.lg,
+        },
+        header: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          marginBottom: spacing.md,
+        },
+        iconWrap: {
+          width: 48,
+          height: 48,
+          borderRadius: 24,
+          backgroundColor: colors.humPrimary,
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginRight: spacing.md,
+        },
+        title: {
+          fontSize: type.size.lg,
+          color: colors.foreground,
+          fontWeight: type.weight.medium,
+        },
+        description: {
+          fontSize: type.size.sm,
+          color: colors.mutedForeground,
+        },
+      }),
+    [colors, spacing, radius, type],
+  );
+
+  return (
+    <View style={[themedStyles.container, style]} testID={testID}>
+      <View style={themedStyles.header}>
+        <View style={themedStyles.iconWrap}>{icon}</View>
+        <Text style={themedStyles.title}>{title}</Text>
+      </View>
+      <Text style={themedStyles.description}>{description}</Text>
+    </View>
+  );
+};
+
+export default FeatureCard;

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
-    "types": ["jest", "react", "react-native"]
+    "types": ["jest", "react"]
   },
   "include": ["src", "**/*.ts", "**/*.tsx"],
   "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]

--- a/packages/ui-screens/index.ts
+++ b/packages/ui-screens/index.ts
@@ -1,1 +1,2 @@
 export { DummyScreen } from './src/DummyScreen';
+export { LightningScreen } from './src/LightningScreen';

--- a/packages/ui-screens/src/LightningScreen.test.tsx
+++ b/packages/ui-screens/src/LightningScreen.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider } from '@hum/ui-components';
+import { LightningScreen, type LightningScreenProps } from './LightningScreen';
+
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+function renderScreen(props?: Partial<LightningScreenProps>) {
+  return render(
+    <ThemeProvider forcedScheme="light">
+      <LightningScreen {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('LightningScreen', () => {
+  it('renders and matches snapshot', () => {
+    const { container } = renderScreen();
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders feature cards', () => {
+    const { getByText } = renderScreen();
+    expect(getByText('Lightning Wallet')).toBeTruthy();
+    expect(getByText('Send & Receive')).toBeTruthy();
+  });
+
+  it('handles back button press', () => {
+    const onBack = jest.fn();
+    const { getByLabelText } = renderScreen({ onBack });
+    fireEvent.click(getByLabelText('Back'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-screens/src/LightningScreen.tsx
+++ b/packages/ui-screens/src/LightningScreen.tsx
@@ -1,0 +1,290 @@
+/* eslint-disable react-native/no-unused-styles */
+import React from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore ScrollView types may be unavailable in tests
+import { View, Text, ScrollView, StyleSheet, Pressable } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme, FeatureCard, Button } from '@hum/ui-components';
+import { Ionicons } from '@expo/vector-icons';
+
+export interface LightningScreenProps {
+  onBack?: () => void;
+}
+
+export const LightningScreen: React.FC<LightningScreenProps> = ({ onBack }) => {
+  const { colors, spacing, radius, type } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  const iconColor = colors.humPrimaryForeground;
+  const iconSize = 24;
+
+  const features = React.useMemo(
+    () => [
+      {
+        icon: <Ionicons name="wallet" size={iconSize} color={iconColor} />,
+        title: 'Lightning Wallet',
+        description:
+          'Manage your Lightning Bitcoin balance and make instant payments',
+      },
+      {
+        icon: <Ionicons name="qr-code" size={iconSize} color={iconColor} />,
+        title: 'Send & Receive',
+        description:
+          'Scan QR codes or share payment links to send money instantly',
+      },
+      {
+        icon: <Ionicons name="time" size={iconSize} color={iconColor} />,
+        title: 'Transaction History',
+        description: 'View all your Lightning payment history and receipts',
+      },
+      {
+        icon: <Ionicons name="card" size={iconSize} color={iconColor} />,
+        title: 'Payment Methods',
+        description:
+          'Connect your bank account or debit card to fund your wallet',
+      },
+      {
+        icon: <Ionicons name="flash" size={iconSize} color={iconColor} />,
+        title: 'Instant Settlements',
+        description: 'Settle payments in milliseconds with low fees',
+      },
+      {
+        icon: <Ionicons name="wallet" size={iconSize} color={iconColor} />,
+        title: 'Multi-Currency Support',
+        description:
+          'Support for Bitcoin, sats, and other Lightning currencies',
+      },
+      {
+        icon: <Ionicons name="qr-code" size={iconSize} color={iconColor} />,
+        title: 'Invoice Generation',
+        description: 'Create and share payment invoices with custom amounts',
+      },
+      {
+        icon: <Ionicons name="time" size={iconSize} color={iconColor} />,
+        title: 'Payment Routing',
+        description:
+          'Automatic routing through the Lightning Network for optimal fees',
+      },
+      {
+        icon: <Ionicons name="card" size={iconSize} color={iconColor} />,
+        title: 'Channel Management',
+        description: 'Open and manage Lightning channels for better liquidity',
+      },
+      {
+        icon: <Ionicons name="flash" size={iconSize} color={iconColor} />,
+        title: 'Backup & Recovery',
+        description:
+          'Secure backup and recovery options for your Lightning wallet',
+      },
+    ],
+    [iconColor, iconSize],
+  );
+
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: colors.background,
+          paddingTop: insets.top,
+        },
+        header: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingHorizontal: spacing.lg,
+          paddingVertical: spacing.md,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+        },
+        backButton: {
+          position: 'absolute',
+          left: spacing.lg,
+          padding: spacing.sm,
+        },
+        headerTitle: {
+          marginLeft: spacing.sm,
+          fontSize: type.size.xl,
+          color: colors.foreground,
+          fontWeight: type.weight.medium,
+        },
+        contentContainer: {
+          paddingHorizontal: spacing.lg,
+          paddingVertical: spacing.xl,
+        },
+        heroIcon: {
+          width: 96,
+          height: 96,
+          borderRadius: 48,
+          backgroundColor: colors.humPrimary,
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: spacing.lg,
+        },
+        heroSection: {
+          alignItems: 'center',
+          marginBottom: spacing.xl,
+        },
+        heroTitle: {
+          fontSize: type.size['2xl'],
+          color: colors.foreground,
+          fontWeight: type.weight.bold,
+          marginBottom: spacing.sm,
+          textAlign: 'center',
+        },
+        heroText: {
+          fontSize: type.size.base,
+          color: colors.mutedForeground,
+          textAlign: 'center',
+        },
+        featuresSection: {
+          marginBottom: spacing.xl,
+        },
+        cardSpacer: {
+          marginBottom: spacing.lg,
+        },
+        banner: {
+          backgroundColor: colors.muted,
+          borderRadius: radius.lg,
+          padding: spacing.lg,
+          marginBottom: spacing.xl,
+        },
+        bannerTitle: {
+          fontSize: type.size.lg,
+          color: colors.foreground,
+          marginBottom: spacing.sm,
+          textAlign: 'center',
+        },
+        bannerText: {
+          fontSize: type.size.sm,
+          color: colors.mutedForeground,
+          textAlign: 'center',
+        },
+        infoContainer: {
+          backgroundColor: colors.card,
+          borderColor: colors.border,
+          borderWidth: 1,
+          borderRadius: radius.lg,
+          padding: spacing.lg,
+          marginBottom: spacing.xl,
+        },
+        infoTitle: {
+          fontSize: type.size.lg,
+          color: colors.foreground,
+          marginBottom: spacing.md,
+        },
+        infoText: {
+          fontSize: type.size.sm,
+          color: colors.mutedForeground,
+          marginBottom: spacing.sm,
+        },
+        infoTextLast: {
+          fontSize: type.size.sm,
+          color: colors.mutedForeground,
+          marginBottom: 0,
+        },
+        betaContainer: {
+          backgroundColor: 'rgba(254,202,26,0.1)',
+          borderRadius: radius.lg,
+          padding: spacing.lg,
+          alignItems: 'center',
+        },
+        betaTitle: {
+          fontSize: type.size.lg,
+          color: colors.foreground,
+          marginBottom: spacing.sm,
+        },
+        betaText: {
+          fontSize: type.size.sm,
+          color: colors.mutedForeground,
+          marginBottom: spacing.lg,
+          textAlign: 'center',
+        },
+      }),
+    [colors, spacing, radius, type, insets.top],
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        {onBack ? (
+          <Pressable
+            onPress={onBack}
+            style={styles.backButton}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+          >
+            <Ionicons name="arrow-back" size={24} color={colors.foreground} />
+          </Pressable>
+        ) : null}
+        <Ionicons name="flash" size={24} color={colors.humPrimary} />
+        <Text style={styles.headerTitle}>Lightning</Text>
+      </View>
+      <ScrollView contentContainerStyle={styles.contentContainer}>
+        <View style={styles.heroSection}>
+          <View style={styles.heroIcon}>
+            <Ionicons
+              name="flash"
+              size={48}
+              color={colors.humPrimaryForeground}
+            />
+          </View>
+          <Text style={styles.heroTitle}>Lightning Payments</Text>
+          <Text style={styles.heroText}>
+            Fast, cheap Bitcoin payments for everyone
+          </Text>
+        </View>
+        <View style={styles.featuresSection}>
+          {features.map((f, idx) => (
+            <View
+              key={f.title}
+              style={
+                idx === features.length - 1 ? undefined : styles.cardSpacer
+              }
+            >
+              <FeatureCard {...f} />
+            </View>
+          ))}
+        </View>
+        <View style={styles.banner}>
+          <Text style={styles.bannerTitle}>Coming Soon</Text>
+          <Text style={styles.bannerText}>
+            Lightning payments will be available in a future update. Stay tuned
+            for instant Bitcoin transactions!
+          </Text>
+        </View>
+        <View style={styles.infoContainer}>
+          <Text style={styles.infoTitle}>Why Lightning?</Text>
+          <Text style={styles.infoText}>
+            • Lightning Network enables instant Bitcoin payments
+          </Text>
+          <Text style={styles.infoText}>
+            • Extremely low fees, often less than a penny
+          </Text>
+          <Text style={styles.infoText}>
+            • Built on Bitcoin’s secure infrastructure
+          </Text>
+          <Text style={styles.infoText}>
+            • Perfect for microtransactions and everyday payments
+          </Text>
+          <Text style={styles.infoTextLast}>
+            • Global reach with 24/7 availability
+          </Text>
+        </View>
+        <View style={styles.betaContainer}>
+          <Text style={styles.betaTitle}>Get Early Access</Text>
+          <Text style={styles.betaText}>
+            Be among the first to try Lightning payments when they launch.
+          </Text>
+          {/* eslint-disable-next-line react-native/no-raw-text */}
+          <Button accessibilityLabel="Join Beta Waitlist">
+            Join Beta Waitlist
+          </Button>
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+export default LightningScreen;

--- a/packages/ui-screens/src/__snapshots__/LightningScreen.test.tsx.snap
+++ b/packages/ui-screens/src/__snapshots__/LightningScreen.test.tsx.snap
@@ -1,0 +1,419 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`LightningScreen renders and matches snapshot 1`] = `
+<div>
+  <div
+    class="css-view-g5y9jx r-backgroundColor-14lw9ot r-flex-13awgt0 r-paddingTop-wk8lta"
+  >
+    <div
+      class="css-view-g5y9jx r-alignItems-1awozwy r-borderBottomColor-vgvm5k r-borderBottomWidth-qklmqi r-flexDirection-18u37iz r-justifyContent-1777fci r-paddingBlock-1mmae3n r-paddingInline-3pj75a"
+    >
+      <div
+        class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-adyw6z r-fontWeight-majxgm r-marginLeft-1jkjb"
+        dir="auto"
+      >
+        Lightning
+      </div>
+    </div>
+    <div
+      class="css-view-g5y9jx r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-agouwx"
+    >
+      <div
+        class="css-view-g5y9jx r-paddingBlock-zo2zu6 r-paddingInline-3pj75a"
+      >
+        <div
+          class="css-view-g5y9jx r-alignItems-1awozwy r-marginBottom-1peese0"
+        >
+          <div
+            class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1udnf30 r-height-1njcn02 r-justifyContent-1777fci r-marginBottom-1ifxtd0 r-width-7bouqp"
+          />
+          <div
+            class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1x35g6 r-fontWeight-b88u0q r-marginBottom-5oul0u r-textAlign-q4m81j"
+            dir="auto"
+          >
+            Lightning Payments
+          </div>
+          <div
+            class="css-text-146c3p1 r-color-qabo0s r-fontSize-1b43r93 r-textAlign-q4m81j"
+            dir="auto"
+          >
+            Fast, cheap Bitcoin payments for everyone
+          </div>
+        </div>
+        <div
+          class="css-view-g5y9jx r-marginBottom-1peese0"
+        >
+          <div
+            class="css-view-g5y9jx r-marginBottom-1ifxtd0"
+          >
+            <div
+              class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+              data-testid="feature-card"
+            >
+              <div
+                class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+              >
+                <div
+                  class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+                />
+                <div
+                  class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+                  dir="auto"
+                >
+                  Lightning Wallet
+                </div>
+              </div>
+              <div
+                class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+                dir="auto"
+              >
+                Manage your Lightning Bitcoin balance and make instant payments
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-g5y9jx r-marginBottom-1ifxtd0"
+          >
+            <div
+              class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+              data-testid="feature-card"
+            >
+              <div
+                class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+              >
+                <div
+                  class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+                />
+                <div
+                  class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+                  dir="auto"
+                >
+                  Send & Receive
+                </div>
+              </div>
+              <div
+                class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+                dir="auto"
+              >
+                Scan QR codes or share payment links to send money instantly
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-g5y9jx r-marginBottom-1ifxtd0"
+          >
+            <div
+              class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+              data-testid="feature-card"
+            >
+              <div
+                class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+              >
+                <div
+                  class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+                />
+                <div
+                  class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+                  dir="auto"
+                >
+                  Transaction History
+                </div>
+              </div>
+              <div
+                class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+                dir="auto"
+              >
+                View all your Lightning payment history and receipts
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-g5y9jx r-marginBottom-1ifxtd0"
+          >
+            <div
+              class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+              data-testid="feature-card"
+            >
+              <div
+                class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+              >
+                <div
+                  class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+                />
+                <div
+                  class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+                  dir="auto"
+                >
+                  Payment Methods
+                </div>
+              </div>
+              <div
+                class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+                dir="auto"
+              >
+                Connect your bank account or debit card to fund your wallet
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-g5y9jx r-marginBottom-1ifxtd0"
+          >
+            <div
+              class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+              data-testid="feature-card"
+            >
+              <div
+                class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+              >
+                <div
+                  class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+                />
+                <div
+                  class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+                  dir="auto"
+                >
+                  Instant Settlements
+                </div>
+              </div>
+              <div
+                class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+                dir="auto"
+              >
+                Settle payments in milliseconds with low fees
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-g5y9jx r-marginBottom-1ifxtd0"
+          >
+            <div
+              class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+              data-testid="feature-card"
+            >
+              <div
+                class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+              >
+                <div
+                  class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+                />
+                <div
+                  class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+                  dir="auto"
+                >
+                  Multi-Currency Support
+                </div>
+              </div>
+              <div
+                class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+                dir="auto"
+              >
+                Support for Bitcoin, sats, and other Lightning currencies
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-g5y9jx r-marginBottom-1ifxtd0"
+          >
+            <div
+              class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+              data-testid="feature-card"
+            >
+              <div
+                class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+              >
+                <div
+                  class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+                />
+                <div
+                  class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+                  dir="auto"
+                >
+                  Invoice Generation
+                </div>
+              </div>
+              <div
+                class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+                dir="auto"
+              >
+                Create and share payment invoices with custom amounts
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-g5y9jx r-marginBottom-1ifxtd0"
+          >
+            <div
+              class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+              data-testid="feature-card"
+            >
+              <div
+                class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+              >
+                <div
+                  class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+                />
+                <div
+                  class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+                  dir="auto"
+                >
+                  Payment Routing
+                </div>
+              </div>
+              <div
+                class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+                dir="auto"
+              >
+                Automatic routing through the Lightning Network for optimal fees
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-g5y9jx r-marginBottom-1ifxtd0"
+          >
+            <div
+              class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+              data-testid="feature-card"
+            >
+              <div
+                class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+              >
+                <div
+                  class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+                />
+                <div
+                  class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+                  dir="auto"
+                >
+                  Channel Management
+                </div>
+              </div>
+              <div
+                class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+                dir="auto"
+              >
+                Open and manage Lightning channels for better liquidity
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-view-g5y9jx"
+          >
+            <div
+              class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-padding-nsbfu8"
+              data-testid="feature-card"
+            >
+              <div
+                class="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-marginBottom-6gpygo"
+              >
+                <div
+                  class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-g4fib6 r-borderRadius-1fuqb1j r-height-h3s6tt r-justifyContent-1777fci r-marginRight-1b7u577 r-width-rwqe4o"
+                />
+                <div
+                  class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-fontWeight-majxgm"
+                  dir="auto"
+                >
+                  Backup & Recovery
+                </div>
+              </div>
+              <div
+                class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn"
+                dir="auto"
+              >
+                Secure backup and recovery options for your Lightning wallet
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="css-view-g5y9jx r-backgroundColor-xm3cbv r-borderRadius-1q9bdsx r-marginBottom-1peese0 r-padding-nsbfu8"
+        >
+          <div
+            class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-marginBottom-5oul0u r-textAlign-q4m81j"
+            dir="auto"
+          >
+            Coming Soon
+          </div>
+          <div
+            class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn r-textAlign-q4m81j"
+            dir="auto"
+          >
+            Lightning payments will be available in a future update. Stay tuned for instant Bitcoin transactions!
+          </div>
+        </div>
+        <div
+          class="css-view-g5y9jx r-backgroundColor-14lw9ot r-borderColor-1jie2fr r-borderRadius-1q9bdsx r-borderWidth-rs99b7 r-marginBottom-1peese0 r-padding-nsbfu8"
+        >
+          <div
+            class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-marginBottom-6gpygo"
+            dir="auto"
+          >
+            Why Lightning?
+          </div>
+          <div
+            class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn r-marginBottom-5oul0u"
+            dir="auto"
+          >
+            • Lightning Network enables instant Bitcoin payments
+          </div>
+          <div
+            class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn r-marginBottom-5oul0u"
+            dir="auto"
+          >
+            • Extremely low fees, often less than a penny
+          </div>
+          <div
+            class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn r-marginBottom-5oul0u"
+            dir="auto"
+          >
+            • Built on Bitcoin’s secure infrastructure
+          </div>
+          <div
+            class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn r-marginBottom-5oul0u"
+            dir="auto"
+          >
+            • Perfect for microtransactions and everyday payments
+          </div>
+          <div
+            class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn r-marginBottom-p1pxzi"
+            dir="auto"
+          >
+            • Global reach with 24/7 availability
+          </div>
+        </div>
+        <div
+          class="css-view-g5y9jx r-alignItems-1awozwy r-backgroundColor-2c72fj r-borderRadius-1q9bdsx r-padding-nsbfu8"
+        >
+          <div
+            class="css-text-146c3p1 r-color-1mmg7l5 r-fontSize-1i10wst r-marginBottom-5oul0u"
+            dir="auto"
+          >
+            Get Early Access
+          </div>
+          <div
+            class="css-text-146c3p1 r-color-qabo0s r-fontSize-1enofrn r-marginBottom-1ifxtd0 r-textAlign-q4m81j"
+            dir="auto"
+          >
+            Be among the first to try Lightning payments when they launch.
+          </div>
+          <button
+            aria-label="Join Beta Waitlist"
+            class="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1777fci"
+            role="button"
+            style="height: 36px; padding: 8px 16px 8px 16px; border-top-left-radius: 10px; border-top-right-radius: 10px; border-bottom-right-radius: 10px; border-bottom-left-radius: 10px; background-color: rgb(254, 202, 26); opacity: 1;"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="css-text-146c3p1"
+              dir="auto"
+              style="font-size: 14px; font-weight: 500; color: rgb(0, 0, 0);"
+            >
+              Join Beta Waitlist
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/ui-screens/tsconfig.json
+++ b/packages/ui-screens/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
-    "types": ["jest", "react", "react-native"]
+    "types": ["jest", "react"]
   },
   "include": ["src", "**/*.ts", "**/*.tsx"],
   "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,10 +8,16 @@ importers:
 
   .:
     dependencies:
+      '@expo/vector-icons':
+        specifier: ^15.0.2
+        version: 15.0.2(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)
       '@testing-library/react':
         specifier: 16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     devDependencies:
+      '@babel/plugin-transform-flow-strip-types':
+        specifier: ^7.27.1
+        version: 7.27.1(@babel/core@7.28.3)
       '@eslint/js':
         specifier: ^9.34.0
         version: 9.34.0
@@ -133,6 +139,9 @@ importers:
       '@babel/runtime':
         specifier: 7.28.3
         version: 7.28.3
+      '@expo/vector-icons':
+        specifier: ^15.0.2
+        version: 15.0.2(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       '@hum/ui-components':
         specifier: workspace:*
         version: link:../../packages/ui-components
@@ -1453,6 +1462,13 @@ packages:
     resolution: {integrity: sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==}
     peerDependencies:
       expo-font: '*'
+      react: '*'
+      react-native: '*'
+
+  '@expo/vector-icons@15.0.2':
+    resolution: {integrity: sha512-IiBjg7ZikueuHNf40wSGCf0zS73a3guJLdZzKnDUxsauB8VWPLMeWnRIupc+7cFhLUkqyvyo0jLNlcxG5xPOuQ==}
+    peerDependencies:
+      expo-font: '>=14.0.4'
       react: '*'
       react-native: '*'
 
@@ -7728,11 +7744,35 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
+  '@expo/vector-icons@14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)':
+    dependencies:
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-native: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
+
   '@expo/vector-icons@14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)':
     dependencies:
       expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1)
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  '@expo/vector-icons@14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+
+  '@expo/vector-icons@15.0.2(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)':
+    dependencies:
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-native: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
+
+  '@expo/vector-icons@15.0.2(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -10448,6 +10488,16 @@ snapshots:
       jest-mock: 30.0.5
       jest-util: 30.0.5
 
+  expo-asset@11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1):
+    dependencies:
+      '@expo/image-utils': 0.7.6
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))
+      react: 19.1.1
+      react-native: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-asset@11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
     dependencies:
       '@expo/image-utils': 0.7.6
@@ -10455,6 +10505,25 @@ snapshots:
       expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-asset@11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@expo/image-utils': 0.7.6
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)):
+    dependencies:
+      '@expo/config': 11.0.13
+      '@expo/env': 1.0.7
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)
+      react-native: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -10467,10 +10536,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)):
+    dependencies:
+      '@expo/config': 11.0.13
+      '@expo/env': 1.0.7
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)
+      react-native: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
+
   expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)):
     dependencies:
       expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+
+  expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)
+      fontfaceobserver: 2.3.0
+      react: 19.1.1
 
   expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -10478,9 +10572,25 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 19.1.1
 
+  expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      fontfaceobserver: 2.3.0
+      react: 19.1.1
+
+  expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)
+      react: 19.1.1
+
   expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
       expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+
+  expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+    dependencies:
+      expo: 53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       react: 19.1.1
 
   expo-modules-autolinking@2.1.14:
@@ -10496,6 +10606,35 @@ snapshots:
   expo-modules-core@2.5.0:
     dependencies:
       invariant: 2.2.4
+
+  expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@expo/cli': 0.24.21
+      '@expo/config': 11.0.13
+      '@expo/config-plugins': 10.1.2
+      '@expo/fingerprint': 0.13.4
+      '@expo/metro-config': 0.20.17
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)
+      babel-preset-expo: 13.2.4(@babel/core@7.28.3)
+      expo-asset: 11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))
+      expo-file-system: 18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react@19.1.1)
+      expo-keep-awake: 14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1))(react@19.1.1)
+      expo-modules-autolinking: 2.1.14
+      expo-modules-core: 2.5.0
+      react: 19.1.1
+      react-native: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
+      react-native-edge-to-edge: 1.6.0(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1)
+      whatwg-url-without-unicode: 8.0.0-3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - graphql
+      - supports-color
+      - utf-8-validate
 
   expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -10517,6 +10656,35 @@ snapshots:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
       react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      whatwg-url-without-unicode: 8.0.0-3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - graphql
+      - supports-color
+      - utf-8-validate
+
+  expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      '@expo/cli': 0.24.21
+      '@expo/config': 11.0.13
+      '@expo/config-plugins': 10.1.2
+      '@expo/fingerprint': 0.13.4
+      '@expo/metro-config': 0.20.17
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      babel-preset-expo: 13.2.4(@babel/core@7.28.3)
+      expo-asset: 11.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      expo-file-system: 18.1.11(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-keep-awake: 14.1.4(expo@53.0.22(@babel/core@7.28.3)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-modules-autolinking: 2.1.14
+      expo-modules-core: 2.5.0
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+      react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
       - '@babel/core'
@@ -12715,10 +12883,20 @@ snapshots:
 
   react-is@19.1.1: {}
 
+  react-native-edge-to-edge@1.6.0(react-native@0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-native: 0.75.4(@babel/core@7.28.3)(@babel/preset-env@7.28.3(@babel/core@7.28.3))(@types/react@19.1.12)(react@19.1.1)(typescript@5.8.3)
+
   react-native-edge-to-edge@1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
     dependencies:
       react: 19.1.1
       react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1)
+
+  react-native-edge-to-edge@1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,11 @@
       "@apps/*": ["apps/*/src"],
       "@packages/*": ["packages/*/src"],
       "@mchat/*": ["packages/*/src"],
-      "@native/*": ["native/*/src"]
+      "@native/*": ["native/*/src"],
+      "@hum/ui-components": ["packages/ui-components"],
+      "@hum/ui-components/*": ["packages/ui-components/*"],
+      "@hum/ui-screens": ["packages/ui-screens"],
+      "@hum/ui-screens/*": ["packages/ui-screens/*"]
     }
   },
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -4,7 +4,9 @@
     "types": [
       "jest",
       "@testing-library/jest-dom",
-      "@testing-library/jest-native"
+      "@testing-library/jest-native",
+      "react",
+      "react-native"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add FeatureCard component and stories
- implement LightningScreen using FeatureCards and brand theming
- add tests and stories for new screen
- configure Storybook's Vite build to handle React Native modules

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --dir apps/storybook exec storybook dev -p 7007 --ci`


------
https://chatgpt.com/codex/tasks/task_e_68b2e7c558d8832fb4d2f88b2342be62