### PR TITLE
Add gated Matrix e2e tests

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -1222,7 +1222,9 @@ dependencies = [
 name = "hum-tests"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "hum-matrix-core",
+ "matrix-sdk",
  "tempfile",
  "tokio",
 ]

--- a/native/rust/tests/Cargo.toml
+++ b/native/rust/tests/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dev-dependencies]
+anyhow = "1"
 hum-matrix-core = { path = "../crates/core" }
+matrix-sdk = { git = "https://github.com/matrix-org/matrix-rust-sdk", tag = "0.7.0", default-features = false, features = ["e2e-encryption", "bundled-sqlite", "experimental-sliding-sync", "native-tls"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/native/rust/tests/tests/e2e_login_sync.rs
+++ b/native/rust/tests/tests/e2e_login_sync.rs
@@ -1,0 +1,39 @@
+use std::env;
+
+use anyhow::Result;
+use matrix_sdk::{Client, config::SyncSettings};
+use tempfile::tempdir;
+
+#[tokio::test]
+#[ignore]
+async fn e2e_login_sync() -> Result<()> {
+    let username = match env::var("MATRIX_USERNAME") {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    let password = match env::var("MATRIX_PASSWORD") {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    let homeserver =
+        env::var("MATRIX_HOMESERVER").unwrap_or_else(|_| "https://matrix.org".to_owned());
+
+    let dir = tempdir()?;
+    let client = Client::builder()
+        .homeserver_url(homeserver)
+        .sqlite_store(dir.path(), None)
+        .build()
+        .await?;
+
+    client
+        .matrix_auth()
+        .login_username(&username, &password)
+        .initial_device_display_name("hum-tests")
+        .send()
+        .await?;
+    assert!(client.session().is_some());
+
+    client.sync_once(SyncSettings::default()).await?;
+
+    Ok(())
+}

--- a/native/rust/tests/tests/e2e_send_message.rs
+++ b/native/rust/tests/tests/e2e_send_message.rs
@@ -1,0 +1,54 @@
+use std::env;
+
+use anyhow::{Result, anyhow};
+use matrix_sdk::{
+    Client,
+    config::SyncSettings,
+    ruma::{OwnedRoomId, events::room::message::RoomMessageEventContent},
+};
+use tempfile::tempdir;
+
+#[tokio::test]
+#[ignore]
+async fn e2e_send_message() -> Result<()> {
+    let username = match env::var("MATRIX_USERNAME") {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    let password = match env::var("MATRIX_PASSWORD") {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    let room_id_str = match env::var("MATRIX_ROOM") {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    let homeserver =
+        env::var("MATRIX_HOMESERVER").unwrap_or_else(|_| "https://matrix.org".to_owned());
+
+    let dir = tempdir()?;
+    let client = Client::builder()
+        .homeserver_url(homeserver)
+        .sqlite_store(dir.path(), None)
+        .build()
+        .await?;
+
+    client
+        .matrix_auth()
+        .login_username(&username, &password)
+        .initial_device_display_name("hum-tests")
+        .send()
+        .await?;
+    client.sync_once(SyncSettings::default()).await?;
+
+    let room_id: OwnedRoomId = room_id_str.parse()?;
+    let room = client
+        .get_room(&room_id)
+        .ok_or_else(|| anyhow!("Room not found"))?;
+
+    let content = RoomMessageEventContent::text_plain("hello from hum tests");
+    let response = room.send(content).await?;
+    assert!(!response.event_id.as_str().is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add dev dependency on matrix-sdk and anyhow for tests crate
- add ignored e2e tests for Matrix login, sync, and message sending

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test -p hum-tests -- --ignored`

------
https://chatgpt.com/codex/tasks/task_e_68b494d924e4832f9ce7c5570ef11094