### PR TITLE
fix(android): correct detox maven path

### DIFF
--- a/apps/mobile/android/build.gradle
+++ b/apps/mobile/android/build.gradle
@@ -30,7 +30,7 @@ allprojects {
     // Detox Android AAR is distributed via npm in node_modules.
     // Add its local Maven repo so androidTestImplementation 'com.wix:detox:+'
     // resolves to the correct artifact rather than the outdated one on Maven Central.
-    maven { url("$rootDir/../../node_modules/detox/Detox-android") }
+    maven { url("$rootDir/../../../node_modules/detox/Detox-android") }
 
     google()
     mavenCentral()


### PR DESCRIPTION
## Summary
- fix Android build by pointing Detox repository to correct node_modules location

## Testing
- `cd apps/mobile/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug` *(fails: Cannot find a Java installation matching 17)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7b4236f0832fb89d5476d7e621db