### PR TITLE
chore: approve build scripts for esbuild and unrs-resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,11 @@
   },
   "dependencies": {
     "@testing-library/react": "16.3.0"
+  },
+  "pnpm": {
+    "trustedDependencies": [
+      "esbuild",
+      "unrs-resolver"
+    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,6 @@ packages:
   - packages/*
   - native/*
 
-onlyBuiltDependencies:
+allowedBuildScripts:
   - esbuild
   - unrs-resolver

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 packages:
-  - 'apps/*'
-  - 'packages/*'
-  - 'native/*'
+  - apps/*
+  - packages/*
+  - native/*
+
+onlyBuiltDependencies:
+  - esbuild
+  - unrs-resolver


### PR DESCRIPTION
## Summary
- allow esbuild and unrs-resolver to run build scripts during install

## Testing
- `pnpm install`
- `pnpm test 2>&1 | tail -n 20 | nl -ba`

------
https://chatgpt.com/codex/tasks/task_e_68b32effee6c832fb7181b0cdd2bc94f