### PR TITLE
feat: add chat view screen

### DIFF
--- a/apps/storybook/storybook/stories/ChatView.stories.tsx
+++ b/apps/storybook/storybook/stories/ChatView.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { ChatView } from '@hum/ui-screens';
+
+const meta: Meta<typeof ChatView> = {
+  title: 'Screens/ChatView',
+  component: ChatView,
+  decorators: [
+    (Story) => (
+      <SafeAreaProvider>
+        <Story />
+      </SafeAreaProvider>
+    ),
+  ],
+  argTypes: {
+    onBack: { action: 'back' },
+  },
+  args: {
+    chatName: 'Alice',
+    chatAvatar: 'https://picsum.photos/200',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ChatView>;
+
+export const Basic: Story = {};
+export const Empty: Story = {
+  args: { messages: [] },
+};

--- a/apps/storybook/storybook/stories/MessageBubble.stories.tsx
+++ b/apps/storybook/storybook/stories/MessageBubble.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MessageBubble } from '@hum/ui-components/message-bubble';
+
+const meta: Meta<typeof MessageBubble> = {
+  title: 'Components/MessageBubble',
+  component: MessageBubble,
+  argTypes: {
+    isOutgoing: { control: 'boolean' },
+    isRead: { control: 'boolean' },
+  },
+  args: {
+    text: 'Hello there',
+    time: '14:15',
+    isOutgoing: true,
+    isRead: true,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageBubble>;
+
+export const OutgoingRead: Story = {};
+export const OutgoingUnread: Story = {
+  args: { isRead: false },
+};
+export const Incoming: Story = {
+  args: { isOutgoing: false },
+};

--- a/apps/storybook/storybook/stories/MessageBubble.stories.tsx
+++ b/apps/storybook/storybook/stories/MessageBubble.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { MessageBubble } from '@hum/ui-components/message-bubble';
+import { MessageBubble } from '../../../../packages/ui-components/src/message-bubble';
 
 const meta: Meta<typeof MessageBubble> = {
   title: 'Components/MessageBubble',

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -4,7 +4,6 @@
     "jsx": "react-jsx",
     "noEmit": true,
     "paths": {
-      "@hum/ui-components": ["../../packages/ui-components/src/index.ts"],
       "@hum/ui-components/*": ["../../packages/ui-components/src/*"],
       "@hum/ui-screens": ["../../packages/ui-screens/src/index.ts"],
       "@hum/ui-screens/*": ["../../packages/ui-screens/src/*"]

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
   resolve: {
     alias: {
       'react-native': 'react-native-web',
-      '@hum/ui-components': r('../../packages/ui-components/'),
+      '@hum/ui-components': r('../../packages/ui-components/src'),
+      '@hum/ui-components/': r('../../packages/ui-components/src/'),
       '@hum/ui-screens': r('../../packages/ui-screens/'),
       'react-native-safe-area-context': r(
         './react-native-safe-area-context.tsx',

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,5 +13,7 @@ module.exports = {
   },
   moduleNameMapper: {
     '^react-native$': 'react-native-web',
+    '^@hum/ui-components(.*)$': '<rootDir>/packages/ui-components/src$1',
+    '^@hum/ui-screens(.*)$': '<rootDir>/packages/ui-screens/src$1',
   },
 };

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -34,3 +34,5 @@ export { Badge } from './src/badge';
 export type { BadgeProps, BadgeVariant } from './src/badge';
 export { AspectRatio } from './src/aspect-ratio';
 export type { AspectRatioProps } from './src/aspect-ratio';
+export { MessageBubble } from './src/message-bubble';
+export type { MessageBubbleProps } from './src/message-bubble';

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -8,6 +8,18 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./avatar": {
+      "types": "./dist/avatar.d.ts",
+      "default": "./dist/avatar.js"
+    },
+    "./message-bubble": {
+      "types": "./dist/message-bubble.d.ts",
+      "default": "./dist/message-bubble.js"
+    },
+    "./theme/ThemeProvider": {
+      "types": "./dist/theme/ThemeProvider.d.ts",
+      "default": "./dist/theme/ThemeProvider.js"
     }
   },
   "files": [

--- a/packages/ui-components/src/__snapshots__/message-bubble.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/message-bubble.test.tsx.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`MessageBubble renders and matches snapshot 1`] = `
+<div
+  className="css-view-g5y9jx r-flexDirection-18u37iz r-justifyContent-17s6mgv"
+  dir={null}
+  ref={[Function]}
+  style={
+    {
+      "marginBottom": "8px",
+    }
+  }
+>
+  <div
+    aria-label="Outgoing message"
+    className="css-view-g5y9jx r-maxWidth-q5oqfz"
+    data-testid="outgoing-bubble"
+    dir={null}
+    ref={[Function]}
+    style={
+      {
+        "backgroundColor": "rgba(254,202,26,1.00)",
+        "borderBottomLeftRadius": "16px",
+        "borderBottomRightRadius": "16px",
+        "borderTopLeftRadius": "16px",
+        "borderTopRightRadius": "16px",
+        "paddingBottom": "8px",
+        "paddingLeft": "12px",
+        "paddingRight": "12px",
+        "paddingTop": "8px",
+      }
+    }
+  >
+    <div
+      className="css-text-146c3p1"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(0,0,0,1.00)",
+          "fontSize": "12px",
+        }
+      }
+    >
+      Hello there
+    </div>
+    <div
+      className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-17s6mgv"
+      dir={null}
+      ref={[Function]}
+      style={
+        {
+          "marginTop": "4px",
+        }
+      }
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(0,0,0,1.00)",
+            "fontSize": "12px",
+          }
+        }
+      >
+        14:15
+      </div>
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(0,0,0,1.00)",
+            "marginLeft": "4px",
+          }
+        }
+      >
+        ✓✓
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/ui-components/src/message-bubble.test.tsx
+++ b/packages/ui-components/src/message-bubble.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { MessageBubble, type MessageBubbleProps } from './message-bubble';
+import { ThemeProvider } from './theme/ThemeProvider';
+
+type Scheme = 'light' | 'dark';
+
+const baseProps: MessageBubbleProps = {
+  text: 'Hello there',
+  time: '14:15',
+  isOutgoing: true,
+  isRead: true,
+};
+
+function renderBubble(
+  scheme: Scheme = 'light',
+  props: Partial<MessageBubbleProps> = {},
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <MessageBubble {...baseProps} {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('MessageBubble', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderBubble();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('shows read indicator when isRead', () => {
+    const { toJSON } = renderBubble('light', { isRead: true });
+    expect(JSON.stringify(toJSON())).toContain('✓✓');
+  });
+
+  it('applies theme colors', () => {
+    const { getByLabelText, rerender } = renderBubble('light');
+    expect(getByLabelText('Outgoing message')).toHaveStyle({
+      backgroundColor: 'rgba(254,202,26,1.00)',
+    });
+    rerender(
+      <ThemeProvider forcedScheme="dark">
+        <MessageBubble {...baseProps} />
+      </ThemeProvider>,
+    );
+    expect(getByLabelText('Outgoing message')).toHaveStyle({
+      backgroundColor: 'rgba(254,202,26,1.00)',
+    });
+  });
+});

--- a/packages/ui-components/src/message-bubble.tsx
+++ b/packages/ui-components/src/message-bubble.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export interface MessageBubbleProps {
+  /** Message text */
+  text: string;
+  /** Time string like 14:15 */
+  time: string;
+  /** Whether the message is outgoing */
+  isOutgoing: boolean;
+  /** Whether the outgoing message has been read */
+  isRead?: boolean;
+}
+
+export const MessageBubble: React.FC<MessageBubbleProps> = ({
+  text,
+  time,
+  isOutgoing,
+  isRead,
+}) => {
+  const { colors, spacing, radius, type } = useTheme();
+  const dynamicStyles = { marginBottom: spacing.sm };
+  const justifyStyle = isOutgoing ? styles.justifyEnd : styles.justifyStart;
+
+  return (
+    <View style={[styles.container, justifyStyle, dynamicStyles]}>
+      <View
+        testID={isOutgoing ? 'outgoing-bubble' : 'incoming-bubble'}
+        accessible
+        accessibilityLabel={
+          isOutgoing ? 'Outgoing message' : 'Incoming message'
+        }
+        style={[
+          styles.bubble,
+          {
+            backgroundColor: isOutgoing ? colors.humPrimary : colors.muted,
+            borderRadius: radius.xl,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+          },
+        ]}
+      >
+        <Text
+          style={[
+            styles.text,
+            {
+              color: isOutgoing
+                ? colors.humPrimaryForeground
+                : colors.foreground,
+              fontSize: type.size.sm,
+            },
+          ]}
+        >
+          {text}
+        </Text>
+        <View
+          style={[
+            styles.metaRow,
+            {
+              marginTop: spacing.xs,
+            },
+          ]}
+        >
+          <Text
+            style={[
+              styles.time,
+              {
+                color: isOutgoing
+                  ? colors.humPrimaryForeground
+                  : colors.mutedForeground,
+                fontSize: type.size.sm,
+              },
+            ]}
+          >
+            {time}
+          </Text>
+          {isOutgoing && isRead && (
+            <Text
+              style={[
+                styles.read,
+                { marginLeft: spacing.xs, color: colors.humPrimaryForeground },
+              ]}
+            >
+              ✓✓
+            </Text>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+  },
+  justifyEnd: {
+    justifyContent: 'flex-end',
+  },
+  justifyStart: {
+    justifyContent: 'flex-start',
+  },
+  bubble: {
+    maxWidth: '80%',
+  },
+  text: {},
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+  },
+  time: {},
+  read: {},
+});
+
+export default MessageBubble;

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
-    "types": ["jest", "react", "react-native"]
+    "types": ["jest", "react", "react-native"],
+    "typeRoots": ["../../tests", "../../node_modules/@types"]
   },
   "include": ["src", "**/*.ts", "**/*.tsx"],
   "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]

--- a/packages/ui-screens/index.ts
+++ b/packages/ui-screens/index.ts
@@ -1,2 +1,3 @@
 export { DummyScreen } from './src/DummyScreen';
 export { ChatItem } from './src/ChatItem';
+export { ChatView } from './src/ChatView';

--- a/packages/ui-screens/src/ChatView.test.tsx
+++ b/packages/ui-screens/src/ChatView.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+const SafeAreaProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => <>{children}</>;
+import { ChatView, type ChatViewProps } from './ChatView';
+import { ThemeProvider } from '@hum/ui-components/theme/ThemeProvider';
+
+type Scheme = 'light' | 'dark';
+
+const baseProps: ChatViewProps = {
+  chatName: 'Alice',
+  chatAvatar: 'https://example.com/avatar.png',
+  onBack: jest.fn(),
+  messages: [
+    { id: '1', text: 'Hello', time: '14:15', isOutgoing: true, isRead: true },
+  ],
+};
+
+function renderChatView(
+  scheme: Scheme = 'light',
+  props?: Partial<ChatViewProps>,
+) {
+  return render(
+    <SafeAreaProvider>
+      <ThemeProvider forcedScheme={scheme}>
+        <ChatView {...baseProps} {...props} />
+      </ThemeProvider>
+    </SafeAreaProvider>,
+  );
+}
+
+describe('ChatView Screen', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderChatView();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('calls onBack when back pressed', () => {
+    const onBack = jest.fn();
+    const { getByLabelText } = renderChatView('light', { onBack });
+    fireEvent.press(getByLabelText('Go back'));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('allows typing in input', () => {
+    const { getByLabelText } = renderChatView();
+    const input = getByLabelText('Message input');
+    fireEvent.changeText(input, 'Hi');
+    expect(input.props.value).toBe('Hi');
+  });
+
+  it('applies theme colors', () => {
+    const { getByLabelText, rerender } = renderChatView('light');
+    expect(getByLabelText('Outgoing message')).toHaveStyle({
+      backgroundColor: 'rgba(254,202,26,1.00)',
+    });
+    rerender(
+      <SafeAreaProvider>
+        <ThemeProvider forcedScheme="dark">
+          <ChatView {...baseProps} />
+        </ThemeProvider>
+      </SafeAreaProvider>,
+    );
+    expect(getByLabelText('Outgoing message')).toHaveStyle({
+      backgroundColor: 'rgba(254,202,26,1.00)',
+    });
+  });
+});

--- a/packages/ui-screens/src/ChatView.tsx
+++ b/packages/ui-screens/src/ChatView.tsx
@@ -8,12 +8,12 @@ import {
   Pressable,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Avatar, AvatarImage } from '@hum/ui-components/avatar';
-import { useTheme } from '@hum/ui-components/theme/ThemeProvider';
+import { Avatar, AvatarImage } from '../../ui-components/src/avatar';
+import { useTheme } from '../../ui-components/src/theme/ThemeProvider';
 import {
   MessageBubble,
   type MessageBubbleProps,
-} from '@hum/ui-components/message-bubble';
+} from '../../ui-components/src/message-bubble';
 
 export interface ChatMessage extends MessageBubbleProps {
   id: string;

--- a/packages/ui-screens/src/ChatView.tsx
+++ b/packages/ui-screens/src/ChatView.tsx
@@ -1,0 +1,270 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  Pressable,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Avatar, AvatarImage } from '@hum/ui-components/avatar';
+import { useTheme } from '@hum/ui-components/theme/ThemeProvider';
+import {
+  MessageBubble,
+  type MessageBubbleProps,
+} from '@hum/ui-components/message-bubble';
+
+export interface ChatMessage extends MessageBubbleProps {
+  id: string;
+}
+
+const mockMessages: ChatMessage[] = [
+  {
+    id: '1',
+    text: 'Hey! How are you doing?',
+    time: '14:15',
+    isOutgoing: false,
+  },
+  {
+    id: '2',
+    text: "I'm doing great! Just finished work. What about you?",
+    time: '14:17',
+    isOutgoing: true,
+    isRead: true,
+  },
+  {
+    id: '3',
+    text: 'Same here! Just wrapped up a big project',
+    time: '14:18',
+    isOutgoing: false,
+  },
+  {
+    id: '4',
+    text: "That's awesome! What kind of project was it?",
+    time: '14:20',
+    isOutgoing: true,
+    isRead: true,
+  },
+];
+
+export interface ChatViewProps {
+  chatName: string;
+  chatAvatar: string;
+  onBack: () => void;
+  messages?: ChatMessage[];
+}
+
+export const ChatView: React.FC<ChatViewProps> = ({
+  chatName,
+  chatAvatar,
+  onBack,
+  messages = mockMessages,
+}) => {
+  const { colors, spacing, type, radius } = useTheme();
+  const insets = useSafeAreaInsets();
+  const [value, setValue] = useState('');
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { paddingTop: insets.top, backgroundColor: colors.background },
+      ]}
+    >
+      <View
+        style={[
+          styles.header,
+          {
+            borderBottomColor: colors.border,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+          },
+        ]}
+      >
+        <View style={styles.headerLeft}>
+          <Pressable
+            onPress={onBack}
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
+            style={{ marginRight: spacing.sm }}
+          >
+            <Text style={[styles.iconLarge, { color: colors.foreground }]}>
+              {'←'}
+            </Text>
+          </Pressable>
+          <Avatar size={40}>
+            <AvatarImage
+              source={{ uri: chatAvatar }}
+              accessibilityLabel={`${chatName} avatar`}
+            />
+          </Avatar>
+          <View style={{ marginLeft: spacing.sm }}>
+            <Text
+              style={{
+                color: colors.foreground,
+                fontSize: type.size.md,
+                fontWeight: type.weight.medium,
+              }}
+            >
+              {chatName}
+            </Text>
+            <Text
+              style={{ color: colors.mutedForeground, fontSize: type.size.sm }}
+            >
+              online
+            </Text>
+          </View>
+        </View>
+        <View style={styles.headerRight}>
+          <Text
+            style={[
+              styles.iconLarge,
+              { marginRight: spacing.md, color: colors.foreground },
+            ]}
+          >
+            {'🎥'}
+          </Text>
+          <Text
+            style={[
+              styles.iconLarge,
+              { marginRight: spacing.md, color: colors.foreground },
+            ]}
+          >
+            {'📞'}
+          </Text>
+          <Text style={[styles.iconLarge, { color: colors.foreground }]}>
+            {'⋮'}
+          </Text>
+        </View>
+      </View>
+
+      <ScrollView
+        style={styles.messages}
+        contentContainerStyle={{
+          paddingHorizontal: spacing.md,
+          paddingVertical: spacing.md,
+        }}
+      >
+        {messages.map((m) => (
+          <MessageBubble
+            key={m.id}
+            text={m.text}
+            time={m.time}
+            isOutgoing={m.isOutgoing}
+            isRead={m.isRead}
+          />
+        ))}
+      </ScrollView>
+
+      <View
+        style={[
+          styles.inputArea,
+          {
+            borderTopColor: colors.border,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+          },
+        ]}
+      >
+        <View style={styles.inputRow}>
+          <Text
+            style={[
+              styles.iconLarge,
+              { marginRight: spacing.sm, color: colors.mutedForeground },
+            ]}
+          >
+            {'+'}
+          </Text>
+          <View
+            style={[
+              styles.textInputContainer,
+              {
+                backgroundColor: colors.muted,
+                borderRadius: radius.xl,
+                paddingHorizontal: spacing.md,
+                paddingVertical: spacing.xs,
+              },
+            ]}
+          >
+            <TextInput
+              style={[styles.textInput, { color: colors.foreground }]}
+              placeholder="Type a message..."
+              placeholderTextColor={colors.mutedForeground}
+              value={value}
+              onChangeText={setValue}
+              accessible
+              accessibilityLabel="Message input"
+            />
+            <Text style={[styles.iconSmall, { color: colors.mutedForeground }]}>
+              {'😊'}
+            </Text>
+          </View>
+          <Text
+            style={[
+              styles.iconLarge,
+              { marginLeft: spacing.sm, color: colors.mutedForeground },
+            ]}
+          >
+            {'📷'}
+          </Text>
+          <Text
+            style={[
+              styles.iconLarge,
+              { marginLeft: spacing.sm, color: colors.mutedForeground },
+            ]}
+          >
+            {'🎤'}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  headerRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  messages: {
+    flex: 1,
+  },
+  inputArea: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  textInputContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  textInput: {
+    flex: 1,
+    padding: 0,
+  },
+  iconLarge: {
+    fontSize: 24,
+  },
+  iconSmall: {
+    fontSize: 20,
+  },
+});
+
+export default ChatView;

--- a/packages/ui-screens/src/__snapshots__/ChatView.test.tsx.snap
+++ b/packages/ui-screens/src/__snapshots__/ChatView.test.tsx.snap
@@ -1,0 +1,435 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ChatView Screen renders and matches snapshot 1`] = `
+<div
+  className="css-view-g5y9jx r-flex-13awgt0"
+  dir={null}
+  ref={[Function]}
+  style={
+    {
+      "backgroundColor": "rgba(255,255,255,1.00)",
+      "paddingTop": "0px",
+    }
+  }
+>
+  <div
+    className="css-view-g5y9jx r-alignItems-1awozwy r-borderBottomWidth-qklmqi r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+    dir={null}
+    ref={[Function]}
+    style={
+      {
+        "borderBottomColor": "rgba(0,0,0,0.10)",
+        "paddingBottom": "8px",
+        "paddingLeft": "12px",
+        "paddingRight": "12px",
+        "paddingTop": "8px",
+      }
+    }
+  >
+    <div
+      className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+      dir={null}
+      ref={[Function]}
+    >
+      <button
+        aria-label="Go back"
+        className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73"
+        dir={null}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        ref={[Function]}
+        role="button"
+        style={
+          {
+            "marginRight": "8px",
+          }
+        }
+        tabIndex={0}
+        type="button"
+      >
+        <div
+          className="css-text-146c3p1"
+          dir="auto"
+          ref={[Function]}
+          style={
+            {
+              "color": "rgba(10,10,10,1.00)",
+              "fontSize": "24px",
+            }
+          }
+        >
+          ←
+        </div>
+      </button>
+      <div
+        className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-justifyContent-1777fci r-overflow-1udh08x"
+        dir={null}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onContextMenu={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        ref={[Function]}
+        role="img"
+        style={
+          {
+            "borderBottomLeftRadius": "20px",
+            "borderBottomRightRadius": "20px",
+            "borderTopLeftRadius": "20px",
+            "borderTopRightRadius": "20px",
+            "height": "40px",
+            "width": "40px",
+          }
+        }
+        tabIndex={0}
+      >
+        <div
+          aria-label="Alice avatar"
+          className="css-view-g5y9jx r-flexBasis-1mlwlqe r-overflow-1udh08x r-zIndex-417010 r-height-1pi2tsx r-width-13qz1uu"
+          dir={null}
+          ref={[Function]}
+        >
+          <div
+            className="css-view-g5y9jx r-backgroundColor-1niwhzg r-backgroundPosition-vvn4in r-backgroundRepeat-u6sd8q r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-zIndex-1wyyakw r-backgroundSize-4gszlv"
+            dir={null}
+            ref={[Function]}
+            style={
+              {
+                "backgroundImage": "url("https://example.com/avatar.png")",
+              }
+            }
+            suppressHydrationWarning={true}
+          />
+          <img
+            alt="Alice avatar"
+            className="css-accessibilityImage-9pa8cd"
+            draggable={false}
+            ref={
+              {
+                "current": null,
+              }
+            }
+            src="https://example.com/avatar.png"
+          />
+        </div>
+      </div>
+      <div
+        className="css-view-g5y9jx"
+        dir={null}
+        ref={[Function]}
+        style={
+          {
+            "marginLeft": "8px",
+          }
+        }
+      >
+        <div
+          className="css-text-146c3p1"
+          dir="auto"
+          ref={[Function]}
+          style={
+            {
+              "color": "rgba(10,10,10,1.00)",
+              "fontSize": "16px",
+              "fontWeight": "500",
+            }
+          }
+        >
+          Alice
+        </div>
+        <div
+          className="css-text-146c3p1"
+          dir="auto"
+          ref={[Function]}
+          style={
+            {
+              "color": "rgba(113,113,130,1.00)",
+              "fontSize": "12px",
+            }
+          }
+        >
+          online
+        </div>
+      </div>
+    </div>
+    <div
+      className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+      dir={null}
+      ref={[Function]}
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "24px",
+            "marginRight": "12px",
+          }
+        }
+      >
+        🎥
+      </div>
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "24px",
+            "marginRight": "12px",
+          }
+        }
+      >
+        📞
+      </div>
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "24px",
+          }
+        }
+      >
+        ⋮
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-view-g5y9jx r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-agouwx r-flex-13awgt0"
+    dir={null}
+    onScroll={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    onWheel={[Function]}
+    ref={[Function]}
+  >
+    <div
+      className="css-view-g5y9jx"
+      dir={null}
+      ref={[Function]}
+      style={
+        {
+          "paddingBottom": "12px",
+          "paddingLeft": "12px",
+          "paddingRight": "12px",
+          "paddingTop": "12px",
+        }
+      }
+    >
+      <div
+        className="css-view-g5y9jx r-flexDirection-18u37iz r-justifyContent-17s6mgv"
+        dir={null}
+        ref={[Function]}
+        style={
+          {
+            "marginBottom": "8px",
+          }
+        }
+      >
+        <div
+          aria-label="Outgoing message"
+          className="css-view-g5y9jx r-maxWidth-q5oqfz"
+          data-testid="outgoing-bubble"
+          dir={null}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(254,202,26,1.00)",
+              "borderBottomLeftRadius": "16px",
+              "borderBottomRightRadius": "16px",
+              "borderTopLeftRadius": "16px",
+              "borderTopRightRadius": "16px",
+              "paddingBottom": "8px",
+              "paddingLeft": "12px",
+              "paddingRight": "12px",
+              "paddingTop": "8px",
+            }
+          }
+        >
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(0,0,0,1.00)",
+                "fontSize": "12px",
+              }
+            }
+          >
+            Hello
+          </div>
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-17s6mgv"
+            dir={null}
+            ref={[Function]}
+            style={
+              {
+                "marginTop": "4px",
+              }
+            }
+          >
+            <div
+              className="css-text-146c3p1"
+              dir="auto"
+              ref={[Function]}
+              style={
+                {
+                  "color": "rgba(0,0,0,1.00)",
+                  "fontSize": "12px",
+                }
+              }
+            >
+              14:15
+            </div>
+            <div
+              className="css-text-146c3p1"
+              dir="auto"
+              ref={[Function]}
+              style={
+                {
+                  "color": "rgba(0,0,0,1.00)",
+                  "marginLeft": "4px",
+                }
+              }
+            >
+              ✓✓
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-view-g5y9jx r-borderTopWidth-5kkj8d"
+    dir={null}
+    ref={[Function]}
+    style={
+      {
+        "borderTopColor": "rgba(0,0,0,0.10)",
+        "paddingBottom": "8px",
+        "paddingLeft": "12px",
+        "paddingRight": "12px",
+        "paddingTop": "8px",
+      }
+    }
+  >
+    <div
+      className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+      dir={null}
+      ref={[Function]}
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "24px",
+            "marginRight": "8px",
+          }
+        }
+      >
+        +
+      </div>
+      <div
+        className="css-view-g5y9jx r-alignItems-1awozwy r-flex-13awgt0 r-flexDirection-18u37iz"
+        dir={null}
+        ref={[Function]}
+        style={
+          {
+            "backgroundColor": "rgba(236,236,240,1.00)",
+            "borderBottomLeftRadius": "16px",
+            "borderBottomRightRadius": "16px",
+            "borderTopLeftRadius": "16px",
+            "borderTopRightRadius": "16px",
+            "paddingBottom": "4px",
+            "paddingLeft": "12px",
+            "paddingRight": "12px",
+            "paddingTop": "4px",
+          }
+        }
+      >
+        <input
+          aria-label="Message input"
+          autoCapitalize="sentences"
+          autoComplete="on"
+          autoCorrect="on"
+          className="css-textinput-11aywtz r-placeholderTextColor-6taxm2 r-flex-13awgt0 r-padding-t60dpp"
+          dir="auto"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onSelect={[Function]}
+          placeholder="Type a message..."
+          readOnly={false}
+          ref={[Function]}
+          rows={1}
+          spellCheck={true}
+          style={
+            {
+              "--placeholderTextColor": "#717182",
+              "color": "rgba(10,10,10,1.00)",
+            }
+          }
+          value=""
+          virtualkeyboardpolicy="auto"
+        />
+        <div
+          className="css-text-146c3p1"
+          dir="auto"
+          ref={[Function]}
+          style={
+            {
+              "color": "rgba(113,113,130,1.00)",
+              "fontSize": "20px",
+            }
+          }
+        >
+          😊
+        </div>
+      </div>
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "24px",
+            "marginLeft": "8px",
+          }
+        }
+      >
+        📷
+      </div>
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "24px",
+            "marginLeft": "8px",
+          }
+        }
+      >
+        🎤
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/ui-screens/src/__snapshots__/ChatView.test.tsx.snap
+++ b/packages/ui-screens/src/__snapshots__/ChatView.test.tsx.snap
@@ -51,13 +51,12 @@ exports[`ChatView Screen renders and matches snapshot 1`] = `
         type="button"
       >
         <div
-          className="css-text-146c3p1"
+          className="css-text-146c3p1 r-fontSize-1x35g6"
           dir="auto"
           ref={[Function]}
           style={
             {
               "color": "rgba(10,10,10,1.00)",
-              "fontSize": "24px",
             }
           }
         >
@@ -161,13 +160,12 @@ exports[`ChatView Screen renders and matches snapshot 1`] = `
       ref={[Function]}
     >
       <div
-        className="css-text-146c3p1"
+        className="css-text-146c3p1 r-fontSize-1x35g6"
         dir="auto"
         ref={[Function]}
         style={
           {
             "color": "rgba(10,10,10,1.00)",
-            "fontSize": "24px",
             "marginRight": "12px",
           }
         }
@@ -175,13 +173,12 @@ exports[`ChatView Screen renders and matches snapshot 1`] = `
         🎥
       </div>
       <div
-        className="css-text-146c3p1"
+        className="css-text-146c3p1 r-fontSize-1x35g6"
         dir="auto"
         ref={[Function]}
         style={
           {
             "color": "rgba(10,10,10,1.00)",
-            "fontSize": "24px",
             "marginRight": "12px",
           }
         }
@@ -189,13 +186,12 @@ exports[`ChatView Screen renders and matches snapshot 1`] = `
         📞
       </div>
       <div
-        className="css-text-146c3p1"
+        className="css-text-146c3p1 r-fontSize-1x35g6"
         dir="auto"
         ref={[Function]}
         style={
           {
             "color": "rgba(10,10,10,1.00)",
-            "fontSize": "24px",
           }
         }
       >
@@ -330,13 +326,12 @@ exports[`ChatView Screen renders and matches snapshot 1`] = `
       ref={[Function]}
     >
       <div
-        className="css-text-146c3p1"
+        className="css-text-146c3p1 r-fontSize-1x35g6"
         dir="auto"
         ref={[Function]}
         style={
           {
             "color": "rgba(113,113,130,1.00)",
-            "fontSize": "24px",
             "marginRight": "8px",
           }
         }
@@ -388,13 +383,12 @@ exports[`ChatView Screen renders and matches snapshot 1`] = `
           virtualkeyboardpolicy="auto"
         />
         <div
-          className="css-text-146c3p1"
+          className="css-text-146c3p1 r-fontSize-adyw6z"
           dir="auto"
           ref={[Function]}
           style={
             {
               "color": "rgba(113,113,130,1.00)",
-              "fontSize": "20px",
             }
           }
         >
@@ -402,13 +396,12 @@ exports[`ChatView Screen renders and matches snapshot 1`] = `
         </div>
       </div>
       <div
-        className="css-text-146c3p1"
+        className="css-text-146c3p1 r-fontSize-1x35g6"
         dir="auto"
         ref={[Function]}
         style={
           {
             "color": "rgba(113,113,130,1.00)",
-            "fontSize": "24px",
             "marginLeft": "8px",
           }
         }
@@ -416,13 +409,12 @@ exports[`ChatView Screen renders and matches snapshot 1`] = `
         📷
       </div>
       <div
-        className="css-text-146c3p1"
+        className="css-text-146c3p1 r-fontSize-1x35g6"
         dir="auto"
         ref={[Function]}
         style={
           {
             "color": "rgba(113,113,130,1.00)",
-            "fontSize": "24px",
             "marginLeft": "8px",
           }
         }

--- a/packages/ui-screens/tsconfig.json
+++ b/packages/ui-screens/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
-    "types": ["jest", "react", "react-native"]
+    "types": ["jest", "react", "react-native"],
+    "typeRoots": ["../../tests", "../../node_modules/@types"]
   },
   "include": ["src", "../ui-components/src/**/*", "**/*.ts", "**/*.tsx"],
   "exclude": [

--- a/tests/react-native.d.ts
+++ b/tests/react-native.d.ts
@@ -6,10 +6,13 @@ declare module 'react-native' {
   export const Image: React.FC<any>;
   export const Pressable: React.FC<any>;
   export const Modal: React.FC<any>;
+  export const ScrollView: React.FC<any>;
+  export const TextInput: React.FC<any>;
   export const Animated: any;
   export const StyleSheet: {
     create: (styles: any) => any;
     absoluteFillObject: any;
+    hairlineWidth: number;
   };
   export type StyleProp<T> = any;
   export interface ViewStyle {}
@@ -39,4 +42,5 @@ declare module 'react-native-safe-area-context' {
     left: number;
     right: number;
   };
+  export const SafeAreaProvider: React.FC<any>;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,11 @@
       "@apps/*": ["apps/*/src"],
       "@packages/*": ["packages/*/src"],
       "@mchat/*": ["packages/*/src"],
-      "@native/*": ["native/*/src"]
+      "@native/*": ["native/*/src"],
+      "@hum/ui-components": ["packages/ui-components/src/index.ts"],
+      "@hum/ui-components/*": ["packages/ui-components/src/*"],
+      "@hum/ui-screens": ["packages/ui-screens/src/index.ts"],
+      "@hum/ui-screens/*": ["packages/ui-screens/src/*"]
     }
   },
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,6 @@
       "@packages/*": ["packages/*/src"],
       "@mchat/*": ["packages/*/src"],
       "@native/*": ["native/*/src"],
-      "@hum/ui-components": ["packages/ui-components/src/index.ts"],
       "@hum/ui-components/*": ["packages/ui-components/src/*"],
       "@hum/ui-screens": ["packages/ui-screens/src/index.ts"],
       "@hum/ui-screens/*": ["packages/ui-screens/src/*"]


### PR DESCRIPTION
## Summary
- add reusable MessageBubble component with themed styling
- implement ChatView screen leveraging MessageBubble and shared UI
- document and test ChatView and MessageBubble

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b30fbb7e80832fbdf13111bcf3e8eb