### PR TITLE
feat: add lightning client package

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,11 @@ module.exports = {
     '^@hum/ui-components$': '<rootDir>/packages/ui-components/index.ts',
     '^@hum/ui-components/(.*)$': '<rootDir>/packages/ui-components/src/$1',
     '^@hum/ui-screens(.*)$': '<rootDir>/packages/ui-screens/src$1',
+    '^@hum/lightning-client$': '<rootDir>/packages/lightning-client/index.ts',
+    '^@hum/lightning-client/(.*)$':
+      '<rootDir>/packages/lightning-client/src/$1',
+    '^@hum/lightning-mocks$': '<rootDir>/packages/lightning-mocks/index.ts',
+    '^@hum/lightning-mocks/(.*)$': '<rootDir>/packages/lightning-mocks/src/$1',
     '\\.svg$': '<rootDir>/tests/__mocks__/svgMock.tsx',
   },
 };

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
+    "@types/node": "^24.3.0",
     "@types/react": "^19.1.12",
     "@types/react-native": "0.73.0",
     "@types/react-test-renderer": "^19.1.0",

--- a/packages/lightning-client/index.ts
+++ b/packages/lightning-client/index.ts
@@ -1,0 +1,1 @@
+export * from './src';

--- a/packages/lightning-client/package.json
+++ b/packages/lightning-client/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-native": ">=0.75",
-    "@breeztech/react-native-breez-sdk": "*"
+    "@breeztech/react-native-breez-sdk": "0.8.1-rc3"
   },
   "devDependencies": {
     "@types/react": "^19.1.12"

--- a/packages/lightning-client/package.json
+++ b/packages/lightning-client/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@hum/lightning-client",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-native": ">=0.75",
+    "@breeztech/react-native-breez-sdk": "*"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.12"
+  }
+}

--- a/packages/lightning-client/src/errors.test.ts
+++ b/packages/lightning-client/src/errors.test.ts
@@ -1,0 +1,26 @@
+import { normalizeError } from './errors';
+
+describe('normalizeError', () => {
+  it('maps insufficient funds', () => {
+    expect(normalizeError({ message: 'Insufficient funds' })).toEqual({
+      type: 'InsufficientFunds',
+    });
+  });
+
+  it('maps invoice expired', () => {
+    expect(normalizeError({ code: 'invoice_expired' })).toEqual({
+      type: 'InvoiceExpired',
+    });
+  });
+
+  it('maps network error', () => {
+    expect(normalizeError({ message: 'Network unreachable' })).toEqual({
+      type: 'NetworkError',
+    });
+  });
+
+  it('maps unknown error', () => {
+    const err = { message: 'other' };
+    expect(normalizeError(err)).toEqual({ type: 'Unknown', error: err });
+  });
+});

--- a/packages/lightning-client/src/errors.ts
+++ b/packages/lightning-client/src/errors.ts
@@ -1,0 +1,16 @@
+import type { LightningError } from './types';
+
+export function normalizeError(err: unknown): LightningError {
+  const error = err as { message?: string; code?: string } | undefined;
+  const msg = String(error?.message || error?.code || '').toLowerCase();
+  if (msg.includes('insufficient')) {
+    return { type: 'InsufficientFunds' };
+  }
+  if (msg.includes('expire')) {
+    return { type: 'InvoiceExpired' };
+  }
+  if (msg.includes('network')) {
+    return { type: 'NetworkError' };
+  }
+  return { type: 'Unknown', error: err };
+}

