### PR TITLE
feat: wire FFI client to core runtime

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -1210,6 +1210,9 @@ name = "hum-matrix-ffi"
 version = "0.1.0"
 dependencies = [
  "hum-matrix-core",
+ "tempfile",
+ "thiserror",
+ "tokio",
  "uniffi",
  "uniffi_build",
 ]

--- a/native/rust/crates/ffi/Cargo.toml
+++ b/native/rust/crates/ffi/Cargo.toml
@@ -9,6 +9,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 uniffi = "0.24.3"
 hum-matrix-core = { path = "../core" }
+tokio = { version = "1", features = ["rt-multi-thread"] }
+thiserror = "1"
 
 [build-dependencies]
 uniffi_build = "0.24.3"
+
+[dev-dependencies]
+tempfile = "3"

--- a/native/rust/crates/ffi/src/hum.udl
+++ b/native/rust/crates/ffi/src/hum.udl
@@ -1,9 +1,18 @@
+[Error]
+enum FfiError {
+    "Other",
+};
+
 interface Client {
+    [Throws=FfiError]
     void login(string username, string password);
+    [Throws=FfiError]
     void start_sync(boolean sliding);
+    [Throws=FfiError]
     void send_text(string room_id, string body);
 };
 
 namespace hum {
+    [Throws=FfiError]
     Client init(string hs_url, string store_path);
 };

--- a/native/rust/crates/ffi/src/lib.rs
+++ b/native/rust/crates/ffi/src/lib.rs
@@ -1,28 +1,69 @@
-#![allow(clippy::empty_line_after_doc_comments)]
+#![allow(clippy::empty_line_after_doc_comments, clippy::useless_conversion)]
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
+
+use hum_matrix_core::{client::HumClient, config::ClientConfig, error::HumError};
 
 uniffi::include_scaffolding!("hum");
 
-pub struct Client;
+/// Errors that can occur when using the FFI client.
+#[derive(Debug, thiserror::Error)]
+pub enum FfiError {
+    /// Any other error.
+    #[error("{msg}")]
+    Other { msg: String },
+}
+
+impl From<HumError> for FfiError {
+    fn from(err: HumError) -> Self {
+        FfiError::Other {
+            msg: err.to_string(),
+        }
+    }
+}
+
+type Result<T, E = FfiError> = std::result::Result<T, E>;
+
+/// FFI client holding a Matrix client and its runtime.
+pub struct Client {
+    /// Underlying [`HumClient`].
+    inner: HumClient,
+    /// Tokio runtime used for async operations. Declared last so it drops last.
+    runtime: tokio::runtime::Runtime,
+}
 
 #[uniffi::export]
-pub fn init(hs_url: String, store_path: String) -> Arc<Client> {
-    let _ = (hs_url, store_path);
-    Arc::new(Client)
+pub fn init(hs_url: String, store_path: String) -> Result<Arc<Client>> {
+    let runtime =
+        tokio::runtime::Runtime::new().map_err(|e| FfiError::Other { msg: e.to_string() })?;
+    let cfg = ClientConfig::new(hs_url, PathBuf::from(store_path));
+    let client = runtime.block_on(HumClient::new(cfg))?;
+    Ok(Arc::new(Client {
+        inner: client,
+        runtime,
+    }))
 }
 
 #[uniffi::export]
 impl Client {
-    pub fn login(&self, username: String, password: String) {
-        let _ = (username, password);
+    /// Log in with a username and password.
+    pub fn login(&self, username: String, password: String) -> Result<()> {
+        self.runtime
+            .block_on(self.inner.login(&username, &password))
+            .map_err(Into::into)
     }
 
-    pub fn start_sync(&self, sliding: bool) {
-        let _ = sliding;
+    /// Start the sync loop.
+    pub fn start_sync(&self, sliding: bool) -> Result<()> {
+        self.runtime
+            .block_on(self.inner.start_sync(sliding))
+            .map_err(Into::into)
     }
 
-    pub fn send_text(&self, room_id: String, body: String) {
-        let _ = (room_id, body);
+    /// Send a text message to a room.
+    pub fn send_text(&self, room_id: String, body: String) -> Result<()> {
+        self.runtime
+            .block_on(self.inner.send_text_message(&room_id, &body))
+            .map_err(Into::into)
     }
 }

--- a/native/rust/crates/ffi/tests/client_smoke.rs
+++ b/native/rust/crates/ffi/tests/client_smoke.rs
@@ -1,9 +1,14 @@
 use hum_matrix_ffi::init;
+use tempfile::tempdir;
 
 #[test]
 fn client_smoke() {
-    let client = init("https://matrix.org".into(), "/tmp".into());
-    client.login("user".into(), "pass".into());
-    client.start_sync(false);
-    client.send_text("!room:server".into(), "hi".into());
+    let dir = tempdir().unwrap();
+    let store = dir.path().to_str().unwrap().to_string();
+    let client = init("https://matrix.org".into(), store).unwrap();
+    client.login("user".into(), "pass".into()).unwrap();
+    client.start_sync(false).unwrap();
+    client
+        .send_text("!room:server".into(), "hi".into())
+        .unwrap();
 }


### PR DESCRIPTION
## Summary
- attach tokio runtime and HumClient in FFI Client
- expose init/login/sync/send_text via real core calls and error type
- add smoke test covering init -> login -> sync

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b474415498832fa37af6cc5c91062e