### PR TITLE
feat: add bottom navigation screen

### DIFF
--- a/apps/storybook/storybook/stories/BottomNavItem.stories.tsx
+++ b/apps/storybook/storybook/stories/BottomNavItem.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { Text } from 'react-native';
+import {
+  BottomNavItem,
+  type BottomNavItemProps,
+} from '@hum/ui-components/bottom-navigation-item';
+
+const ExampleItem: React.FC<BottomNavItemProps> = (props) => (
+  <BottomNavItem icon={<Text>💬</Text>} label="Inbox" {...props} />
+);
+
+const meta: Meta<typeof ExampleItem> = {
+  title: 'Components/BottomNavItem',
+  component: ExampleItem,
+  argTypes: {
+    onPress: { action: 'press' },
+    isActive: { control: 'boolean' },
+    badgeCount: { control: 'number' },
+  },
+  args: {
+    isActive: false,
+    badgeCount: 0,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ExampleItem>;
+
+export const Basic: Story = {};
+export const Active: Story = { args: { isActive: true } };
+export const WithBadge: Story = { args: { badgeCount: 5 } };

--- a/apps/storybook/storybook/stories/BottomNavItem.stories.tsx
+++ b/apps/storybook/storybook/stories/BottomNavItem.stories.tsx
@@ -1,10 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 import { Text } from 'react-native';
-import {
-  BottomNavItem,
-  type BottomNavItemProps,
-} from '@hum/ui-components/bottom-navigation-item';
+import { BottomNavItem, type BottomNavItemProps } from '@hum/ui-components';
 
 const ExampleItem: React.FC<BottomNavItemProps> = (props) => (
   <BottomNavItem icon={<Text>💬</Text>} label="Inbox" {...props} />

--- a/apps/storybook/storybook/stories/BottomNavigation.stories.tsx
+++ b/apps/storybook/storybook/stories/BottomNavigation.stories.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { BottomNavigation, type BottomNavigationProps } from '@hum/ui-screens';
+
+const Wrapper: React.FC<BottomNavigationProps> = (props) => {
+  const [active, setActive] = React.useState(props.activeTab);
+  return (
+    <BottomNavigation {...props} activeTab={active} onTabChange={setActive} />
+  );
+};
+
+const meta: Meta<typeof Wrapper> = {
+  title: 'Screens/BottomNavigation',
+  component: Wrapper,
+  decorators: [
+    (Story) => (
+      <SafeAreaProvider>
+        <Story />
+      </SafeAreaProvider>
+    ),
+  ],
+  argTypes: {
+    chatsBadgeCount: { control: 'number' },
+  },
+  args: {
+    activeTab: 'chats',
+    chatsBadgeCount: 0,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Wrapper>;
+
+export const Basic: Story = {};
+export const WithBadge: Story = { args: { chatsBadgeCount: 5 } };

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,8 @@ module.exports = {
   },
   moduleNameMapper: {
     '^react-native$': 'react-native-web',
-    '^@hum/ui-components(.*)$': '<rootDir>/packages/ui-components/src$1',
+    '^@hum/ui-components$': '<rootDir>/packages/ui-components/index.ts',
+    '^@hum/ui-components/(.*)$': '<rootDir>/packages/ui-components/src/$1',
     '^@hum/ui-screens(.*)$': '<rootDir>/packages/ui-screens/src$1',
   },
 };

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -36,3 +36,5 @@ export { AspectRatio } from './src/aspect-ratio';
 export type { AspectRatioProps } from './src/aspect-ratio';
 export { MessageBubble } from './src/message-bubble';
 export type { MessageBubbleProps } from './src/message-bubble';
+export { BottomNavItem } from './src/bottom-navigation-item';
+export type { BottomNavItemProps } from './src/bottom-navigation-item';

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -17,6 +17,10 @@
       "types": "./dist/message-bubble.d.ts",
       "default": "./dist/message-bubble.js"
     },
+    "./bottom-navigation-item": {
+      "types": "./dist/bottom-navigation-item.d.ts",
+      "default": "./dist/bottom-navigation-item.js"
+    },
     "./theme/ThemeProvider": {
       "types": "./dist/theme/ThemeProvider.d.ts",
       "default": "./dist/theme/ThemeProvider.js"

--- a/packages/ui-components/src/__snapshots__/bottom-navigation-item.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/bottom-navigation-item.test.tsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`BottomNavItem renders and matches snapshot 1`] = `
+<button
+  aria-label="Inbox"
+  className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci"
+  dir={null}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  ref={[Function]}
+  role="button"
+  style={
+    {
+      "minHeight": "60px",
+      "paddingBottom": "12px",
+      "paddingLeft": "8px",
+      "paddingRight": "8px",
+      "paddingTop": "12px",
+    }
+  }
+  tabIndex={0}
+  type="button"
+>
+  <div
+    className="css-view-g5y9jx r-position-bnwqim"
+    dir={null}
+    ref={[Function]}
+  >
+    <div
+      className="css-text-146c3p1"
+      data-testid="icon"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(113,113,130,1.00)",
+          "fontSize": "24px",
+        }
+      }
+    >
+      I
+    </div>
+  </div>
+  <div
+    className="css-text-146c3p1 r-textAlign-q4m81j"
+    dir="auto"
+    ref={[Function]}
+    style={
+      {
+        "color": "rgba(113,113,130,1.00)",
+        "fontSize": "12px",
+        "marginTop": "4px",
+      }
+    }
+  >
+    Inbox
+  </div>
+</button>
+`;

--- a/packages/ui-components/src/bottom-navigation-item.test.tsx
+++ b/packages/ui-components/src/bottom-navigation-item.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import '@testing-library/jest-native/extend-expect';
+import {
+  BottomNavItem,
+  type BottomNavItemProps,
+} from './bottom-navigation-item';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
+
+type Scheme = 'light' | 'dark';
+
+function renderItem(
+  scheme: Scheme = 'light',
+  props?: Partial<BottomNavItemProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <BottomNavItem
+        icon={<Text testID="icon">I</Text>}
+        label="Inbox"
+        {...props}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe('BottomNavItem', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderItem();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('calls onPress when pressed', () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = renderItem('light', { onPress });
+    fireEvent.press(getByLabelText('Inbox'));
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  it('shows badge when badgeCount > 0', () => {
+    const { UNSAFE_getAllByType } = renderItem('light', { badgeCount: 3 });
+    const texts = UNSAFE_getAllByType(Text).map((t) => t.props.children);
+    expect(texts).toContain(3);
+  });
+
+  it('limits badge text to 9+', () => {
+    const { UNSAFE_getAllByType } = renderItem('light', { badgeCount: 12 });
+    const texts = UNSAFE_getAllByType(Text).map((t) => t.props.children);
+    expect(texts).toContain('9+');
+  });
+
+  it('applies active styling', () => {
+    const { UNSAFE_getAllByType, rerender } = renderItem();
+    const label = UNSAFE_getAllByType(Text).find(
+      (t) => t.props.children === 'Inbox',
+    );
+    expect(label).toHaveStyle({ color: colors.light.mutedForeground });
+    rerender(
+      <ThemeProvider forcedScheme="light">
+        <BottomNavItem icon={<Text>I</Text>} label="Inbox" isActive />
+      </ThemeProvider>,
+    );
+    const updated = UNSAFE_getAllByType(Text).find(
+      (t) => t.props.children === 'Inbox',
+    );
+    expect(updated).toHaveStyle({ color: colors.light.humPrimary });
+  });
+
+  it('applies theme colors', () => {
+    const { UNSAFE_getAllByType, rerender } = renderItem('light');
+    const label = UNSAFE_getAllByType(Text).find(
+      (t) => t.props.children === 'Inbox',
+    );
+    expect(label).toHaveStyle({ color: colors.light.mutedForeground });
+    rerender(
+      <ThemeProvider forcedScheme="dark">
+        <BottomNavItem icon={<Text>I</Text>} label="Inbox" />
+      </ThemeProvider>,
+    );
+    const updated = UNSAFE_getAllByType(Text).find(
+      (t) => t.props.children === 'Inbox',
+    );
+    expect(updated).toHaveStyle({ color: colors.dark.mutedForeground });
+  });
+});

--- a/packages/ui-components/src/bottom-navigation-item.tsx
+++ b/packages/ui-components/src/bottom-navigation-item.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import {
+  Pressable,
+  View,
+  Text,
+  StyleSheet,
+  GestureResponderEvent,
+} from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export interface BottomNavItemProps {
+  icon: React.ReactNode;
+  label: string;
+  isActive?: boolean;
+  onPress?: (event: GestureResponderEvent) => void;
+  badgeCount?: number;
+  testID?: string;
+}
+
+export const BottomNavItem: React.FC<BottomNavItemProps> = ({
+  icon,
+  label,
+  isActive = false,
+  onPress,
+  badgeCount = 0,
+  testID,
+}) => {
+  const { colors, spacing, type } = useTheme();
+  const iconColor = isActive ? colors.humPrimary : colors.mutedForeground;
+
+  const renderIcon = () => {
+    if (React.isValidElement(icon)) {
+      return React.cloneElement(
+        icon as React.ReactElement<{ style?: object }>,
+        {
+          style: [
+            { color: iconColor, fontSize: 24 },
+            (icon as React.ReactElement<{ style?: object }>).props.style,
+          ],
+        },
+      );
+    }
+    return icon;
+  };
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: isActive }}
+      onPress={onPress}
+      testID={testID}
+      style={({ pressed }: { pressed: boolean }) => [
+        styles.container,
+        {
+          paddingVertical: spacing.md,
+          paddingHorizontal: spacing.sm,
+          minHeight: 60,
+        },
+        pressed && { backgroundColor: colors.muted },
+      ]}
+    >
+      <View style={styles.iconWrapper}>
+        {renderIcon()}
+        {badgeCount > 0 && (
+          <View style={[styles.badge, { backgroundColor: colors.humPrimary }]}>
+            <Text
+              style={[
+                styles.badgeText,
+                {
+                  color: colors.humPrimaryForeground,
+                  fontSize: type.size.sm,
+                  fontWeight: type.weight.medium,
+                },
+              ]}
+            >
+              {badgeCount > 9 ? '9+' : badgeCount}
+            </Text>
+          </View>
+        )}
+      </View>
+      <Text
+        style={[
+          styles.label,
+          {
+            color: isActive ? colors.humPrimary : colors.mutedForeground,
+            fontSize: type.size.sm,
+            marginTop: spacing.xs,
+          },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  iconWrapper: {
+    position: 'relative',
+  },
+  badge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    minWidth: 20,
+    height: 20,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  badgeText: {
+    textAlign: 'center',
+  },
+  label: {
+    textAlign: 'center',
+  },
+});
+
+export default BottomNavItem;

--- a/packages/ui-screens/index.ts
+++ b/packages/ui-screens/index.ts
@@ -1,3 +1,5 @@
 export { DummyScreen } from './src/DummyScreen';
 export { ChatItem } from './src/ChatItem';
 export { ChatView } from './src/ChatView';
+export { BottomNavigation } from './src/BottomNavigation';
+export type { BottomNavigationProps } from './src/BottomNavigation';

--- a/packages/ui-screens/src/BottomNavigation.test.tsx
+++ b/packages/ui-screens/src/BottomNavigation.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import '@testing-library/jest-native/extend-expect';
+import {
+  BottomNavigation,
+  type BottomNavigationProps,
+} from './BottomNavigation';
+import { ThemeProvider } from '@hum/ui-components/theme/ThemeProvider';
+import { colors } from '../../ui-components/src/theme/colors';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const baseProps: BottomNavigationProps = {
+  activeTab: 'chats',
+};
+
+type Scheme = 'light' | 'dark';
+
+function renderNav(
+  scheme: Scheme = 'light',
+  props?: Partial<BottomNavigationProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <BottomNavigation {...baseProps} {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('BottomNavigation Screen', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderNav();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('calls onTabChange when a tab is pressed', () => {
+    const onTabChange = jest.fn();
+    const { getByLabelText } = renderNav('light', { onTabChange });
+    fireEvent.press(getByLabelText('Lightning'));
+    expect(onTabChange).toHaveBeenCalledWith('lightning');
+  });
+
+  it('shows badge count', () => {
+    const { UNSAFE_getAllByType } = renderNav('light', { chatsBadgeCount: 4 });
+    const texts = UNSAFE_getAllByType(Text).map((t) => t.props.children);
+    expect(texts).toContain(4);
+  });
+
+  it('applies theme colors', () => {
+    const { UNSAFE_getAllByType, rerender } = renderNav('light');
+    const label = UNSAFE_getAllByType(Text).find(
+      (t) => t.props.children === 'Lightning',
+    );
+    expect(label).toHaveStyle({ color: colors.light.mutedForeground });
+    rerender(
+      <ThemeProvider forcedScheme="dark">
+        <BottomNavigation {...baseProps} />
+      </ThemeProvider>,
+    );
+    const updated = UNSAFE_getAllByType(Text).find(
+      (t) => t.props.children === 'Lightning',
+    );
+    expect(updated).toHaveStyle({ color: colors.dark.mutedForeground });
+  });
+});

--- a/packages/ui-screens/src/BottomNavigation.tsx
+++ b/packages/ui-screens/src/BottomNavigation.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { View, StyleSheet, Text } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { BottomNavItem } from '@hum/ui-components/bottom-navigation-item';
+import { useTheme } from '@hum/ui-components/theme/ThemeProvider';
+
+export interface BottomNavigationProps {
+  activeTab?: string;
+  onTabChange?: (tab: string) => void;
+  chatsBadgeCount?: number;
+}
+
+export const BottomNavigation: React.FC<BottomNavigationProps> = ({
+  activeTab = 'chats',
+  onTabChange,
+  chatsBadgeCount = 0,
+}) => {
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  const navItems = [
+    {
+      id: 'chats',
+      icon: <Text>💬</Text>,
+      label: 'Chats',
+      badgeCount: chatsBadgeCount,
+    },
+    { id: 'lightning', icon: <Text>⚡</Text>, label: 'Lightning' },
+    { id: 'settings', icon: <Text>⚙️</Text>, label: 'Settings' },
+  ];
+
+  return (
+    <View
+      accessibilityRole="tablist"
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          borderTopColor: colors.border,
+          paddingBottom: insets.bottom,
+        },
+      ]}
+    >
+      <View style={styles.row}>
+        {navItems.map((item) => (
+          <BottomNavItem
+            key={item.id}
+            icon={item.icon}
+            label={item.label}
+            isActive={activeTab === item.id}
+            onPress={() => onTabChange?.(item.id)}
+            badgeCount={item.badgeCount || 0}
+          />
+        ))}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderTopWidth: 1,
+  },
+  row: {
+    flexDirection: 'row',
+  },
+});
+
+export default BottomNavigation;

