### PR TITLE
chore: use new husky command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsc -p packages/ui-components/tsconfig.json",
     "lint": "eslint 'packages/**/*.{ts,tsx,js}'",
     "format": "prettier --write '**/*.{ts,tsx,js,json,md}'",
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "jest",
     "build": "pnpm -r --filter './packages/*' build",
     "storybook:start": "npm --prefix apps/storybook start",


### PR DESCRIPTION
## Summary
- fix deprecated `husky install` by using current `husky` command

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3179965d8832f884679a879ad3146