### PR TITLE
fix detox build with matrix native package

### DIFF
--- a/detox.config.js
+++ b/detox.config.js
@@ -13,14 +13,14 @@ module.exports = {
       binaryPath:
         'apps/mobile/ios/build/Build/Products/Debug-iphonesimulator/hum.app',
       build:
-        'npm run -w @hum/ui-components build && npm run -w @hum/ui-screens build && xcodebuild -workspace apps/mobile/ios/hum.xcworkspace -scheme hum -configuration Debug -sdk iphonesimulator -derivedDataPath apps/mobile/ios/build',
+        'npm run -w @hum/hum-matrix-native build && npm run -w @hum/ui-components build && npm run -w @hum/ui-screens build && xcodebuild -workspace apps/mobile/ios/hum.xcworkspace -scheme hum -configuration Debug -sdk iphonesimulator -derivedDataPath apps/mobile/ios/build',
     },
     'myApp.android': {
       type: 'android.apk',
       binaryPath:
         'apps/mobile/android/app/build/outputs/apk/debug/app-debug.apk',
       build:
-        'npm run -w @hum/ui-components build && npm run -w @hum/ui-screens build && cd apps/mobile/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
+        'npm run -w @hum/hum-matrix-native build && npm run -w @hum/ui-components build && npm run -w @hum/ui-screens build && cd apps/mobile/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug',
     },
   },
   devices: {


### PR DESCRIPTION
## Summary
- build `@hum/hum-matrix-native` before running platform builds

## Testing
- `DEV_FEATURES=1 npx detox build -c android.emu.debug` *(fails: Could not determine the dependencies of task ':gradle-plugin:settings-plugin:compileKotlin' due to missing Java 17)*

------
https://chatgpt.com/codex/tasks/task_e_68be84b76028832f807e4b91944cb23d