### PR TITLE
chore: cache Playwright browsers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - uses: actions/cache@v4
+        with:
+          path: '~/.cache/ms-playwright'
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+
       - name: Lint
         run: pnpm lint
 


### PR DESCRIPTION
## Summary
- cache Playwright browser downloads to speed up CI

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b324bc1d2c832fb0fad8cdc6fdb92b