--- a/packages/lightning-client/src/index.ts
+++ b/packages/lightning-client/src/index.ts
@@ -1,0 +1,108 @@
+import { EventEmitter } from 'events';
+import type {
+  Balance,
+  LspInfo,
+  LightningClientApi,
+  LightningEvent,
+} from './types';
+import { normalizeError } from './errors';
+
+interface BreezSDK {
+  initServices?: () => Promise<void>;
+  getLspInfo?: () => Promise<{ setupFee?: number; proportionalFee?: number }>;
+  createInvoice?: (args: {
+    amount: number;
+    description: string;
+  }) => Promise<{ bolt11?: string }>;
+  payInvoice?: (args: { bolt11: string }) => Promise<void>;
+  getBalance?: () => Promise<{ onchain?: number; offchain?: number }>;
+}
+
+let sdk: BreezSDK | undefined;
+
+export const events$ = new EventEmitter();
+
+export async function initLightning(): Promise<void> {
+  if (!sdk) {
+    sdk = (await import('@breeztech/react-native-breez-sdk')) as BreezSDK;
+    await sdk.initServices?.();
+  }
+}
+
+export async function getLspInfo(): Promise<LspInfo> {
+  if (!sdk) throw new Error('Lightning not initialized');
+  try {
+    const info = await sdk.getLspInfo?.();
+    return {
+      setupFee: info?.setupFee ?? 0,
+      proportionalFee: info?.proportionalFee ?? 0,
+    };
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function createInvoice(
+  amount: number,
+  description: string,
+): Promise<string> {
+  if (!sdk) throw new Error('Lightning not initialized');
+  try {
+    const inv = await sdk.createInvoice?.({ amount, description });
+    return inv?.bolt11 ?? '';
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+export async function payInvoice(invoice: string): Promise<void> {
+  if (!sdk) throw new Error('Lightning not initialized');
+  try {
+    await sdk.payInvoice?.({ bolt11: invoice });
+    events$.emit('payment-succeeded', {
+      type: 'payment-succeeded',
+      invoice,
+    } satisfies LightningEvent);
+  } catch (e) {
+    const err = normalizeError(e);
+    events$.emit('payment-failed', {
+      type: 'payment-failed',
+      invoice,
+      error: err,
+    } satisfies LightningEvent);
+    throw err;
+  }
+}
+
+export async function getBalance(): Promise<Balance> {
+  if (!sdk) throw new Error('Lightning not initialized');
+  try {
+    const bal = await sdk.getBalance?.();
+    return { onChain: bal?.onchain ?? 0, lightning: bal?.offchain ?? 0 };
+  } catch (e) {
+    throw normalizeError(e);
+  }
+}
+
+const service: LightningClientApi = {
+  initLightning,
+  getLspInfo,
+  createInvoice,
+  payInvoice,
+  getBalance,
+  events$,
+};
+
+export function useLightning(): LightningClientApi {
+  return service;
+}
+
+export type {
+  LspInfo,
+  Balance,
+  LightningError,
+  LightningEvent,
+  LightningClientApi,
+} from './types';
+export { normalizeError } from './errors';
+export default service;

--- a/packages/lightning-client/src/service.test.ts
+++ b/packages/lightning-client/src/service.test.ts
@@ -1,0 +1,56 @@
+jest.mock(
+  '@breeztech/react-native-breez-sdk',
+  () => ({
+    initServices: jest.fn().mockResolvedValue(undefined),
+    getLspInfo: jest
+      .fn()
+      .mockResolvedValue({ setupFee: 1, proportionalFee: 0.1 }),
+    createInvoice: jest.fn().mockResolvedValue({ bolt11: 'bolt123' }),
+    payInvoice: jest.fn().mockResolvedValue({}),
+    getBalance: jest.fn().mockResolvedValue({ onchain: 2, offchain: 3 }),
+  }),
+  { virtual: true },
+);
+
+import {
+  initLightning,
+  getLspInfo,
+  createInvoice,
+  payInvoice,
+  getBalance,
+  events$,
+} from './index';
+
+describe('lightning-client service', () => {
+  beforeEach(() => {
+    events$.removeAllListeners();
+  });
+
+  it('initializes breez sdk', async () => {
+    await initLightning();
+    const sdk = await import('@breeztech/react-native-breez-sdk');
+    expect(sdk.initServices).toHaveBeenCalled();
+  });
+
+  it('creates invoice and pays', async () => {
+    await initLightning();
+    const invoice = await createInvoice(10, 'test');
+    expect(invoice).toBe('bolt123');
+
+    const handler = jest.fn();
+    events$.once('payment-succeeded', handler);
+    await payInvoice(invoice);
+    expect(handler).toHaveBeenCalledWith({
+      type: 'payment-succeeded',
+      invoice,
+    });
+  });
+
+  it('gets lsp info and balance', async () => {
+    await initLightning();
+    const info = await getLspInfo();
+    expect(info).toEqual({ setupFee: 1, proportionalFee: 0.1 });
+    const balance = await getBalance();
+    expect(balance).toEqual({ onChain: 2, lightning: 3 });
+  });
+});

--- a/packages/lightning-client/src/types.ts
+++ b/packages/lightning-client/src/types.ts
@@ -1,0 +1,31 @@
+import { EventEmitter } from 'events';
+
+export interface LspInfo {
+  setupFee: number;
+  proportionalFee: number;
+}
+
+export interface Balance {
+  onChain: number;
+  lightning: number;
+}
+
+export type LightningError =
+  | { type: 'InsufficientFunds' }
+  | { type: 'InvoiceExpired' }
+  | { type: 'NetworkError' }
+  | { type: 'Unknown'; error: unknown };
+
+export type LightningEvent =
+  | { type: 'channel-opened' }
+  | { type: 'payment-succeeded'; invoice: string }
+  | { type: 'payment-failed'; invoice: string; error: LightningError };
+
+export interface LightningClientApi {
+  initLightning: () => Promise<void>;
+  getLspInfo: () => Promise<LspInfo>;
+  createInvoice: (amount: number, description: string) => Promise<string>;
+  payInvoice: (invoice: string) => Promise<void>;
+  getBalance: () => Promise<Balance>;
+  events$: EventEmitter;
+}

--- a/packages/lightning-client/tsconfig.json
+++ b/packages/lightning-client/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
-    "types": ["jest", "react", "react-native"],
+    "types": ["node", "jest", "react", "react-native"],
     "typeRoots": ["../../tests", "../../node_modules/@types"]
   },
   "include": ["src", "**/*.ts", "**/*.tsx"],

--- a/packages/lightning-client/tsconfig.json
+++ b/packages/lightning-client/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "rootDir": ".",
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "types": ["jest", "react", "react-native"],
+    "typeRoots": ["../../tests", "../../node_modules/@types"]
+  },
+  "include": ["src", "**/*.ts", "**/*.tsx"],
+  "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/lightning-mocks/index.ts
+++ b/packages/lightning-mocks/index.ts
@@ -1,0 +1,1 @@
+export * from './src';

--- a/packages/lightning-mocks/package.json
+++ b/packages/lightning-mocks/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@hum/lightning-mocks",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@hum/lightning-client": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-native": ">=0.75"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.12"
+  }
+}

