### PR TITLE
feat: add Settings screen and reusable item component

### DIFF
--- a/apps/storybook/storybook/stories/SettingsItem.stories.tsx
+++ b/apps/storybook/storybook/stories/SettingsItem.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SettingsItem } from '@hum/ui-components';
+import { Text } from 'react-native';
+
+const meta: Meta<typeof SettingsItem> = {
+  title: 'Components/SettingsItem',
+  component: SettingsItem,
+  args: {
+    title: 'Account',
+    subtitle: 'Manage your account',
+  },
+  argTypes: {
+    onPress: { action: 'pressed' },
+  },
+};
+
+export default meta;
+
+export type Story = StoryObj<typeof SettingsItem>;
+
+export const Basic: Story = {
+  render: (args) => <SettingsItem {...args} icon={<Text>👤</Text>} />,
+};
+
+export const WithoutSubtitle: Story = {
+  render: (args) => (
+    <SettingsItem {...args} icon={<Text>👤</Text>} subtitle={undefined} />
+  ),
+};
+
+export const CustomIcon: Story = {
+  render: (args) => <SettingsItem {...args} icon={<Text>🔐</Text>} />,
+};

--- a/apps/storybook/storybook/stories/SettingsScreen.stories.tsx
+++ b/apps/storybook/storybook/stories/SettingsScreen.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SettingsScreen } from '@hum/ui-screens';
+
+const meta: Meta<typeof SettingsScreen> = {
+  title: 'Screens/SettingsScreen',
+  component: SettingsScreen,
+  argTypes: {
+    onBack: { action: 'back' },
+  },
+};
+
+export default meta;
+
+export type Story = StoryObj<typeof SettingsScreen>;
+
+export const Default: Story = {};
+
+export const WithBackButton: Story = {
+  args: { onBack: () => {} },
+};

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -40,3 +40,5 @@ export { BottomNavItem } from './src/bottom-navigation-item';
 export type { BottomNavItemProps } from './src/bottom-navigation-item';
 export { ListRow } from './src/list-row';
 export type { ListRowProps } from './src/list-row';
+export { SettingsItem } from './src/settings-item';
+export type { SettingsItemProps } from './src/settings-item';

--- a/packages/ui-components/src/__snapshots__/settings-item.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/settings-item.test.tsx.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`SettingsItem renders and matches snapshot 1`] = `
+<div
+  aria-label="Account"
+  className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+  dir={null}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  ref={[Function]}
+  style={
+    {
+      "backgroundColor": "rgba(0,0,0,0.00)",
+      "paddingBottom": "12px",
+      "paddingLeft": "16px",
+      "paddingRight": "16px",
+      "paddingTop": "12px",
+    }
+  }
+  tabIndex={0}
+>
+  <div
+    className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+    dir={null}
+    ref={[Function]}
+  >
+    <div
+      className="css-view-g5y9jx"
+      dir={null}
+      ref={[Function]}
+      style={
+        {
+          "marginRight": "12px",
+        }
+      }
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+      >
+        ⭐️
+      </div>
+    </div>
+    <div
+      className="css-view-g5y9jx"
+      dir={null}
+      ref={[Function]}
+    >
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(10,10,10,1.00)",
+            "fontSize": "16px",
+            "fontWeight": "500",
+          }
+        }
+      >
+        Account
+      </div>
+      <div
+        className="css-text-146c3p1"
+        dir="auto"
+        ref={[Function]}
+        style={
+          {
+            "color": "rgba(113,113,130,1.00)",
+            "fontSize": "12px",
+          }
+        }
+      >
+        Manage your account
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-text-146c3p1"
+    dir="auto"
+    ref={[Function]}
+    style={
+      {
+        "color": "rgba(113,113,130,1.00)",
+        "fontSize": "18px",
+      }
+    }
+  >
+    ›
+  </div>
+</div>
+`;

