### PR TITLE
Add mobile build and binding scripts

### DIFF
--- a/native/rust/scripts/build-android.sh
+++ b/native/rust/scripts/build-android.sh
@@ -5,19 +5,21 @@ cd "$(dirname "$0")/.."
 
 usage() {
   cat <<'USAGE'
-Usage: build-android.sh --out <dir> [--release]
+Usage: build-android.sh --out <dir> [--release] [--package <name>]
 
 Build Android shared libraries (.so) and an AAR using cargo-ndk.
 
 Options:
   --out <dir>     Output directory for generated artifacts
   --release       Build in release mode
+  --package <name>  Package name for Android manifest (default: com.example.ffi)
   -h, --help      Show this help message and exit
 USAGE
 }
 
 out=""
 release=""
+package="com.example.ffi"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -28,6 +30,10 @@ while [[ $# -gt 0 ]]; do
     --release)
       release="--release"
       shift
+      ;;
+    --package)
+      package="$2"
+      shift 2
       ;;
     -h|--help)
       usage
@@ -64,7 +70,7 @@ cargo ndk "${args[@]}" build $release
 
 tmpdir="$(mktemp -d)"
 manifest="$tmpdir/AndroidManifest.xml"
-printf '<manifest package="com.example.ffi" />\n' > "$manifest"
+printf '<manifest package="%s" />\n' "$package" > "$manifest"
 mkdir -p "$tmpdir/empty"
 jar cf "$tmpdir/classes.jar" -C "$tmpdir/empty" .
 cp -r "$out/jniLibs" "$tmpdir/"

--- a/native/rust/scripts/build-android.sh
+++ b/native/rust/scripts/build-android.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+  cat <<'USAGE'
+Usage: build-android.sh --out <dir> [--release]
+
+Build Android shared libraries (.so) and an AAR using cargo-ndk.
+
+Options:
+  --out <dir>     Output directory for generated artifacts
+  --release       Build in release mode
+  -h, --help      Show this help message and exit
+USAGE
+}
+
+out=""
+release=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      out="$2"
+      shift 2
+      ;;
+    --release)
+      release="--release"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$out" ]]; then
+  echo "Missing required --out argument" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! command -v jar >/dev/null 2>&1; then
+  echo "jar command not found" >&2
+  exit 1
+fi
+
+mkdir -p "$out"
+
+ndk_targets=(arm64-v8a armeabi-v7a x86_64)
+args=(-o "$out/jniLibs")
+for t in "${ndk_targets[@]}"; do
+  args+=( -t "$t" )
+done
+
+cargo ndk "${args[@]}" build $release
+
+tmpdir="$(mktemp -d)"
+manifest="$tmpdir/AndroidManifest.xml"
+printf '<manifest package="com.example.ffi" />\n' > "$manifest"
+mkdir -p "$tmpdir/empty"
+jar cf "$tmpdir/classes.jar" -C "$tmpdir/empty" .
+cp -r "$out/jniLibs" "$tmpdir/"
+(cd "$tmpdir" && jar cf "$out/ffi.aar" AndroidManifest.xml classes.jar jniLibs)
+rm -rf "$tmpdir"

--- a/native/rust/scripts/build-ios.sh
+++ b/native/rust/scripts/build-ios.sh
@@ -59,7 +59,7 @@ profile="debug"
 
 package="ffi"
 
-targets=(aarch64-apple-ios aarch64-apple-ios-sim)
+targets=(aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios-sim)
 for t in "${targets[@]}"; do
   cargo build -p "$package" --target "$t" $release
 done

--- a/native/rust/scripts/build-ios.sh
+++ b/native/rust/scripts/build-ios.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+  cat <<'USAGE'
+Usage: build-ios.sh --out <dir> [--release]
+
+Build an iOS xcframework and Swift Package Manager bundle.
+
+Options:
+  --out <dir>     Output directory for generated artifacts
+  --release       Build in release mode
+  -h, --help      Show this help message and exit
+USAGE
+}
+
+out=""
+release=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      out="$2"
+      shift 2
+      ;;
+    --release)
+      release="--release"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$out" ]]; then
+  echo "Missing required --out argument" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! command -v xcodebuild >/dev/null 2>&1; then
+  echo "xcodebuild is required" >&2
+  exit 1
+fi
+
+mkdir -p "$out"
+
+profile="debug"
+[[ -n "$release" ]] && profile="release"
+
+package="ffi"
+
+targets=(aarch64-apple-ios aarch64-apple-ios-sim)
+for t in "${targets[@]}"; do
+  cargo build -p "$package" --target "$t" $release
+done
+
+libs=()
+for t in "${targets[@]}"; do
+  libs+=( -library "target/$t/$profile/lib${package}.a" )
+done
+
+xcodebuild -create-xcframework "${libs[@]}" -output "$out/${package}.xcframework"
+
+spm_dir="$out/${package}Package"
+mkdir -p "$spm_dir"
+cat > "$spm_dir/Package.swift" <<SWIFT
+// swift-tools-version:5.7
+import PackageDescription
+let package = Package(
+    name: "$package",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(name: "$package", targets: ["$package"])
+    ],
+    targets: [
+        .binaryTarget(name: "$package", path: "../${package}.xcframework")
+    ]
+)
+SWIFT

--- a/native/rust/scripts/gen-bindings.sh
+++ b/native/rust/scripts/gen-bindings.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+  cat <<'USAGE'
+Usage: gen-bindings.sh --udl <file> --out <dir>
+
+Generate Swift and Kotlin bindings using UniFFI.
+
+Options:
+  --udl <file>    Path to the UniFFI UDL file
+  --out <dir>     Output directory for generated bindings
+  -h, --help      Show this help message and exit
+USAGE
+}
+
+udl=""
+out=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --udl)
+      udl="$2"
+      shift 2
+      ;;
+    --out)
+      out="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$udl" || -z "$out" ]]; then
+  echo "Both --udl and --out are required" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! command -v uniffi-bindgen >/dev/null 2>&1; then
+  echo "uniffi-bindgen not found" >&2
+  exit 1
+fi
+
+mkdir -p "$out/swift" "$out/kotlin"
+
+uniffi-bindgen generate "$udl" --language swift --out-dir "$out/swift"
+uniffi-bindgen generate "$udl" --language kotlin --out-dir "$out/kotlin"


### PR DESCRIPTION
## Summary
- add build-android.sh to compile Android libraries and package an AAR
- add build-ios.sh to produce an xcframework and Swift Package bundle
- add gen-bindings.sh to generate Swift/Kotlin bindings via UniFFI

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b42b5be49c832fb356120447d6f3e4