--- a/packages/lightning-mocks/src/index.test.ts
+++ b/packages/lightning-mocks/src/index.test.ts
@@ -1,0 +1,34 @@
+import {
+  initLightning,
+  getLspInfo,
+  createInvoice,
+  payInvoice,
+  getBalance,
+  events$,
+} from './index';
+
+describe('lightning-mocks', () => {
+  beforeEach(() => {
+    events$.removeAllListeners();
+  });
+
+  it('provides deterministic responses', async () => {
+    await initLightning();
+    expect(await getLspInfo()).toEqual({
+      setupFee: 1000,
+      proportionalFee: 0.01,
+    });
+    const invoice = await createInvoice(5, 'test');
+    expect(invoice).toBe('lnmock_5_test');
+
+    const handler = jest.fn();
+    events$.once('payment-succeeded', handler);
+    await payInvoice(invoice);
+    expect(handler).toHaveBeenCalledWith({
+      type: 'payment-succeeded',
+      invoice,
+    });
+
+    expect(await getBalance()).toEqual({ onChain: 1234, lightning: 5678 });
+  });
+});

--- a/packages/lightning-mocks/src/index.ts
+++ b/packages/lightning-mocks/src/index.ts
@@ -1,0 +1,47 @@
+import { EventEmitter } from 'events';
+import type {
+  Balance,
+  LspInfo,
+  LightningClientApi,
+} from '@hum/lightning-client';
+
+export const events$ = new EventEmitter();
+
+export async function initLightning(): Promise<void> {
+  // no-op for mocks
+}
+
+export async function getLspInfo(): Promise<LspInfo> {
+  return { setupFee: 1000, proportionalFee: 0.01 };
+}
+
+export async function createInvoice(
+  amount: number,
+  description: string,
+): Promise<string> {
+  return `lnmock_${amount}_${description}`;
+}
+
+export async function payInvoice(invoice: string): Promise<void> {
+  events$.emit('payment-succeeded', { type: 'payment-succeeded', invoice });
+}
+
+export async function getBalance(): Promise<Balance> {
+  return { onChain: 1234, lightning: 5678 };
+}
+
+const service: LightningClientApi = {
+  initLightning,
+  getLspInfo,
+  createInvoice,
+  payInvoice,
+  getBalance,
+  events$,
+};
+
+export function useLightning(): LightningClientApi {
+  return service;
+}
+
+export type { LightningError, LightningEvent } from '@hum/lightning-client';
+export default service;

