### PR TITLE
fix: use ESM Vite config for Storybook

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -2,6 +2,7 @@
   "name": "@mchat/storybook",
   "private": true,
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "start": "storybook dev -p 7007",
     "ios": "expo run:ios",

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "noEmit": true,
+    "module": "ESNext",
     "paths": {
       "@hum/ui-components": ["../../packages/ui-components/src/index.ts"],
       "@hum/ui-components/*": ["../../packages/ui-components/src/*"],


### PR DESCRIPTION
## Summary
- configure Storybook package for ESM to avoid deprecated Vite CJS API warning

## Testing
- `pnpm lint`
- `pnpm --dir apps/storybook exec storybook dev -p 7007 --ci`
- `pnpm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b316db5964832fa407b1d3a565900c