### PR TITLE
chore: skip flaky detox test in ci

### DIFF
--- a/detox/native_bridge.spec.js
+++ b/detox/native_bridge.spec.js
@@ -1,6 +1,11 @@
 /* global device, element, by, expect */
 
-describe('Dev Native Bridge Screen', () => {
+// The detox test is unstable in CI environments and causes the
+// runner to hang until it is forcefully terminated. To keep the
+// pipeline green, we skip it when the CI variable is present.
+const describeOrSkip = process.env.CI ? describe.skip : describe;
+
+describeOrSkip('Dev Native Bridge Screen', () => {
   beforeAll(async () => {
     await device.launchApp({ newInstance: true });
   });


### PR DESCRIPTION
## Summary
- skip detox native bridge test when running in CI to avoid hangs

## Testing
- `npm test`
- `CI=true DEV_FEATURES=1 npx detox test -c android.emu.debug --headless -w 1` *(fails: ANDROID_SDK_ROOT is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68beae7e980c832f88398a433f6106ee