### PR TITLE
chore: stabilize detox ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,16 +261,28 @@ jobs:
         env:
           CI: true
           NODE_ENV: production
+          DETOX_LOGLEVEL: trace
+          DETOX_REPORT_SPECS: true
         run: DEV_FEATURES=1 npx detox build -c android.emu.debug
 
       - name: Run Detox on Android emulator
         uses: reactivecircus/android-emulator-runner@v2
+        env:
+          DETOX_LOGLEVEL: trace
+          DETOX_REPORT_SPECS: true
         with:
           api-level: 34
           arch: x86_64
           profile: pixel_6
           force-avd-creation: false
-          emulator-options: -no-window -gpu off -no-snapshot -noaudio -no-boot-anim -accel off
+          emulator-options: -no-window -no-snapshot -no-boot-anim -gpu swiftshader_indirect -noaudio
           script: |
-            CI=true NODE_ENV=production DEV_FEATURES=1 npx detox test -c android.emu.debug --headless -w 1
+            CI=true NODE_ENV=production DEV_FEATURES=1 npx detox test -c android.emu.debug --headless -w 1 --record-logs failing --record-videos failing --take-screenshots failing --artifacts-location ./detox-artifacts
           emulator-boot-timeout: 900
+
+      - name: Upload Detox artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: detox-artifacts
+          path: detox-artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ storybook-static/
 playwright-report/
 test-results/
 
+# Detox artifacts
+detox-artifacts/
+
 # React Native / Expo
 .expo/
 .expo-shared/

--- a/detox.config.js
+++ b/detox.config.js
@@ -6,6 +6,10 @@ module.exports = {
       $0: 'jest',
       config: 'detox/jest.config.js',
     },
+    // Extend environment setup time to allow emulator and app start.
+    jest: {
+      setupTimeout: 300000,
+    },
   },
   apps: {
     'myApp.ios': {

--- a/detox/setup.js
+++ b/detox/setup.js
@@ -1,3 +1,4 @@
 // Keep this file for lightweight Jest tweaks only.
 // Detox init/cleanup is handled by the Detox Jest environment.
-jest.setTimeout(240000);
+// Allow ample time for emulator boot and app launch in CI.
+jest.setTimeout(600000);


### PR DESCRIPTION
## Summary
- extend Detox setup time and increase Jest timeout
- harden Detox CI job with emulator flags, verbose logging, and artifact capture

## Testing
- `npm test packages/ui-components/src/avatar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bf007ccfbc832faba33f83358a9baa