### PR TITLE
chore: align husky pre-commit with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Format
+        run: pnpm format:check
+
       - name: Test
         run: pnpm test
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,4 @@
 #!/bin/sh
-npx lint-staged
+pnpm lint
+pnpm typecheck
+pnpm format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,14 @@
 # Contributing
 
 ## How we work
+
 Describe how to get involved and the development workflow.
 Avoid committing IDE-specific folders (e.g., `.idea/`).
 
 ## Commit style
+
 Use concise, conventional commit messages (e.g., `feat:`, `fix:`, `chore:`).
 
 ## Running tests
+
 Tests will be added later. For now, ensure changes build and lint successfully.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,4 +1,3 @@
 # Mobile App
 
 The canonical source root for the mobile app is `apps/mobile/src/`. All mobile-specific code will live under this directory going forward.
-

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -15,7 +15,6 @@ const preview: Preview = {
 
   tags: ['autodocs'],
   decorators: [
-
     (Story) => (
       <ThemeProvider forcedScheme="light">
         <Story />

--- a/apps/storybook/babel.config.js
+++ b/apps/storybook/babel.config.js
@@ -1,6 +1,6 @@
-module.exports = function(api) {
+module.exports = function (api) {
   api.cache(true);
   return {
-    presets: ['babel-preset-expo']
+    presets: ['babel-preset-expo'],
   };
 };

--- a/apps/storybook/storybook/stories/Hello.stories.tsx
+++ b/apps/storybook/storybook/stories/Hello.stories.tsx
@@ -1,11 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
-const Card: React.FC<{ label?: string }> = ({ label = 'Hello Storybook 👋' }) => (
-  <div style={{
-    fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif',
-    padding: 24, borderRadius: 12, border: '1px solid #ddd', minWidth: 280
-  }}>
+const Card: React.FC<{ label?: string }> = ({
+  label = 'Hello Storybook 👋',
+}) => (
+  <div
+    style={{
+      fontFamily:
+        'system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif',
+      padding: 24,
+      borderRadius: 12,
+      border: '1px solid #ddd',
+      minWidth: 280,
+    }}
+  >
     <h3 style={{ margin: 0, marginBottom: 12 }}>Demo</h3>
     <p style={{ margin: 0 }}>{label}</p>
   </div>

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -4,12 +4,15 @@
 - Date: 2025-08-20
 
 ## Context
+
 Software projects benefit from documenting significant architectural decisions. These records help future contributors understand why certain paths were taken.
 
 ## Decision
+
 Adopt Architecture Decision Records (ADRs) to capture important architectural choices. Each ADR will reside in this folder and follow the format described in the README.
 
 ## Consequences
+
 - Provides a history of the project's key decisions.
 - Facilitates informed discussions when revisiting or revising past decisions.
 - Requires contributors to maintain ADRs as the architecture evolves.

--- a/docs/adr/0002-react-native-expo-dev-client.md
+++ b/docs/adr/0002-react-native-expo-dev-client.md
@@ -4,12 +4,15 @@
 - Date: 2025-08-20
 
 ## Context
+
 The project targets iOS and Android with a single codebase while maintaining a native feel. Expo Dev Client provides a customizable runtime for React Native apps and streamlines development.
 
 ## Decision
+
 Build the mobile interface using React Native and Expo Dev Client. This choice allows rapid iteration with JavaScript and TypeScript while keeping the option to add native modules when necessary.
 
 ## Consequences
+
 - Single codebase for multiple platforms.
 - Faster development and hot-reload during the prototyping phase.
 - Dependency on the Expo ecosystem and React Native updates.

--- a/docs/adr/0003-rust-core.md
+++ b/docs/adr/0003-rust-core.md
@@ -4,12 +4,15 @@
 - Date: 2025-08-20
 
 ## Context
+
 End-to-end encryption and protocol handling require performance and safety. Rust offers memory safety without a garbage collector and has an existing Matrix SDK.
 
 ## Decision
+
 Develop the application's core using Rust, leveraging `matrix-rust-sdk`, and expose functionality to the React Native layer through a native module.
 
 ## Consequences
+
 - High-performance, memory-safe core.
 - Shared logic across platforms.
 - Requires a bridging layer to connect Rust and JavaScript.

--- a/docs/adr/0004-lightning-deep-link-first.md
+++ b/docs/adr/0004-lightning-deep-link-first.md
@@ -4,12 +4,15 @@
 - Date: 2025-08-20
 
 ## Context
+
 Supporting Lightning Network payments is a project goal. Embedding a wallet is complex and may delay core messaging features.
 
 ## Decision
+
 Initial Lightning support will use deep-links to existing wallet apps. Users can send and receive payments through their preferred wallet without embedding wallet code in the app.
 
 ## Consequences
+
 - Enables Lightning payments early in the project.
 - Reduces security and maintenance burden by relying on established wallets.
 - Requires users to have a compatible Lightning wallet installed.

--- a/docs/adr/0005-matrix-federation.md
+++ b/docs/adr/0005-matrix-federation.md
@@ -4,12 +4,15 @@
 - Date: 2025-08-20
 
 ## Context
+
 The project aims to avoid walled gardens and interoperate with other messaging systems. Matrix provides an open standard for secure, decentralized communication.
 
 ## Decision
+
 Adopt the Matrix protocol for federation. Servers and clients will communicate using Matrix APIs, enabling interoperability with the wider Matrix ecosystem.
 
 ## Consequences
+
 - Aligns the project with a well-supported open protocol.
 - Allows communication with existing Matrix users and servers.
 - Requires handling Matrix-specific concepts such as rooms and events.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,6 +3,7 @@
 This folder stores Architecture Decision Records (ADRs) for the project.
 
 ## How to add a new ADR
+
 1. Choose the next sequential number and create a file named `NNNN-your-title.md`.
 2. Use the following sections:
    - **Status**: `Accepted`, `Proposed`, etc.

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,4 +1,3 @@
 # Development Setup
 
 Placeholder for setting up the development environment.
-

--- a/native/ln-core/README.md
+++ b/native/ln-core/README.md
@@ -24,4 +24,3 @@ This package will be linked into the app via an Expo Config Plugin
 (`with-ln-core`) which will configure the native build to include the
 module on both Android and iOS. The config plugin will be added in a
 future update.
-

--- a/native/ln-core/index.ts
+++ b/native/ln-core/index.ts
@@ -11,4 +11,3 @@ export const LnCore = {
 };
 
 export default LnCore;
-

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "typecheck": "tsc -p packages/ui-components/tsconfig.json",
     "lint": "eslint 'packages/**/*.{ts,tsx,js}'",
     "format": "prettier --write '**/*.{ts,tsx,js,json,md}'",
+    "format:check": "prettier --check '**/*.{ts,tsx,js,json,md}'",
     "prepare": "husky install",
     "test": "jest",
     "build": "pnpm -r --filter './packages/*' build",


### PR DESCRIPTION
## Summary
- run lint, typecheck, and format from Husky pre-commit hook
- add `pnpm format:check` and run it in CI
- format repository to satisfy Prettier check

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31826e454832f8dd711abf41ba0f3