### PR TITLE
refactor: reorganize UI package structure

### DIFF
--- a/apps/storybook/storybook/stories/BottomNavigation.stories.tsx
+++ b/apps/storybook/storybook/stories/BottomNavigation.stories.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { BottomNavigation, type BottomNavigationProps } from '@hum/ui-screens';
+import {
+  BottomNavigation,
+  type BottomNavigationProps,
+} from '@hum/ui-components';
 
 const Wrapper: React.FC<BottomNavigationProps> = (props) => {
   const [active, setActive] = React.useState(props.activeTab);
@@ -11,7 +14,7 @@ const Wrapper: React.FC<BottomNavigationProps> = (props) => {
 };
 
 const meta: Meta<typeof Wrapper> = {
-  title: 'Screens/BottomNavigation',
+  title: 'Components/BottomNavigation',
   component: Wrapper,
   decorators: [
     (Story) => (

--- a/apps/storybook/storybook/stories/ChatItem.stories.tsx
+++ b/apps/storybook/storybook/stories/ChatItem.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ChatItem } from '@hum/ui-screens';
+import { ChatItem } from '@hum/ui-components';
 
 type Story = StoryObj<typeof ChatItem>;
 
 const meta: Meta<typeof ChatItem> = {
-  title: 'Screens/ChatItem',
+  title: 'Components/ChatItem',
   component: ChatItem,
   argTypes: {
     onPress: { action: 'pressed' },

--- a/apps/storybook/storybook/stories/ChatScreen.stories.tsx
+++ b/apps/storybook/storybook/stories/ChatScreen.stories.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { ChatView } from '@hum/ui-screens';
+import { ChatScreen } from '@hum/ui-screens';
 
-const meta: Meta<typeof ChatView> = {
-  title: 'Screens/ChatView',
-  component: ChatView,
+const meta: Meta<typeof ChatScreen> = {
+  title: 'Screens/ChatScreen',
+  component: ChatScreen,
   decorators: [
     (Story) => (
       <SafeAreaProvider>
@@ -23,7 +23,7 @@ const meta: Meta<typeof ChatView> = {
 };
 export default meta;
 
-type Story = StoryObj<typeof ChatView>;
+type Story = StoryObj<typeof ChatScreen>;
 
 export const Basic: Story = {};
 export const Empty: Story = {

--- a/apps/storybook/storybook/stories/TopBar.stories.tsx
+++ b/apps/storybook/storybook/stories/TopBar.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { TopBar, type TopBarProps } from '@hum/ui-screens';
+import { TopBar, type TopBarProps } from '@hum/ui-components';
 
 const meta: Meta<typeof TopBar> = {
-  title: 'Screens/TopBar',
+  title: 'Components/TopBar',
   component: TopBar,
   decorators: [
     (Story) => (

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -44,5 +44,12 @@ export { FeatureCard } from './src/feature-card';
 export type { FeatureCardProps } from './src/feature-card';
 export { SettingsItem } from './src/settings-item';
 export type { SettingsItemProps } from './src/settings-item';
+export { BottomNavigation } from './src/BottomNavigation';
+export type { BottomNavigationProps } from './src/BottomNavigation';
+export { ChatItem } from './src/ChatItem';
+export type { ChatItemProps } from './src/ChatItem';
+export { TopBar } from './src/TopBar';
+export type { TopBarProps } from './src/TopBar';
+
 export { Icon } from './src/theme/Icon';
 export type { IconName, IconProps } from './src/theme/Icon';

--- a/packages/ui-components/src/BottomNavigation.test.tsx
+++ b/packages/ui-components/src/BottomNavigation.test.tsx
@@ -5,8 +5,8 @@ import {
   BottomNavigation,
   type BottomNavigationProps,
 } from './BottomNavigation';
-import { ThemeProvider } from '@hum/ui-components/theme/ThemeProvider';
-import { colors } from '../../ui-components/src/theme/colors';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { colors } from './theme/colors';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
@@ -29,7 +29,7 @@ function renderNav(
   );
 }
 
-describe('BottomNavigation Screen', () => {
+describe('BottomNavigation Component', () => {
   it('renders and matches snapshot', () => {
     const { asFragment } = renderNav();
     expect(asFragment()).toMatchSnapshot();

--- a/packages/ui-components/src/BottomNavigation.tsx
+++ b/packages/ui-components/src/BottomNavigation.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { BottomNavItem, Icon, useTheme } from '@hum/ui-components';
+import { BottomNavItem } from './bottom-navigation-item';
+import { Icon } from './theme/Icon';
+import { useTheme } from './theme/ThemeProvider';
 
 export interface BottomNavigationProps {
   activeTab?: string;

--- a/packages/ui-components/src/ChatItem.test.tsx
+++ b/packages/ui-components/src/ChatItem.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ChatItem, type ChatItemProps } from './ChatItem';
-import { ThemeProvider } from '../../ui-components/src/theme/ThemeProvider';
+import { ThemeProvider } from './theme/ThemeProvider';
 
 type Scheme = 'light' | 'dark';
 
@@ -24,7 +24,7 @@ function renderChatItem(
   );
 }
 
-describe('ChatItem Screen', () => {
+describe('ChatItem Component', () => {
   it('renders and matches snapshot', () => {
     const { asFragment } = renderChatItem();
     expect(asFragment()).toMatchSnapshot();

--- a/packages/ui-components/src/ChatItem.tsx
+++ b/packages/ui-components/src/ChatItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
-import { Avatar, AvatarImage } from '../../ui-components/src/avatar';
-import { useTheme } from '../../ui-components/src/theme/ThemeProvider';
+import { Avatar, AvatarImage } from './avatar';
+import { useTheme } from './theme/ThemeProvider';
 
 export interface ChatItemProps {
   name: string;

--- a/packages/ui-components/src/TopBar.test.tsx
+++ b/packages/ui-components/src/TopBar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import '@testing-library/jest-native/extend-expect';
-import { ThemeProvider } from '@hum/ui-components/theme/ThemeProvider';
+import { ThemeProvider } from './theme/ThemeProvider';
 import { TopBar, type TopBarProps } from './TopBar';
 
 jest.mock('react-native-safe-area-context', () => ({
@@ -24,7 +24,7 @@ function renderTopBar(scheme: Scheme = 'light', props?: Partial<TopBarProps>) {
   );
 }
 
-describe('TopBar Screen', () => {
+describe('TopBar Component', () => {
   it('renders and matches snapshot', () => {
     const { toJSON } = renderTopBar();
     expect(toJSON()).toMatchSnapshot();

--- a/packages/ui-components/src/TopBar.tsx
+++ b/packages/ui-components/src/TopBar.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Button, useTheme, Icon } from '@hum/ui-components';
+import { Button } from './button';
+import { useTheme } from './theme/ThemeProvider';
+import { Icon } from './theme/Icon';
 
 export interface TopBarProps {
   onMenuPress?: () => void;

--- a/packages/ui-components/src/__snapshots__/BottomNavigation.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/BottomNavigation.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`BottomNavigation Screen renders and matches snapshot 1`] = `
+exports[`BottomNavigation Component renders and matches snapshot 1`] = `
 <DocumentFragment>
   <div
     class="css-view-g5y9jx r-borderTopWidth-5kkj8d r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj"

--- a/packages/ui-components/src/__snapshots__/ChatItem.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/ChatItem.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ChatItem Screen renders and matches snapshot 1`] = `
+exports[`ChatItem Component renders and matches snapshot 1`] = `
 <DocumentFragment>
   <div
     aria-label="Chat with Alice"

--- a/packages/ui-components/src/__snapshots__/TopBar.test.tsx.snap
+++ b/packages/ui-components/src/__snapshots__/TopBar.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`TopBar Screen renders and matches snapshot 1`] = `
+exports[`TopBar Component renders and matches snapshot 1`] = `
 <div
   className="css-view-g5y9jx r-alignItems-1awozwy r-flexDirection-18u37iz r-justifyContent-1wtj0ep"
   dir={null}

--- a/packages/ui-screens/index.ts
+++ b/packages/ui-screens/index.ts
@@ -1,10 +1,5 @@
 export { DummyScreen } from './src/DummyScreen';
-export { ChatItem } from './src/ChatItem';
-export { ChatView } from './src/ChatView';
-export { BottomNavigation } from './src/BottomNavigation';
-export type { BottomNavigationProps } from './src/BottomNavigation';
-export { TopBar } from './src/TopBar';
-export type { TopBarProps } from './src/TopBar';
+export { ChatScreen } from './src/ChatScreen';
 export { ChatsScreen } from './src/ChatsScreen';
 export type { ChatsScreenProps, Chat } from './src/ChatsScreen';
 export { mockChats } from './src/ChatsScreen';

--- a/packages/ui-screens/src/ChatScreen.test.tsx
+++ b/packages/ui-screens/src/ChatScreen.test.tsx
@@ -8,12 +8,12 @@ jest.mock('react-native-safe-area-context', () => ({
 const SafeAreaProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => <>{children}</>;
-import { ChatView, type ChatViewProps } from './ChatView';
+import { ChatScreen, type ChatScreenProps } from './ChatScreen';
 import { ThemeProvider } from '@hum/ui-components/theme/ThemeProvider';
 
 type Scheme = 'light' | 'dark';
 
-const baseProps: ChatViewProps = {
+const baseProps: ChatScreenProps = {
   chatName: 'Alice',
   chatAvatar: 'https://example.com/avatar.png',
   onBack: jest.fn(),
@@ -22,48 +22,48 @@ const baseProps: ChatViewProps = {
   ],
 };
 
-function renderChatView(
+function renderChatScreen(
   scheme: Scheme = 'light',
-  props?: Partial<ChatViewProps>,
+  props?: Partial<ChatScreenProps>,
 ) {
   return render(
     <SafeAreaProvider>
       <ThemeProvider forcedScheme={scheme}>
-        <ChatView {...baseProps} {...props} />
+        <ChatScreen {...baseProps} {...props} />
       </ThemeProvider>
     </SafeAreaProvider>,
   );
 }
 
-describe('ChatView Screen', () => {
+describe('ChatScreen Screen', () => {
   it('renders and matches snapshot', () => {
-    const { asFragment } = renderChatView();
+    const { asFragment } = renderChatScreen();
     expect(asFragment()).toMatchSnapshot();
   });
 
   it('calls onBack when back pressed', () => {
     const onBack = jest.fn();
-    const { getByLabelText } = renderChatView('light', { onBack });
+    const { getByLabelText } = renderChatScreen('light', { onBack });
     fireEvent.click(getByLabelText('Go back'));
     expect(onBack).toHaveBeenCalled();
   });
 
   it('allows typing in input', () => {
-    const { getByLabelText } = renderChatView();
+    const { getByLabelText } = renderChatScreen();
     const input = getByLabelText('Message input');
     fireEvent.change(input, { target: { value: 'Hi' } });
     expect((input as unknown as { value: string }).value).toBe('Hi');
   });
 
   it('applies theme colors', () => {
-    const { getByLabelText, rerender } = renderChatView('light');
+    const { getByLabelText, rerender } = renderChatScreen('light');
     expect(getByLabelText('Outgoing message')).toHaveStyle({
       backgroundColor: 'rgba(254,202,26,1.00)',
     });
     rerender(
       <SafeAreaProvider>
         <ThemeProvider forcedScheme="dark">
-          <ChatView {...baseProps} />
+          <ChatScreen {...baseProps} />
         </ThemeProvider>
       </SafeAreaProvider>,
     );

--- a/packages/ui-screens/src/ChatScreen.tsx
+++ b/packages/ui-screens/src/ChatScreen.tsx
@@ -46,14 +46,14 @@ const mockMessages: ChatMessage[] = [
   },
 ];
 
-export interface ChatViewProps {
+export interface ChatScreenProps {
   chatName: string;
   chatAvatar: string;
   onBack: () => void;
   messages?: ChatMessage[];
 }
 
-export const ChatView: React.FC<ChatViewProps> = ({
+export const ChatScreen: React.FC<ChatScreenProps> = ({
   chatName,
   chatAvatar,
   onBack,
@@ -252,4 +252,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default ChatView;
+export default ChatScreen;

--- a/packages/ui-screens/src/ChatsScreen.tsx
+++ b/packages/ui-screens/src/ChatsScreen.tsx
@@ -7,9 +7,9 @@ import {
   Button,
   ListRow,
   Icon,
+  TopBar,
+  ChatItem,
 } from '@hum/ui-components';
-import { TopBar } from './TopBar';
-import { ChatItem } from './ChatItem';
 
 export interface Chat {
   id: string;

--- a/packages/ui-screens/src/__snapshots__/ChatScreen.test.tsx.snap
+++ b/packages/ui-screens/src/__snapshots__/ChatScreen.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`ChatView Screen renders and matches snapshot 1`] = `
+exports[`ChatScreen Screen renders and matches snapshot 1`] = `
 <DocumentFragment>
   <div
     class="css-view-g5y9jx r-flex-13awgt0"


### PR DESCRIPTION
## Summary
- move shared components into ui-components package
- rename ChatView to ChatScreen and update exports
- fix Storybook stories and imports after refactor

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm storybook:build`


------
https://chatgpt.com/codex/tasks/task_e_68b480843cc0832f9dccb038fa318f83