### PR TITLE
feat: support verifying current device

### DIFF
--- a/native/rust/Cargo.lock
+++ b/native/rust/Cargo.lock
@@ -1187,6 +1187,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 name = "hum-cli"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "hum-matrix-core",
  "tokio",
 ]

--- a/native/rust/crates/core/src/lib.rs
+++ b/native/rust/crates/core/src/lib.rs
@@ -10,6 +10,8 @@ pub mod config;
 pub mod error;
 pub mod messaging;
 pub mod sync;
+pub mod verification;
 
 pub use client::HumClient;
 pub use error::{HumError, Result};
+pub use matrix_sdk::encryption::verification::{SasState, SasVerification};

--- a/native/rust/crates/core/src/verification.rs
+++ b/native/rust/crates/core/src/verification.rs
@@ -1,0 +1,37 @@
+//! Device verification helpers for the Hum client.
+
+use matrix_sdk::{Error as MatrixError, encryption::verification::SasVerification};
+
+use crate::{client::HumClient, error::Result};
+
+impl HumClient {
+    /// Request verification for the currently logged in device.
+    ///
+    /// If the client has not been initialised or the device is already
+    /// verified, `Ok(None)` will be returned. Otherwise an interactive SAS
+    /// verification flow is started and the `SasVerification` object is
+    /// returned so the caller can drive the verification to completion.
+    pub async fn verify_own_device(&self) -> Result<Option<SasVerification>> {
+        let Some(client) = self.inner() else {
+            return Ok(None);
+        };
+
+        let device = client
+            .encryption()
+            .get_own_device()
+            .await
+            .map_err(MatrixError::from)?;
+
+        let Some(device) = device else {
+            return Ok(None);
+        };
+
+        if device.is_verified() {
+            return Ok(None);
+        }
+
+        let request = device.request_verification().await?;
+        let sas = request.start_sas().await?;
+        Ok(sas)
+    }
+}

--- a/native/rust/examples/cli/Cargo.toml
+++ b/native/rust/examples/cli/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 hum-matrix-core = { path = "../../crates/core" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+futures-util = "0.3"

--- a/native/rust/examples/cli/src/main.rs
+++ b/native/rust/examples/cli/src/main.rs
@@ -1,6 +1,7 @@
-use std::env;
+use std::{env, io};
 
-use hum_matrix_core::{HumClient, Result, config::ClientConfig};
+use futures_util::StreamExt;
+use hum_matrix_core::{HumClient, Result, SasState, config::ClientConfig};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -15,6 +16,50 @@ async fn main() -> Result<()> {
 
     client.login(&username, &password).await?;
     client.start_sync(false).await?;
+
+    if let Some(sas) = client.verify_own_device().await? {
+        sas.accept().await?;
+        let mut stream = sas.changes();
+
+        while let Some(state) = stream.next().await {
+            match state {
+                SasState::KeysExchanged { .. } => {
+                    if let Some(emojis) = sas.emoji() {
+                        let emoji_string = emojis
+                            .iter()
+                            .map(|e| format!("{} {}", e.symbol, e.description))
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        println!("Compare the following emojis:\n{emoji_string}");
+                    } else if let Some((a, b, c)) = sas.decimals() {
+                        println!("Compare the numbers: {a} {b} {c}");
+                    }
+
+                    println!("Do the codes match? (y/N): ");
+                    let mut input = String::new();
+                    io::stdin()
+                        .read_line(&mut input)
+                        .expect("failed to read input");
+                    if input.trim().eq_ignore_ascii_case("y") {
+                        sas.confirm().await?;
+                    } else {
+                        sas.mismatch().await?;
+                        break;
+                    }
+                }
+                SasState::Done { .. } => {
+                    println!("Device verified.");
+                    break;
+                }
+                SasState::Cancelled(info) => {
+                    println!("Verification cancelled: {}", info.reason());
+                    break;
+                }
+                SasState::Started { .. } | SasState::Accepted { .. } | SasState::Confirmed => (),
+            }
+        }
+    }
+
     println!("Logged in and syncing. Press Ctrl-C to exit.");
 
     tokio::signal::ctrl_c()


### PR DESCRIPTION
## Summary
- expose SAS device verification through `HumClient`
- add interactive verification flow to CLI example

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d62ccddc832f97df92f42907a29e