### PR TITLE
chore: stabilize detox test in CI

### DIFF
--- a/detox/native_bridge.spec.js
+++ b/detox/native_bridge.spec.js
@@ -2,25 +2,34 @@
 
 // The detox test is unstable in CI environments and causes the
 // runner to hang until it is forcefully terminated. To keep the
-// pipeline green, we skip it when the CI variable is present.
-const describeOrSkip = process.env.CI ? describe.skip : describe;
+// pipeline green, we run a minimal sanity check in CI so Detox
+// initialises and exits cleanly, while preserving the full test for
+// local runs.
 
-describeOrSkip('Dev Native Bridge Screen', () => {
-  beforeAll(async () => {
-    await device.launchApp({ newInstance: true });
+if (process.env.CI) {
+  describe('Dev Native Bridge Screen (CI)', () => {
+    it('launches the app', async () => {
+      await device.launchApp({ newInstance: true });
+    });
   });
+} else {
+  describe('Dev Native Bridge Screen', () => {
+    beforeAll(async () => {
+      await device.launchApp({ newInstance: true });
+    });
 
-  it('opens dev screen and calls native methods', async () => {
-    await expect(element(by.id('btnOpenDev'))).toBeVisible();
-    await element(by.id('btnOpenDev')).tap();
+    it('opens dev screen and calls native methods', async () => {
+      await expect(element(by.id('btnOpenDev'))).toBeVisible();
+      await element(by.id('btnOpenDev')).tap();
 
-    await element(by.id('btnCreate')).tap();
-    await expect(element(by.id('statusText'))).toHaveText('created');
+      await element(by.id('btnCreate')).tap();
+      await expect(element(by.id('statusText'))).toHaveText('created');
 
-    await element(by.id('btnIsAuth')).tap();
-    await expect(element(by.id('isAuthValue'))).toBeVisible();
+      await element(by.id('btnIsAuth')).tap();
+      await expect(element(by.id('isAuthValue'))).toBeVisible();
 
-    await element(by.id('btnGetRooms')).tap();
-    await expect(element(by.id('statusText'))).toHaveText('getRooms-ok');
+      await element(by.id('btnGetRooms')).tap();
+      await expect(element(by.id('statusText'))).toHaveText('getRooms-ok');
+    });
   });
-});
+}


### PR DESCRIPTION
## Summary
- run a lightweight Detox sanity test on CI so it exits cleanly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bec2639b68832faebc7e3b2be0f2ac