--- a/packages/lightning-mocks/tsconfig.json
+++ b/packages/lightning-mocks/tsconfig.json
@@ -6,8 +6,12 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
-    "types": ["jest", "react", "react-native"],
-    "typeRoots": ["../../tests", "../../node_modules/@types"]
+    "types": ["node", "jest", "react", "react-native"],
+    "typeRoots": ["../../tests", "../../node_modules/@types"],
+    "paths": {
+      "@hum/lightning-client": ["../lightning-client/dist/index"],
+      "@hum/lightning-client/*": ["../lightning-client/dist/*"]
+    }
   },
   "include": ["src", "**/*.ts", "**/*.tsx"],
   "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]

--- a/packages/lightning-mocks/tsconfig.json
+++ b/packages/lightning-mocks/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "rootDir": ".",
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "types": ["jest", "react", "react-native"],
+    "typeRoots": ["../../tests", "../../node_modules/@types"]
+  },
+  "include": ["src", "**/*.ts", "**/*.tsx"],
+  "exclude": ["dist", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,38 @@ importers:
         specifier: '*'
         version: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
+  packages/lightning-client:
+    dependencies:
+      '@breeztech/react-native-breez-sdk':
+        specifier: '*'
+        version: 0.8.1-rc3(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
+      react:
+        specifier: ^19.0.0
+        version: 19.1.1
+      react-native:
+        specifier: '>=0.75'
+        version: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.12
+        version: 19.1.12
+
+  packages/lightning-mocks:
+    dependencies:
+      '@hum/lightning-client':
+        specifier: workspace:*
+        version: link:../lightning-client
+      react:
+        specifier: ^19.0.0
+        version: 19.1.1
+      react-native:
+        specifier: '>=0.75'
+        version: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.12
+        version: 19.1.12
+
   packages/ui-components:
     dependencies:
       '@testing-library/jest-dom':
@@ -1036,6 +1068,12 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@breeztech/react-native-breez-sdk@0.8.1-rc3':
+    resolution: {integrity: sha512-rmrxL4V2Ibsw91HkkohMSlvVrMe0KRlJHObHX94hAJhEEF07J7ek+0i0V/XjLYM7WAln724+mafV0PtikwQJ9Q==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -7475,6 +7513,11 @@ snapshots:
       '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@breeztech/react-native-breez-sdk@0.8.1-rc3(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1)
 
   '@csstools/color-helpers@5.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,7 +216,7 @@ importers:
   packages/lightning-client:
     dependencies:
       '@breeztech/react-native-breez-sdk':
-        specifier: '*'
+        specifier: 0.8.1-rc3
         version: 0.8.1-rc3(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@14.1.0(typescript@5.8.3))(@types/react@19.1.12)(react@19.1.1))(react@19.1.1)
       react:
         specifier: ^19.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.0
       '@types/react':
         specifier: ^19.1.12
         version: 19.1.12

--- a/tests/breez-sdk.d.ts
+++ b/tests/breez-sdk.d.ts
@@ -1,0 +1,1 @@
+declare module '@breeztech/react-native-breez-sdk';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,7 +18,11 @@
       "@hum/ui-components": ["packages/ui-components/index.ts"],
       "@hum/ui-components/*": ["packages/ui-components/src/*"],
       "@hum/ui-screens": ["packages/ui-screens/src/index.ts"],
-      "@hum/ui-screens/*": ["packages/ui-screens/src/*"]
+      "@hum/ui-screens/*": ["packages/ui-screens/src/*"],
+      "@hum/lightning-client": ["packages/lightning-client/index.ts"],
+      "@hum/lightning-client/*": ["packages/lightning-client/src/*"],
+      "@hum/lightning-mocks": ["packages/lightning-mocks/index.ts"],
+      "@hum/lightning-mocks/*": ["packages/lightning-mocks/src/*"]
     }
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- add @hum/lightning-client wrapper around Breez SDK with typed API and hook
- provide mock implementation for lightning operations
- wire up config paths and tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b727a75340832fb8005e105c594125