--- a/packages/ui-components/src/settings-item.test.tsx
+++ b/packages/ui-components/src/settings-item.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import '@testing-library/jest-native/extend-expect';
+
+import { SettingsItem, type SettingsItemProps } from './settings-item';
+import { ThemeProvider } from './theme/ThemeProvider';
+
+const baseProps: SettingsItemProps = {
+  icon: <Text>⭐️</Text>,
+  title: 'Account',
+  subtitle: 'Manage your account',
+};
+
+type Scheme = 'light' | 'dark';
+
+function renderItem(
+  scheme: Scheme = 'light',
+  props?: Partial<SettingsItemProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <SettingsItem {...baseProps} {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('SettingsItem', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderItem();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('calls onPress when pressed', () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = renderItem('light', { onPress });
+    fireEvent.press(getByLabelText('Account'));
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  it('renders in both themes', () => {
+    const { rerender } = renderItem('light');
+    rerender(
+      <ThemeProvider forcedScheme="dark">
+        <SettingsItem {...baseProps} />
+      </ThemeProvider>,
+    );
+  });
+});

--- a/packages/ui-components/src/settings-item.tsx
+++ b/packages/ui-components/src/settings-item.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useTheme } from './theme/ThemeProvider';
+
+export interface SettingsItemProps {
+  icon?: React.ReactNode;
+  title: string;
+  subtitle?: string;
+  onPress?: () => void;
+}
+
+export const SettingsItem: React.FC<SettingsItemProps> = ({
+  icon,
+  title,
+  subtitle,
+  onPress,
+}) => {
+  const { colors, spacing, type } = useTheme();
+
+  return (
+    <Pressable
+      style={({ pressed }: { pressed: boolean }) => [
+        styles.container,
+        {
+          paddingHorizontal: spacing.lg,
+          paddingVertical: spacing.md,
+          backgroundColor: pressed ? colors.muted : 'transparent',
+        },
+      ]}
+      accessibilityRole={onPress ? 'button' : undefined}
+      accessibilityLabel={title}
+      onPress={onPress}
+    >
+      <View style={styles.left}>
+        {icon ? <View style={{ marginRight: spacing.md }}>{icon}</View> : null}
+        <View>
+          <Text
+            style={{
+              color: colors.foreground,
+              fontSize: type.size.md,
+              fontWeight: type.weight.medium,
+            }}
+          >
+            {title}
+          </Text>
+          {subtitle ? (
+            <Text
+              style={{
+                color: colors.mutedForeground,
+                fontSize: type.size.sm,
+              }}
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+      <Text style={{ color: colors.mutedForeground, fontSize: type.size.lg }}>
+        ›
+      </Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  left: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});
+
+export default SettingsItem;

--- a/packages/ui-screens/index.ts
+++ b/packages/ui-screens/index.ts
@@ -8,3 +8,5 @@ export type { TopBarProps } from './src/TopBar';
 export { ChatsScreen } from './src/ChatsScreen';
 export type { ChatsScreenProps, Chat } from './src/ChatsScreen';
 export { mockChats } from './src/ChatsScreen';
+export { SettingsScreen } from './src/SettingsScreen';
+export type { SettingsScreenProps } from './src/SettingsScreen';

--- a/packages/ui-screens/src/SettingsScreen.test.tsx
+++ b/packages/ui-screens/src/SettingsScreen.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import '@testing-library/jest-native/extend-expect';
+import { ThemeProvider } from '@hum/ui-components/theme/ThemeProvider';
+import { SettingsScreen, type SettingsScreenProps } from './SettingsScreen';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+type Scheme = 'light' | 'dark';
+
+function renderScreen(
+  scheme: Scheme = 'light',
+  props?: Partial<SettingsScreenProps>,
+) {
+  return render(
+    <ThemeProvider forcedScheme={scheme}>
+      <SettingsScreen {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('SettingsScreen', () => {
+  it('renders and matches snapshot', () => {
+    const { toJSON } = renderScreen();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('updates search input text', () => {
+    const { getByLabelText } = renderScreen();
+    const input = getByLabelText('Search');
+    fireEvent.changeText(input, 'hello');
+    expect(input.props.value).toBe('hello');
+  });
+
+  it('fires onBack when back button pressed', () => {
+    const onBack = jest.fn();
+    const { getByLabelText } = renderScreen('light', { onBack });
+    fireEvent.press(getByLabelText('Go back'));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('renders in light and dark themes', () => {
+    const { rerender } = renderScreen('light');
+    rerender(
+      <ThemeProvider forcedScheme="dark">
+        <SettingsScreen />
+      </ThemeProvider>,
+    );
+  });
+});

--- a/packages/ui-screens/src/SettingsScreen.tsx
+++ b/packages/ui-screens/src/SettingsScreen.tsx
@@ -1,0 +1,321 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  Image,
+  Pressable,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme, SettingsItem } from '@hum/ui-components';
+
+export interface SettingsScreenProps {
+  onBack?: () => void;
+}
+
+export const SettingsScreen: React.FC<SettingsScreenProps> = ({ onBack }) => {
+  const { colors, spacing, radius, type } = useTheme();
+  const insets = useSafeAreaInsets();
+  const [search, setSearch] = React.useState('');
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: colors.background, paddingTop: insets.top },
+      ]}
+    >
+      {/* Header */}
+      <View
+        style={[
+          styles.header,
+          {
+            paddingVertical: spacing.lg,
+            borderBottomWidth: StyleSheet.hairlineWidth,
+            borderBottomColor: colors.border,
+          },
+        ]}
+      >
+        {onBack ? (
+          <Pressable
+            onPress={onBack}
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
+            style={[styles.backButton, { left: spacing.lg }]}
+          >
+            <Text
+              style={{
+                color: colors.foreground,
+                fontSize: type.size.xl,
+              }}
+            >
+              ‹
+            </Text>
+          </Pressable>
+        ) : null}
+        <Text
+          testID="settings-title"
+          style={{
+            color: colors.foreground,
+            fontSize: type.size.xl,
+            fontWeight: type.weight.medium,
+          }}
+        >
+          Settings
+        </Text>
+      </View>
+
+      {/* Scrollable Content */}
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={{ paddingBottom: insets.bottom }}
+      >
+        {/* Search Bar */}
+        <View style={{ padding: spacing.lg }}>
+          <View
+            style={[
+              styles.searchBar,
+              {
+                backgroundColor: colors.muted,
+                borderRadius: radius.lg,
+                paddingHorizontal: spacing.lg,
+              },
+            ]}
+          >
+            <Text
+              style={{ color: colors.mutedForeground, marginRight: spacing.md }}
+            >
+              🔍
+            </Text>
+            <TextInput
+              value={search}
+              onChangeText={setSearch}
+              placeholder="Search"
+              placeholderTextColor={colors.mutedForeground}
+              style={[
+                styles.searchInput,
+                {
+                  color: colors.foreground,
+                  fontSize: type.size.md,
+                  paddingVertical: spacing.sm,
+                },
+              ]}
+              accessibilityLabel="Search"
+              accessibilityRole="search"
+            />
+          </View>
+        </View>
+
+        {/* Profile Section */}
+        <View
+          style={[
+            styles.profileSection,
+            { paddingHorizontal: spacing.lg, paddingVertical: spacing.lg },
+          ]}
+        >
+          <View style={styles.profileRow}>
+            <View style={styles.profileInfo}>
+              <Image
+                source={{
+                  uri: 'https://images.unsplash.com/photo-1719257751404-1dea075324bd?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHxwcm9mZXNzaW9uYWwlMjBoZWFkc2hvdCUyMG1hbnxlbnwxfHx8fDE3NTY0NjA5ODd8MA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral',
+                }}
+                style={styles.profileImage}
+                accessibilityLabel="Profile"
+              />
+              <View style={{ marginLeft: spacing.md }}>
+                <Text
+                  style={{
+                    color: colors.foreground,
+                    fontSize: type.size.lg,
+                    fontWeight: type.weight.medium,
+                  }}
+                >
+                  Your Name
+                </Text>
+                <Text
+                  style={{
+                    color: colors.mutedForeground,
+                    fontSize: type.size.sm,
+                  }}
+                >
+                  Hey there! I am using Hum.
+                </Text>
+              </View>
+            </View>
+            <Text
+              style={{ color: colors.mutedForeground, fontSize: type.size.lg }}
+            >
+              🔳
+            </Text>
+          </View>
+        </View>
+
+        {/* Settings Items */}
+        <View style={{ paddingBottom: spacing.xl }}>
+          <SettingsItem
+            icon={<Text>👤</Text>}
+            title="Account"
+            subtitle="Security notifications, change number"
+          />
+          <SettingsItem
+            icon={<Text>🛡️</Text>}
+            title="Privacy"
+            subtitle="Block contacts, disappearing messages"
+          />
+          <SettingsItem
+            icon={<Text>🔔</Text>}
+            title="Notifications"
+            subtitle="Message, group & call tones"
+          />
+          <SettingsItem
+            icon={<Text>📦</Text>}
+            title="Storage and data"
+            subtitle="Network usage, auto-download"
+          />
+          <SettingsItem
+            icon={<Text>❓</Text>}
+            title="Help"
+            subtitle="Help center, contact us, privacy policy"
+          />
+          <View style={{ height: spacing.md }} />
+          <SettingsItem
+            icon={<Text>👥</Text>}
+            title="Linked devices"
+            subtitle="Manage connected devices"
+          />
+          <SettingsItem
+            icon={<Text>🔒</Text>}
+            title="Two-step verification"
+            subtitle="Add extra security to your account"
+          />
+          <SettingsItem
+            icon={<Text>📄</Text>}
+            title="Request account info"
+            subtitle="Request a report of your account information"
+          />
+          <SettingsItem
+            icon={<Text>🌐</Text>}
+            title="App language"
+            subtitle="English (device's language)"
+          />
+          <SettingsItem
+            icon={<Text>🎨</Text>}
+            title="Theme"
+            subtitle="Choose your app theme"
+          />
+          <SettingsItem
+            icon={<Text>🖼️</Text>}
+            title="Wallpaper"
+            subtitle="Change your chat wallpaper"
+          />
+          <SettingsItem
+            icon={<Text>🔊</Text>}
+            title="Sound"
+            subtitle="Ringtone and notification sounds"
+          />
+          <SettingsItem
+            icon={<Text>📧</Text>}
+            title="Invite friends"
+            subtitle="Share Hum with friends and family"
+          />
+          <SettingsItem
+            icon={<Text>🗑️</Text>}
+            title="Delete my account"
+            subtitle="Delete your account and erase your message history"
+          />
+          {/* App Info */}
+          <View
+            style={[
+              styles.appInfo,
+              {
+                marginTop: spacing.xl,
+                paddingTop: spacing.lg,
+                borderTopWidth: StyleSheet.hairlineWidth,
+                borderTopColor: colors.border,
+                paddingHorizontal: spacing.lg,
+              },
+            ]}
+          >
+            <Text
+              style={{ color: colors.mutedForeground, fontSize: type.size.sm }}
+            >
+              Hum for Web
+            </Text>
+            <Text
+              style={{
+                color: colors.mutedForeground,
+                fontSize: type.size.sm,
+                marginTop: spacing.xs,
+              }}
+            >
+              Version 1.0.0
+            </Text>
+            <Text
+              style={{
+                color: colors.mutedForeground,
+                fontSize: type.size.sm,
+                marginTop: spacing.xs,
+              }}
+            >
+              © 2024 Hum Technologies
+            </Text>
+            <Text
+              style={{
+                color: colors.mutedForeground,
+                fontSize: type.size.sm,
+                marginTop: spacing.xs,
+              }}
+            >
+              Build 2024.08.29
+            </Text>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backButton: {
+    position: 'absolute',
+  },
+  scroll: {
+    flex: 1,
+  },
+  searchBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  searchInput: {
+    flex: 1,
+  },
+  profileRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  profileInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  profileSection: {},
+  profileImage: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+  },
+  appInfo: {
+    alignItems: 'center',
+  },
+});
+
+export default SettingsScreen;

--- a/packages/ui-screens/src/__snapshots__/SettingsScreen.test.tsx.snap
+++ b/packages/ui-screens/src/__snapshots__/SettingsScreen.test.tsx.snap
@@ -1,0 +1,1627 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`SettingsScreen renders and matches snapshot 1`] = `
+<div
+  className="css-view-g5y9jx r-flex-13awgt0"
+  dir={null}
+  ref={[Function]}
+  style={
+    {
+      "backgroundColor": "rgba(255,255,255,1.00)",
+      "paddingTop": "0px",
+    }
+  }
+>
+  <div
+    className="css-view-g5y9jx r-alignItems-1awozwy r-justifyContent-1777fci"
+    dir={null}
+    ref={[Function]}
+    style={
+      {
+        "borderBottomColor": "rgba(0,0,0,0.10)",
+        "borderBottomWidth": "1px",
+        "paddingBottom": "16px",
+        "paddingTop": "16px",
+      }
+    }
+  >
+    <div
+      className="css-text-146c3p1"
+      data-testid="settings-title"
+      dir="auto"
+      ref={[Function]}
+      style={
+        {
+          "color": "rgba(10,10,10,1.00)",
+          "fontSize": "20px",
+          "fontWeight": "500",
+        }
+      }
+    >
+      Settings
+    </div>
+  </div>
+  <div
+    className="css-view-g5y9jx r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-agouwx r-flex-13awgt0"
+    dir={null}
+    onScroll={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    onWheel={[Function]}
+    ref={[Function]}
+  >
+    <div
+      className="css-view-g5y9jx"
+      dir={null}
+      ref={[Function]}
+      style={
+        {
+          "paddingBottom": "0px",
+        }
+      }
+    >
+      <div
+        className="css-view-g5y9jx"
+        dir={null}
+        ref={[Function]}
+        style={
+          {
+            "paddingBottom": "16px",
+            "paddingLeft": "16px",
+            "paddingRight": "16px",
+            "paddingTop": "16px",
+          }
+        }
+      >
+        <div
+          className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+          dir={null}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(236,236,240,1.00)",
+              "borderBottomLeftRadius": "12px",
+              "borderBottomRightRadius": "12px",
+              "borderTopLeftRadius": "12px",
+              "borderTopRightRadius": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+            }
+          }
+        >
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "marginRight": "12px",
+              }
+            }
+          >
+            🔍
+          </div>
+          <input
+            aria-label="Search"
+            autoCapitalize="sentences"
+            autoComplete="on"
+            autoCorrect="on"
+            className="css-textinput-11aywtz r-placeholderTextColor-6taxm2 r-flex-13awgt0"
+            dir="auto"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onSelect={[Function]}
+            placeholder="Search"
+            readOnly={false}
+            ref={[Function]}
+            role="search"
+            rows={1}
+            spellCheck={true}
+            style={
+              {
+                "--placeholderTextColor": "#717182",
+                "color": "rgba(10,10,10,1.00)",
+                "fontSize": "16px",
+                "paddingBottom": "8px",
+                "paddingTop": "8px",
+              }
+            }
+            value=""
+            virtualkeyboardpolicy="auto"
+          />
+        </div>
+      </div>
+      <div
+        className="css-view-g5y9jx"
+        dir={null}
+        ref={[Function]}
+        style={
+          {
+            "paddingBottom": "16px",
+            "paddingLeft": "16px",
+            "paddingRight": "16px",
+            "paddingTop": "16px",
+          }
+        }
+      >
+        <div
+          className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          ref={[Function]}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              aria-label="Profile"
+              className="css-view-g5y9jx r-flexBasis-1mlwlqe r-overflow-1udh08x r-zIndex-417010 r-borderRadius-nsiyw1 r-height-sga3zk r-width-7a29px"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-view-g5y9jx r-backgroundColor-1niwhzg r-backgroundPosition-vvn4in r-backgroundRepeat-u6sd8q r-bottom-1p0dtai r-height-1pi2tsx r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-width-13qz1uu r-zIndex-1wyyakw r-backgroundSize-4gszlv"
+                dir={null}
+                ref={[Function]}
+                style={
+                  {
+                    "backgroundImage": "url("https://images.unsplash.com/photo-1719257751404-1dea075324bd?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHxwcm9mZXNzaW9uYWwlMjBoZWFkc2hvdCUyMG1hbnxlbnwxfHx8fDE3NTY0NjA5ODd8MA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral")",
+                  }
+                }
+                suppressHydrationWarning={true}
+              />
+              <img
+                alt="Profile"
+                className="css-accessibilityImage-9pa8cd"
+                draggable={false}
+                ref={
+                  {
+                    "current": null,
+                  }
+                }
+                src="https://images.unsplash.com/photo-1719257751404-1dea075324bd?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHxwcm9mZXNzaW9uYWwlMjBoZWFkc2hvdCUyMG1hbnxlbnwxfHx8fDE3NTY0NjA5ODd8MA&ixlib=rb-4.1.0&q=80&w=1080&utm_source=figma&utm_medium=referral"
+              />
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginLeft": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "18px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Your Name
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Hey there! I am using Hum.
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            🔳
+          </div>
+        </div>
+      </div>
+      <div
+        className="css-view-g5y9jx"
+        dir={null}
+        ref={[Function]}
+        style={
+          {
+            "paddingBottom": "24px",
+          }
+        }
+      >
+        <div
+          aria-label="Account"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                👤
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Account
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Security notifications, change number
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Privacy"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                🛡️
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Privacy
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Block contacts, disappearing messages
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Notifications"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                🔔
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Notifications
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Message, group & call tones
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Storage and data"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                📦
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Storage and data
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Network usage, auto-download
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Help"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                ❓
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Help
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Help center, contact us, privacy policy
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          className="css-view-g5y9jx"
+          dir={null}
+          ref={[Function]}
+          style={
+            {
+              "height": "12px",
+            }
+          }
+        />
+        <div
+          aria-label="Linked devices"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                👥
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Linked devices
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Manage connected devices
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Two-step verification"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                🔒
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Two-step verification
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Add extra security to your account
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Request account info"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                📄
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Request account info
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Request a report of your account information
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="App language"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                🌐
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                App language
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                English (device's language)
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Theme"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                🎨
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Theme
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Choose your app theme
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Wallpaper"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                🖼️
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Wallpaper
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Change your chat wallpaper
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Sound"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                🔊
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Sound
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Ringtone and notification sounds
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Invite friends"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                📧
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Invite friends
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Share Hum with friends and family
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          aria-label="Delete my account"
+          className="css-view-g5y9jx r-cursor-1loqt21 r-touchAction-1otgn73 r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
+          dir={null}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          ref={[Function]}
+          style={
+            {
+              "backgroundColor": "rgba(0,0,0,0.00)",
+              "paddingBottom": "12px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "12px",
+            }
+          }
+          tabIndex={0}
+        >
+          <div
+            className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz"
+            dir={null}
+            ref={[Function]}
+          >
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+              style={
+                {
+                  "marginRight": "12px",
+                }
+              }
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+              >
+                🗑️
+              </div>
+            </div>
+            <div
+              className="css-view-g5y9jx"
+              dir={null}
+              ref={[Function]}
+            >
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(10,10,10,1.00)",
+                    "fontSize": "16px",
+                    "fontWeight": "500",
+                  }
+                }
+              >
+                Delete my account
+              </div>
+              <div
+                className="css-text-146c3p1"
+                dir="auto"
+                ref={[Function]}
+                style={
+                  {
+                    "color": "rgba(113,113,130,1.00)",
+                    "fontSize": "12px",
+                  }
+                }
+              >
+                Delete your account and erase your message history
+              </div>
+            </div>
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "18px",
+              }
+            }
+          >
+            ›
+          </div>
+        </div>
+        <div
+          className="css-view-g5y9jx r-alignItems-1awozwy"
+          dir={null}
+          ref={[Function]}
+          style={
+            {
+              "borderTopColor": "rgba(0,0,0,0.10)",
+              "borderTopWidth": "1px",
+              "marginTop": "24px",
+              "paddingLeft": "16px",
+              "paddingRight": "16px",
+              "paddingTop": "16px",
+            }
+          }
+        >
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "12px",
+              }
+            }
+          >
+            Hum for Web
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "12px",
+                "marginTop": "4px",
+              }
+            }
+          >
+            Version 1.0.0
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "12px",
+                "marginTop": "4px",
+              }
+            }
+          >
+            © 2024 Hum Technologies
+          </div>
+          <div
+            className="css-text-146c3p1"
+            dir="auto"
+            ref={[Function]}
+            style={
+              {
+                "color": "rgba(113,113,130,1.00)",
+                "fontSize": "12px",
+                "marginTop": "4px",
+              }
+            }
+          >
+            Build 2024.08.29
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Summary
- add SettingsScreen with search, profile, and navigable list
- create reusable SettingsItem component
- document and test new screen and component

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm storybook:build`
- `pnpm storybook:start` *(fails: xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b35790c434832f94685005bb5156bb