### PR TITLE
chore(ci): run jobs by changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       node: ${{ steps.filter.outputs.node }}
       rust: ${{ steps.filter.outputs.rust }}
       storybook: ${{ steps.filter.outputs.storybook }}
+      ci: ${{ steps.filter.outputs.ci }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,11 +60,13 @@ jobs:
               - '.nvmrc'
               - 'playwright.config.ts'
               - 'tsconfig*.json'
+            ci:
+              - '.github/workflows/**'
 
   node:
     needs: changes
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.base_ref == 'main' || needs.changes.outputs.node == 'true'
+    if: github.ref == 'refs/heads/main' || github.base_ref == 'main' || needs.changes.outputs.node == 'true' || needs.changes.outputs.ci == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -98,7 +101,7 @@ jobs:
   rust:
     needs: changes
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.base_ref == 'main' || needs.changes.outputs.rust == 'true'
+    if: github.ref == 'refs/heads/main' || github.base_ref == 'main' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
     defaults:
       run:
         working-directory: native/rust
@@ -129,7 +132,7 @@ jobs:
   storybook-e2e:
     needs: changes
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.base_ref == 'main' || needs.changes.outputs.storybook == 'true'
+    if: github.ref == 'refs/heads/main' || github.base_ref == 'main' || needs.changes.outputs.storybook == 'true' || needs.changes.outputs.ci == 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,56 @@ on:
       - develop
 
 jobs:
-  node:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      node: ${{ steps.filter.outputs.node }}
+      rust: ${{ steps.filter.outputs.rust }}
+      storybook: ${{ steps.filter.outputs.storybook }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            node:
+              - 'apps/**'
+              - 'packages/**'
+              - 'scripts/**'
+              - 'tests/**'
+              - 'docs/**'
+              - 'assets/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.nvmrc'
+              - '.prettierrc.json'
+              - '.prettierignore'
+              - 'eslint.config.mjs'
+              - 'jest.config.js'
+              - 'tsconfig*.json'
+              - 'metro.config.js'
+            rust:
+              - 'native/rust/**'
+            storybook:
+              - 'e2e/**'
+              - 'apps/**'
+              - 'packages/**'
+              - 'docs/**'
+              - 'assets/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.nvmrc'
+              - 'playwright.config.ts'
+              - 'tsconfig*.json'
+
+  node:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.base_ref == 'main' || needs.changes.outputs.node == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -44,18 +92,17 @@ jobs:
         run: pnpm -r --filter './packages/*' build
 
   rust:
+    needs: changes
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.base_ref == 'main' || needs.changes.outputs.rust == 'true'
     defaults:
       run:
         working-directory: native/rust
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
@@ -76,7 +123,9 @@ jobs:
       #  run: cargo test --features sqlite
 
   storybook-e2e:
+    needs: changes
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.base_ref == 'main' || needs.changes.outputs.storybook == 'true'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- only run node, rust, and storybook jobs on develop when relevant files change
- always run jobs on main and report path-based changes via a preliminary check
- switch rust toolchain setup to `dtolnay/rust-toolchain@stable`

## Testing
- `/tmp/actionlint .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b871c3a27c832f92fe861efea90824