--- a/packages/ui-screens/src/BottomNavigation.tsx
+++ b/packages/ui-screens/src/BottomNavigation.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { BottomNavItem } from '@hum/ui-components/bottom-navigation-item';
-import { useTheme } from '@hum/ui-components/theme/ThemeProvider';
+import { BottomNavItem } from '@hum/ui-components';
+import { useTheme } from '@hum/ui-components';
 
 export interface BottomNavigationProps {
   activeTab?: string;

--- a/packages/ui-screens/src/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/packages/ui-screens/src/__snapshots__/BottomNavigation.test.tsx.snap
@@ -1,0 +1,195 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`BottomNavigation Screen renders and matches snapshot 1`] = `
+<div
+  className="css-view-g5y9jx r-borderTopWidth-5kkj8d r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj"
+  dir={null}
+  ref={[Function]}
+  role="tablist"
+  style={
+    {
+      "backgroundColor": "rgba(255,255,255,1.00)",
+      "borderTopColor": "rgba(0,0,0,0.10)",
+      "paddingBottom": "0px",
+    }
+  }
+>
+  <div
+    className="css-view-g5y9jx r-flexDirection-18u37iz"
+    dir={null}
+    ref={[Function]}
+  >
+    <button
+      aria-label="Chats"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "minHeight": "60px",
+          "paddingBottom": "12px",
+          "paddingLeft": "8px",
+          "paddingRight": "8px",
+          "paddingTop": "12px",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-view-g5y9jx r-position-bnwqim"
+        dir={null}
+        ref={[Function]}
+      >
+        <div
+          className="css-text-146c3p1"
+          dir="auto"
+          ref={[Function]}
+          style={
+            {
+              "color": "rgba(254,202,26,1.00)",
+              "fontSize": "24px",
+            }
+          }
+        >
+          💬
+        </div>
+      </div>
+      <div
+        className="css-text-146c3p1 r-textAlign-q4m81j"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(254,202,26,1.00)",
+            "fontSize": "12px",
+            "marginTop": "4px",
+          }
+        }
+      >
+        Chats
+      </div>
+    </button>
+    <button
+      aria-label="Lightning"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "minHeight": "60px",
+          "paddingBottom": "12px",
+          "paddingLeft": "8px",
+          "paddingRight": "8px",
+          "paddingTop": "12px",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-view-g5y9jx r-position-bnwqim"
+        dir={null}
+        ref={[Function]}
+      >
+        <div
+          className="css-text-146c3p1"
+          dir="auto"
+          ref={[Function]}
+          style={
+            {
+              "color": "rgba(113,113,130,1.00)",
+              "fontSize": "24px",
+            }
+          }
+        >
+          ⚡
+        </div>
+      </div>
+      <div
+        className="css-text-146c3p1 r-textAlign-q4m81j"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "marginTop": "4px",
+          }
+        }
+      >
+        Lightning
+      </div>
+    </button>
+    <button
+      aria-label="Settings"
+      className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flex-13awgt0 r-justifyContent-1777fci"
+      dir={null}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      ref={[Function]}
+      role="button"
+      style={
+        {
+          "minHeight": "60px",
+          "paddingBottom": "12px",
+          "paddingLeft": "8px",
+          "paddingRight": "8px",
+          "paddingTop": "12px",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="css-view-g5y9jx r-position-bnwqim"
+        dir={null}
+        ref={[Function]}
+      >
+        <div
+          className="css-text-146c3p1"
+          dir="auto"
+          ref={[Function]}
+          style={
+            {
+              "color": "rgba(113,113,130,1.00)",
+              "fontSize": "24px",
+            }
+          }
+        >
+          ⚙️
+        </div>
+      </div>
+      <div
+        className="css-text-146c3p1 r-textAlign-q4m81j"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+            "marginTop": "4px",
+          }
+        }
+      >
+        Settings
+      </div>
+    </button>
+  </div>
+</div>
+`;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
       "@packages/*": ["packages/*/src"],
       "@mchat/*": ["packages/*/src"],
       "@native/*": ["native/*/src"],
+      "@hum/ui-components": ["packages/ui-components/index.ts"],
       "@hum/ui-components/*": ["packages/ui-components/src/*"],
       "@hum/ui-screens": ["packages/ui-screens/src/index.ts"],
       "@hum/ui-screens/*": ["packages/ui-screens/src/*"]


### PR DESCRIPTION
## Summary
- add reusable BottomNavItem component
- implement BottomNavigation screen and stories
- add tests and storybook stories

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:start` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b31de64284832f88cc0aa8f68c746e