### PR TITLE
feat: add i18n support with en and de locales

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
-import { View, StyleSheet, useColorScheme } from 'react-native';
+import { View, StyleSheet, useColorScheme, Text } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { BottomNavigation, ThemeProvider } from '@hum/ui-components';
+import { BottomNavigation, ThemeProvider, Button } from '@hum/ui-components';
 import Constants from 'expo-constants';
 import {
   ChatsScreen,
@@ -12,6 +12,8 @@ import {
 import { MainSettingsScreen, ThemeSettingsScreen } from './setting_screens';
 import DevNativeBridgeScreen from './src/DevNativeBridgeScreen';
 import { HumClientProvider, useHumClient } from './src/hum/HumClientProvider';
+import { I18nextProvider, useTranslation } from 'react-i18next';
+import i18n from '@hum/i18n';
 
 function AppInner() {
   const [activeTab, setActiveTab] = useState('chats');
@@ -29,6 +31,7 @@ function AppInner() {
   const [settingsView, setSettingsView] = useState<'main' | 'theme'>('main');
   const systemScheme = useColorScheme() ?? 'light';
   const resolvedScheme = theme === 'auto' ? systemScheme : theme;
+  const { i18n: i18next } = useTranslation();
 
   return (
     <SafeAreaProvider>
@@ -71,6 +74,23 @@ function AppInner() {
                 testID="btnOpenDev"
                 onTouchEnd={() => setShowDev(true)}
               />
+              <View style={styles.langRow}>
+                <Button
+                  size="sm"
+                  onPress={() => i18next.changeLanguage('en')}
+                  testID="btnEn"
+                >
+                  <Text>EN</Text>
+                </Button>
+                <View style={styles.langSpacer} />
+                <Button
+                  size="sm"
+                  onPress={() => i18next.changeLanguage('de')}
+                  testID="btnDe"
+                >
+                  <Text>DE</Text>
+                </Button>
+              </View>
             </View>
           )}
         </View>
@@ -90,9 +110,11 @@ function ChatsFromProvider({
 
 export default function App() {
   return (
-    <HumClientProvider>
-      <AppInner />
-    </HumClientProvider>
+    <I18nextProvider i18n={i18n}>
+      <HumClientProvider>
+        <AppInner />
+      </HumClientProvider>
+    </I18nextProvider>
   );
 }
 
@@ -109,4 +131,6 @@ const styles = StyleSheet.create({
     borderRadius: 18,
     backgroundColor: '#FF00AA',
   },
+  langSpacer: { width: 8 },
+  langRow: { flexDirection: 'row', marginTop: 8 },
 });

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,6 +21,7 @@
     "@hum/hum-matrix-native": "file:../../packages/hum-matrix-native",
     "@hum/ui-components": "file:../../packages/ui-components",
     "@hum/ui-screens": "file:../../packages/ui-screens",
+    "@hum/i18n": "file:../../packages/i18n",
     "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "54.0.7",
     "react": "19.1.0",

--- a/apps/mobile/setting_screens/Main.tsx
+++ b/apps/mobile/setting_screens/Main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SettingsItem, Icon, useTheme } from '@hum/ui-components';
 import { SettingsScreen } from '@hum/ui-screens';
+import { useTranslation } from 'react-i18next';
 
 export type MainSettingsScreenProps = {
   theme: 'light' | 'dark' | 'auto';
@@ -12,13 +13,13 @@ export const MainSettingsScreen: React.FC<MainSettingsScreenProps> = ({
   onNavigateToTheme,
 }) => {
   const { colors } = useTheme();
-  const themeLabel =
-    theme === 'auto' ? 'Auto' : theme.charAt(0).toUpperCase() + theme.slice(1);
+  const { t } = useTranslation();
+  const themeLabel = t(`labels.${theme}`);
   return (
     <SettingsScreen>
       <SettingsItem
         icon={<Icon name="palette" size={24} color={colors.humPrimary} />}
-        title="Theme"
+        title={t('labels.theme')}
         subtitle={themeLabel}
         onPress={onNavigateToTheme}
       />

--- a/apps/mobile/setting_screens/Theme.tsx
+++ b/apps/mobile/setting_screens/Theme.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ListRow } from '@hum/ui-components';
 import { SettingsScreen } from '@hum/ui-screens';
+import { useTranslation } from 'react-i18next';
 
 export type ThemeSettingsScreenProps = {
   theme: 'light' | 'dark' | 'auto';
@@ -12,24 +13,27 @@ export const ThemeSettingsScreen: React.FC<ThemeSettingsScreenProps> = ({
   theme,
   onBack,
   onSelectTheme,
-}) => (
-  <SettingsScreen onBack={onBack}>
-    <ListRow
-      label="Light"
-      onPress={() => onSelectTheme('light')}
-      rightText={theme === 'light' ? '✓' : undefined}
-    />
-    <ListRow
-      label="Dark"
-      onPress={() => onSelectTheme('dark')}
-      rightText={theme === 'dark' ? '✓' : undefined}
-    />
-    <ListRow
-      label="Auto"
-      onPress={() => onSelectTheme('auto')}
-      rightText={theme === 'auto' ? '✓' : undefined}
-    />
-  </SettingsScreen>
-);
+}) => {
+  const { t } = useTranslation();
+  return (
+    <SettingsScreen onBack={onBack}>
+      <ListRow
+        label={t('labels.light')}
+        onPress={() => onSelectTheme('light')}
+        rightText={theme === 'light' ? '✓' : undefined}
+      />
+      <ListRow
+        label={t('labels.dark')}
+        onPress={() => onSelectTheme('dark')}
+        rightText={theme === 'dark' ? '✓' : undefined}
+      />
+      <ListRow
+        label={t('labels.auto')}
+        onPress={() => onSelectTheme('auto')}
+        rightText={theme === 'auto' ? '✓' : undefined}
+      />
+    </SettingsScreen>
+  );
+};
 
 export default ThemeSettingsScreen;

--- a/apps/mobile/src/DevNativeBridgeScreen.tsx
+++ b/apps/mobile/src/DevNativeBridgeScreen.tsx
@@ -100,10 +100,12 @@ export const DevNativeBridgeScreen: React.FC<{ onBack?: () => void }> = ({
         {t('labels.dev_bridge')}
       </Text>
 
-      <Text style={{ color: colors.mutedForeground }}>Backend: {backend}</Text>
+      <Text style={{ color: colors.mutedForeground }}>
+        {t('labels.backend')}:{backend}
+      </Text>
       <View style={{ height: spacing.xs }} />
       <Button testID="btnToggleBackend" onPress={toggleBackend}>
-        <Text>Toggle Mock</Text>
+        <Text>{t('actions.toggle_mock')}</Text>
       </Button>
       <View style={{ height: spacing.sm }} />
 

--- a/apps/mobile/src/DevNativeBridgeScreen.tsx
+++ b/apps/mobile/src/DevNativeBridgeScreen.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme, Button } from '@hum/ui-components';
+import { useTranslation } from 'react-i18next';
 import HumNative, {
   type Client,
   type RoomSummary,
@@ -16,6 +17,7 @@ export const DevNativeBridgeScreen: React.FC<{ onBack?: () => void }> = ({
   const [status, setStatus] = useState<string>('idle');
   const [isAuth, setIsAuth] = useState<boolean>(false);
   const [rooms, setRooms] = useState<RoomSummary[]>([]);
+  const { t } = useTranslation();
 
   const safeClient = async (): Promise<Client> => {
     if (!clientRef.current) {
@@ -82,25 +84,25 @@ export const DevNativeBridgeScreen: React.FC<{ onBack?: () => void }> = ({
       ]}
     >
       <Text style={[styles.title, { color: colors.foreground }]}>
-        Dev Bridge
+        {t('labels.dev_bridge')}
       </Text>
 
       <View style={{ height: spacing.sm }} />
 
       <Button testID="btnCreate" onPress={handleCreate}>
-        <Text>Create Client</Text>
+        <Text>{t('actions.create_client')}</Text>
       </Button>
       <View style={{ height: spacing.xs }} />
       <Button testID="btnLogin" onPress={handleLogin}>
-        <Text>Login</Text>
+        <Text>{t('actions.login')}</Text>
       </Button>
       <View style={{ height: spacing.xs }} />
       <Button testID="btnIsAuth" onPress={handleIsAuth}>
-        <Text>Is Authenticated?</Text>
+        <Text>{t('actions.is_authenticated')}</Text>
       </Button>
       <View style={{ height: spacing.xs }} />
       <Button testID="btnGetRooms" onPress={handleGetRooms}>
-        <Text>Get Rooms</Text>
+        <Text>{t('actions.get_rooms')}</Text>
       </Button>
 
       <View style={{ height: spacing.md }} />
@@ -109,7 +111,7 @@ export const DevNativeBridgeScreen: React.FC<{ onBack?: () => void }> = ({
         {status}
       </Text>
       <Text testID="isAuthValue" style={{ color: colors.mutedForeground }}>
-        {isAuth ? 'true' : 'false'}
+        {String(isAuth)}
       </Text>
       <Text testID="roomsCount" style={{ color: colors.mutedForeground }}>
         {String(rooms.length)}
@@ -118,7 +120,7 @@ export const DevNativeBridgeScreen: React.FC<{ onBack?: () => void }> = ({
       {onBack && (
         <View style={[styles.backWrap, { top: insets.top + 8 }]}>
           <Button variant="secondary" testID="btnDevBack" onPress={onBack}>
-            <Text>Back</Text>
+            <Text>{t('actions.back')}</Text>
           </Button>
         </View>
       )}

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,16 @@
+# Internationalization
+
+The app uses [i18next](https://www.i18next.com/) with `react-i18next` for
+translation. Languages are stored in `packages/i18n` and loaded at runtime.
+
+## Adding a new locale
+
+1. Create a folder `packages/i18n/src/locales/<lang>`.
+2. Copy `common.json` from another locale and translate the values.
+3. Ensure the keys match across all locale files.
+4. Run `npm run i18n:missing` to verify no keys are missing.
+5. Use `t('key.path')` from `react-i18next` in components.
+
+The app auto-detects the system locale on startup and falls back to English.
+During development, you can switch languages using the EN/DE buttons when dev
+features are enabled.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,7 +51,7 @@ export default [
       'react-native/sort-styles': 'off',
       'react/jsx-no-literals': ['error', {
         noStrings: true,
-        allowedStrings: ['+', '⋮', '⋯', '‹', '›', '✓', '✓✓', '❤️', '📍', 'EN', 'DE', '• '],
+        allowedStrings: ['+', '⋮', '⋯', '‹', '›', '✓', '✓✓', '❤️', '📍', 'EN', 'DE', '• ', ":",],
         ignoreProps: true,
       }],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,7 @@ export default [
         __dirname: 'readonly',
         __filename: 'readonly',
         process: 'readonly',
+        console: 'readonly',
       },
     },
     rules: {
@@ -48,11 +49,28 @@ export default [
       'prettier/prettier': 'error',
       'react-native/no-color-literals': 'off',
       'react-native/sort-styles': 'off',
+      'react/jsx-no-literals': ['error', {
+        noStrings: true,
+        allowedStrings: ['+', '⋮', '⋯', '‹', '›', '✓', '✓✓', '❤️', '📍', 'EN', 'DE', '• '],
+        ignoreProps: true,
+      }],
     },
     settings: {
       react: {
         version: 'detect',
       },
+    },
+  },
+  {
+    files: ['**/*.test.{ts,tsx,js}', '**/tests/**'],
+    rules: {
+      'react/jsx-no-literals': 'off',
+    },
+  },
+  {
+    files: ['apps/storybook/**/*.{ts,tsx,js}'],
+    rules: {
+      'react/jsx-no-literals': 'off',
     },
   },
   prettierConfig,

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ module.exports = {
       '<rootDir>/packages/lightning-client/src/$1',
     '^@hum/lightning-mocks$': '<rootDir>/packages/lightning-mocks/index.ts',
     '^@hum/lightning-mocks/(.*)$': '<rootDir>/packages/lightning-mocks/src/$1',
+    '^@hum/i18n$': '<rootDir>/packages/i18n/src/index.ts',
     '\\.svg$': '<rootDir>/tests/__mocks__/svgMock.tsx',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
       "dependencies": {
         "@babel/runtime": "7.28.3",
         "@hum/hum-matrix-native": "file:../../packages/hum-matrix-native",
+        "@hum/i18n": "file:../../packages/i18n",
         "@hum/ui-components": "file:../../packages/ui-components",
         "@hum/ui-screens": "file:../../packages/ui-screens",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -4784,6 +4785,10 @@
     },
     "node_modules/@hum/hum-matrix-native": {
       "resolved": "packages/hum-matrix-native",
+      "link": true
+    },
+    "node_modules/@hum/i18n": {
+      "resolved": "packages/i18n",
       "link": true
     },
     "node_modules/@hum/lightning-client": {
@@ -14478,6 +14483,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -14603,6 +14617,38 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -21252,6 +21298,28 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.5.0.tgz",
+      "integrity": "sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.5",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -22482,6 +22550,12 @@
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "license": "MIT"
+    },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -25788,6 +25862,15 @@
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
     },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -26451,6 +26534,31 @@
         "react-native": ">=0.75"
       }
     },
+    "packages/i18n": {
+      "name": "@hum/i18n",
+      "version": "0.1.0",
+      "dependencies": {
+        "expo-localization": "^15.0.1",
+        "i18next": "^23.10.1",
+        "i18next-browser-languagedetector": "^8.0.2",
+        "react-i18next": "^13.2.2"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "packages/i18n/node_modules/expo-localization": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-15.0.3.tgz",
+      "integrity": "sha512-IfcmlKuKRlowR9qIzL0e+nGHBeNoF7l2GQaOJstc7HZiPjNJ4J1R4D53ZNf483dt7JSkTRJBihdTadOtOEjRdg==",
+      "license": "MIT",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "packages/lightning-client": {
       "name": "@hum/lightning-client",
       "version": "0.1.0",
@@ -26481,7 +26589,8 @@
       "name": "@hum/ui-components",
       "version": "0.1.0",
       "dependencies": {
-        "@testing-library/jest-dom": "6.8.0"
+        "@testing-library/jest-dom": "6.8.0",
+        "react-i18next": "^13.2.2"
       },
       "devDependencies": {
         "@types/react": "^19.1.12"
@@ -26497,7 +26606,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@hum/ui-components": "file:../ui-components",
-        "@testing-library/jest-dom": "6.8.0"
+        "@testing-library/jest-dom": "6.8.0",
+        "react-i18next": "^13.2.2"
       },
       "devDependencies": {
         "@types/react": "^19.1.12"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sb:build": "npm run storybook:build",
     "sb:ios": "npm run storybook:ios",
     "sb:android": "npm run storybook:android",
+    "i18n:missing": "node scripts/i18n-missing.cjs",
     "rust:test": "cargo test --manifest-path native/rust/Cargo.toml",
     "rust:format": "cargo fmt --all --manifest-path native/rust/Cargo.toml",
     "rust:lint": "cargo clippy --manifest-path native/rust/Cargo.toml --all-targets --all-features -- -D warnings",

--- a/packages/i18n/index.test.ts
+++ b/packages/i18n/index.test.ts
@@ -1,0 +1,36 @@
+import i18n from './src/index';
+
+describe('i18n configuration', () => {
+  beforeAll(async () => {
+    if (!i18n.isInitialized) {
+      await new Promise<void>((resolve) => {
+        const handle = () => {
+          i18n.off('initialized', handle);
+          resolve();
+        };
+        i18n.on('initialized', handle);
+      });
+    }
+    await i18n.changeLanguage('en');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('provides English translations by default', () => {
+    expect(i18n.t('nav.chats')).toBe('Chats');
+    expect(i18n.t('actions.back')).toBe('Go back');
+  });
+
+  it('switches to German translations when requested', async () => {
+    await i18n.changeLanguage('de');
+    expect(i18n.t('nav.settings')).toBe('Einstellungen');
+    expect(i18n.t('actions.search')).toBe('Suchen');
+  });
+
+  it('falls back to English for unsupported locales', async () => {
+    await i18n.changeLanguage('fr');
+    expect(i18n.t('nav.lightning')).toBe('Lightning');
+  });
+});

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@hum/i18n",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0"
+  },
+  "dependencies": {
+    "i18next": "^23.10.1",
+    "react-i18next": "^13.2.2",
+    "i18next-browser-languagedetector": "^8.0.2",
+    "expo-localization": "^15.0.1"
+  }
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -17,29 +17,33 @@ const isBrowser =
   typeof window.document !== 'undefined' &&
   typeof window.navigator !== 'undefined';
 
+declare const require: undefined | ((module: string) => unknown);
+
 function detectFromNativeApis(): string {
   try {
-    // expo-localization is only available on native targets. Requiring it in
-    // non-native environments (tests, SSR) throws, so we guard it.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- conditional native require
-    const localization = require('expo-localization');
-    const getLocales:
-      | (() => Array<{
+    if (typeof require === 'function') {
+      // expo-localization is only available on native targets. Requiring it in
+      // non-native environments (tests, SSR) throws, so we guard it.
+
+      const localization = require('expo-localization') as {
+        getLocales?: () => Array<{
           languageCode?: string;
           languageTag?: string;
-        }>)
-      | undefined = localization?.getLocales;
-    if (typeof getLocales === 'function') {
-      const locales = getLocales();
-      if (Array.isArray(locales) && locales.length > 0) {
-        const primary = locales[0];
-        if (primary?.languageCode) {
-          return primary.languageCode;
-        }
-        if (primary?.languageTag) {
-          const [language] = primary.languageTag.split('-');
-          if (language) {
-            return language;
+        }>;
+      };
+      const getLocales = localization?.getLocales;
+      if (typeof getLocales === 'function') {
+        const locales = getLocales();
+        if (Array.isArray(locales) && locales.length > 0) {
+          const primary = locales[0];
+          if (primary?.languageCode) {
+            return primary.languageCode;
+          }
+          if (primary?.languageTag) {
+            const [language] = primary.languageTag.split('-');
+            if (language) {
+              return language;
+            }
           }
         }
       }

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,27 +1,96 @@
 import i18n from 'i18next';
-import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import { initReactI18next } from 'react-i18next';
 
-import en from './locales/en/common.json';
 import de from './locales/de/common.json';
+import en from './locales/en/common.json';
 
-// Simple native detector using Intl APIs
-const nativeDetector = {
-  type: 'languageDetector' as const,
+type DetectorPlugin = {
+  type: 'languageDetector';
+  init: () => void;
+  detect: () => string;
+  cacheUserLanguage: () => void;
+};
+
+const isBrowser =
+  typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  typeof window.navigator !== 'undefined';
+
+function detectFromNativeApis(): string {
+  try {
+    // expo-localization is only available on native targets. Requiring it in
+    // non-native environments (tests, SSR) throws, so we guard it.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- conditional native require
+    const localization = require('expo-localization');
+    const getLocales:
+      | (() => Array<{
+          languageCode?: string;
+          languageTag?: string;
+        }>)
+      | undefined = localization?.getLocales;
+    if (typeof getLocales === 'function') {
+      const locales = getLocales();
+      if (Array.isArray(locales) && locales.length > 0) {
+        const primary = locales[0];
+        if (primary?.languageCode) {
+          return primary.languageCode;
+        }
+        if (primary?.languageTag) {
+          const [language] = primary.languageTag.split('-');
+          if (language) {
+            return language;
+          }
+        }
+      }
+    }
+  } catch {
+    // expo-localization isn't available (e.g. jest or browser). Fall back to
+    // the Intl logic below.
+  }
+
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    const [language] = navigator.language.split('-');
+    if (language) {
+      return language;
+    }
+  }
+
+  if (typeof Intl !== 'undefined') {
+    const locale = Intl.DateTimeFormat().resolvedOptions().locale;
+    if (locale) {
+      const [language] = locale.split('-');
+      if (language) {
+        return language;
+      }
+    }
+  }
+
+  return 'en';
+}
+
+const nativeDetector: DetectorPlugin = {
+  type: 'languageDetector',
   init: () => {},
-  detect: () =>
-    Intl?.DateTimeFormat().resolvedOptions().locale.split('-')[0] ?? 'en',
+  detect: detectFromNativeApis,
   cacheUserLanguage: () => {},
 };
 
-const detector =
-  typeof window !== 'undefined' ? new LanguageDetector() : nativeDetector;
+const detector = isBrowser ? new LanguageDetector() : nativeDetector;
+
+const detectionConfig = isBrowser
+  ? {
+      order: ['htmlTag', 'navigator', 'querystring', 'cookie', 'localStorage'],
+    }
+  : undefined;
 
 void i18n
   .use(detector)
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
+    supportedLngs: ['en', 'de'],
+    compatibilityJSON: 'v3',
     resources: {
       en: { common: en },
       de: { common: de },
@@ -29,9 +98,7 @@ void i18n
     ns: ['common'],
     defaultNS: 'common',
     interpolation: { escapeValue: false },
-    detection: {
-      order: ['navigator', 'querystring', 'cookie', 'localStorage'],
-    },
+    detection: detectionConfig,
   });
 
 export default i18n;

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,0 +1,37 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+import en from './locales/en/common.json';
+import de from './locales/de/common.json';
+
+// Simple native detector using Intl APIs
+const nativeDetector = {
+  type: 'languageDetector' as const,
+  init: () => {},
+  detect: () =>
+    Intl?.DateTimeFormat().resolvedOptions().locale.split('-')[0] ?? 'en',
+  cacheUserLanguage: () => {},
+};
+
+const detector =
+  typeof window !== 'undefined' ? new LanguageDetector() : nativeDetector;
+
+void i18n
+  .use(detector)
+  .use(initReactI18next)
+  .init({
+    fallbackLng: 'en',
+    resources: {
+      en: { common: en },
+      de: { common: de },
+    },
+    ns: ['common'],
+    defaultNS: 'common',
+    interpolation: { escapeValue: false },
+    detection: {
+      order: ['navigator', 'querystring', 'cookie', 'localStorage'],
+    },
+  });
+
+export default i18n;

--- a/packages/i18n/src/locales/de/common.json
+++ b/packages/i18n/src/locales/de/common.json
@@ -18,7 +18,8 @@
     "get_rooms": "Räume abrufen",
     "back": "Zurück",
     "outgoing_message": "Ausgehende Nachricht",
-    "incoming_message": "Eingehende Nachricht"
+    "incoming_message": "Eingehende Nachricht",
+    "toggle_mock": "Mock umschalten"
   },
   "labels": {
     "archived": "Archiviert",
@@ -31,7 +32,8 @@
     "auto": "Auto",
     "your_name": "Dein Name",
     "profile_status_default": "Hey! Ich nutze Hum.",
-    "dev_bridge": "Dev Bridge"
+    "dev_bridge": "Dev Bridge",
+    "backend": "Backend"
   },
   "placeholders": {
     "search": "Suchen",

--- a/packages/i18n/src/locales/de/common.json
+++ b/packages/i18n/src/locales/de/common.json
@@ -1,0 +1,107 @@
+{
+  "nav": {
+    "chats": "Chats",
+    "lightning": "Lightning",
+    "settings": "Einstellungen"
+  },
+  "actions": {
+    "menu": "Menü",
+    "open_camera": "Kamera öffnen",
+    "video_call": "Videoanruf",
+    "voice_call": "Sprachanruf",
+    "more_options": "Weitere Optionen",
+    "add": "Hinzufügen",
+    "search": "Suchen",
+    "create_client": "Client erstellen",
+    "login": "Anmelden",
+    "is_authenticated": "Authentifiziert?",
+    "get_rooms": "Räume abrufen",
+    "back": "Zurück",
+    "outgoing_message": "Ausgehende Nachricht",
+    "incoming_message": "Eingehende Nachricht"
+  },
+  "labels": {
+    "archived": "Archiviert",
+    "message_input": "Nachrichteneingabe",
+    "avatar": "Avatar von {{name}}",
+    "profile": "Profil",
+    "theme": "Thema",
+    "light": "Hell",
+    "dark": "Dunkel",
+    "auto": "Auto",
+    "your_name": "Dein Name",
+    "profile_status_default": "Hey! Ich nutze Hum.",
+    "dev_bridge": "Dev Bridge"
+  },
+  "placeholders": {
+    "search": "Suchen",
+    "type_message": "Nachricht eingeben..."
+  },
+  "lightning": {
+    "hero": {
+      "title": "Lightning-Zahlungen",
+      "subtitle": "Schnelle, günstige Bitcoin-Zahlungen für alle"
+    },
+    "coming": {
+      "title": "Kommt bald",
+      "description": "Lightning-Zahlungen werden in einem zukünftigen Update verfügbar sein. Bleib dran für sofortige Bitcoin-Transaktionen!"
+    },
+    "why": {
+      "title": "Warum Lightning?",
+      "bullets": {
+        "instant": "Lightning-Netzwerk ermöglicht sofortige Bitcoin-Zahlungen",
+        "low_fees": "Sehr niedrige Gebühren, oft weniger als ein Cent",
+        "secure": "Auf der sicheren Bitcoin-Infrastruktur aufgebaut",
+        "micro": "Perfekt für Mikrotransaktionen und tägliche Zahlungen",
+        "global": "Globale Reichweite mit 24/7-Verfügbarkeit"
+      }
+    },
+    "beta": {
+      "title": "Frühen Zugriff erhalten",
+      "message": "Sei einer der Ersten, die Lightning-Zahlungen ausprobieren, sobald sie starten.",
+      "button": "Beta-Warteliste beitreten"
+    },
+    "features": {
+      "wallet": {
+        "title": "Lightning Wallet",
+        "description": "Verwalte dein Lightning-Bitcoin-Guthaben und tätige sofortige Zahlungen"
+      },
+      "send_receive": {
+        "title": "Senden & Empfangen",
+        "description": "Scanne QR-Codes oder teile Zahlungslinks, um sofort Geld zu senden"
+      },
+      "history": {
+        "title": "Transaktionsverlauf",
+        "description": "Sieh dir deinen gesamten Lightning-Zahlungsverlauf und Quittungen an"
+      },
+      "methods": {
+        "title": "Zahlungsmethoden",
+        "description": "Verbinde dein Bankkonto oder deine Debitkarte, um dein Wallet aufzuladen"
+      },
+      "settlements": {
+        "title": "Sofortige Abrechnung",
+        "description": "Begleiche Zahlungen in Millisekunden mit geringen Gebühren"
+      },
+      "multicurrency": {
+        "title": "Multiwährungsunterstützung",
+        "description": "Unterstützung für Bitcoin, Sats und andere Lightning-Währungen"
+      },
+      "invoice": {
+        "title": "Rechnungsstellung",
+        "description": "Erstelle und teile Zahlungsrechnungen mit individuellen Beträgen"
+      },
+      "routing": {
+        "title": "Zahlungsrouting",
+        "description": "Automatisches Routing durch das Lightning-Netzwerk für optimale Gebühren"
+      },
+      "channel": {
+        "title": "Kanalverwaltung",
+        "description": "Öffne und verwalte Lightning-Kanäle für bessere Liquidität"
+      },
+      "backup": {
+        "title": "Backup & Wiederherstellung",
+        "description": "Sichere Backup- und Wiederherstellungsoptionen für dein Lightning-Wallet"
+      }
+    }
+  }
+}

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -16,7 +16,7 @@
     "login": "Login",
     "is_authenticated": "Is Authenticated?",
     "get_rooms": "Get Rooms",
-    "back": "Back",
+    "back": "Go back",
     "outgoing_message": "Outgoing message",
     "incoming_message": "Incoming message"
   },

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -1,0 +1,107 @@
+{
+  "nav": {
+    "chats": "Chats",
+    "lightning": "Lightning",
+    "settings": "Settings"
+  },
+  "actions": {
+    "menu": "Menu",
+    "open_camera": "Open camera",
+    "video_call": "Video call",
+    "voice_call": "Voice call",
+    "more_options": "More options",
+    "add": "Add",
+    "search": "Search",
+    "create_client": "Create Client",
+    "login": "Login",
+    "is_authenticated": "Is Authenticated?",
+    "get_rooms": "Get Rooms",
+    "back": "Back",
+    "outgoing_message": "Outgoing message",
+    "incoming_message": "Incoming message"
+  },
+  "labels": {
+    "archived": "Archived",
+    "message_input": "Message input",
+    "avatar": "{{name}} avatar",
+    "profile": "Profile",
+    "theme": "Theme",
+    "light": "Light",
+    "dark": "Dark",
+    "auto": "Auto",
+    "your_name": "Your Name",
+    "profile_status_default": "Hey there! I am using Hum.",
+    "dev_bridge": "Dev Bridge"
+  },
+  "placeholders": {
+    "search": "Search",
+    "type_message": "Type a message..."
+  },
+  "lightning": {
+    "hero": {
+      "title": "Lightning Payments",
+      "subtitle": "Fast, cheap Bitcoin payments for everyone"
+    },
+    "coming": {
+      "title": "Coming Soon",
+      "description": "Lightning payments will be available in a future update. Stay tuned for instant Bitcoin transactions!"
+    },
+    "why": {
+      "title": "Why Lightning?",
+      "bullets": {
+        "instant": "Lightning Network enables instant Bitcoin payments",
+        "low_fees": "Extremely low fees, often less than a penny",
+        "secure": "Built on Bitcoin's secure infrastructure",
+        "micro": "Perfect for microtransactions and everyday payments",
+        "global": "Global reach with 24/7 availability"
+      }
+    },
+    "beta": {
+      "title": "Get Early Access",
+      "message": "Be among the first to try Lightning payments when they launch.",
+      "button": "Join Beta Waitlist"
+    },
+    "features": {
+      "wallet": {
+        "title": "Lightning Wallet",
+        "description": "Manage your Lightning Bitcoin balance and make instant payments"
+      },
+      "send_receive": {
+        "title": "Send & Receive",
+        "description": "Scan QR codes or share payment links to send money instantly"
+      },
+      "history": {
+        "title": "Transaction History",
+        "description": "View all your Lightning payment history and receipts"
+      },
+      "methods": {
+        "title": "Payment Methods",
+        "description": "Connect your bank account or debit card to fund your wallet"
+      },
+      "settlements": {
+        "title": "Instant Settlements",
+        "description": "Settle payments in milliseconds with low fees"
+      },
+      "multicurrency": {
+        "title": "Multi-Currency Support",
+        "description": "Support for Bitcoin, sats, and other Lightning currencies"
+      },
+      "invoice": {
+        "title": "Invoice Generation",
+        "description": "Create and share payment invoices with custom amounts"
+      },
+      "routing": {
+        "title": "Payment Routing",
+        "description": "Automatic routing through the Lightning Network for optimal fees"
+      },
+      "channel": {
+        "title": "Channel Management",
+        "description": "Open and manage Lightning channels for better liquidity"
+      },
+      "backup": {
+        "title": "Backup & Recovery",
+        "description": "Secure backup and recovery options for your Lightning wallet"
+      }
+    }
+  }
+}

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -18,7 +18,8 @@
     "get_rooms": "Get Rooms",
     "back": "Go back",
     "outgoing_message": "Outgoing message",
-    "incoming_message": "Incoming message"
+    "incoming_message": "Incoming message",
+    "toggle_mock": "Toggle Mock"
   },
   "labels": {
     "archived": "Archived",
@@ -31,7 +32,8 @@
     "auto": "Auto",
     "your_name": "Your Name",
     "profile_status_default": "Hey there! I am using Hum.",
-    "dev_bridge": "Dev Bridge"
+    "dev_bridge": "Dev Bridge",
+    "backend": "Backend"
   },
   "placeholders": {
     "search": "Search",

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "lib": ["ES2022", "DOM"],
+    "types": ["react"],
+    "resolveJsonModule": true,
+    "typeRoots": ["../../node_modules/@types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist"]
+}

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -41,6 +41,7 @@
     "@types/react": "^19.1.12"
   },
   "dependencies": {
-    "@testing-library/jest-dom": "6.8.0"
+    "@testing-library/jest-dom": "6.8.0",
+    "react-i18next": "^13.2.2"
   }
 }

--- a/packages/ui-components/src/bottom-navigation.tsx
+++ b/packages/ui-components/src/bottom-navigation.tsx
@@ -4,6 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BottomNavItem } from './bottom-navigation-item';
 import { Icon } from './theme/icon';
 import { useTheme } from './theme/theme-provider';
+import { useTranslation } from 'react-i18next';
 
 export interface BottomNavigationProps {
   activeTab?: string;
@@ -18,16 +19,21 @@ export const BottomNavigation: React.FC<BottomNavigationProps> = ({
 }) => {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   const navItems = [
     {
       id: 'chats',
       icon: <Icon name="chat" />,
-      label: 'Chats',
+      label: t('nav.chats'),
       badgeCount: chatsBadgeCount,
     },
-    { id: 'lightning', icon: <Icon name="lightning" />, label: 'Lightning' },
-    { id: 'settings', icon: <Icon name="gear" />, label: 'Settings' },
+    {
+      id: 'lightning',
+      icon: <Icon name="lightning" />,
+      label: t('nav.lightning'),
+    },
+    { id: 'settings', icon: <Icon name="gear" />, label: t('nav.settings') },
   ];
 
   return (

--- a/packages/ui-components/src/message-bubble.tsx
+++ b/packages/ui-components/src/message-bubble.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTheme } from './theme/theme-provider';
+import { useTranslation } from 'react-i18next';
 
 export interface MessageBubbleProps {
   /** Message text */
@@ -22,6 +23,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   const { colors, spacing, radius, type } = useTheme();
   const dynamicStyles = { marginBottom: spacing.sm };
   const justifyStyle = isOutgoing ? styles.justifyEnd : styles.justifyStart;
+  const { t } = useTranslation();
 
   return (
     <View style={[styles.container, justifyStyle, dynamicStyles]}>
@@ -29,7 +31,9 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
         testID={isOutgoing ? 'outgoing-bubble' : 'incoming-bubble'}
         accessible
         accessibilityLabel={
-          isOutgoing ? 'Outgoing message' : 'Incoming message'
+          isOutgoing
+            ? t('actions.outgoing_message')
+            : t('actions.incoming_message')
         }
         style={[
           styles.bubble,

--- a/packages/ui-components/src/top-bar.tsx
+++ b/packages/ui-components/src/top-bar.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, Pressable, TextInput } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from './theme/theme-provider';
 import { Icon, type IconName } from './theme/icon';
+import { useTranslation } from 'react-i18next';
 
 export type TopBarItem =
   | {
@@ -46,13 +47,15 @@ export const TopBar: React.FC<TopBarProps> = ({
   rightItems = [],
   testID,
   showSearch = false,
-  searchPlaceholder = 'Search',
+  searchPlaceholder,
   searchValue,
   onChangeSearch,
   onSubmitSearch,
 }) => {
   const { colors, spacing, type, radius } = useTheme();
   const insets = useSafeAreaInsets();
+  const { t } = useTranslation();
+  const placeholder = searchPlaceholder ?? t('placeholders.search');
 
   const renderItem = (item: TopBarItem, index: number) => {
     const commonTest = item.testID
@@ -116,7 +119,7 @@ export const TopBar: React.FC<TopBarProps> = ({
             <Pressable
               onPress={onBackPress}
               accessibilityRole={onBackPress ? 'button' : undefined}
-              accessibilityLabel="Go back"
+              accessibilityLabel={t('actions.back')}
               hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
               style={leftItems.length ? { marginRight: spacing.md } : undefined}
               testID="back-button"
@@ -184,7 +187,7 @@ export const TopBar: React.FC<TopBarProps> = ({
             <TextInput
               testID="topbar-search-input"
               {...{ 'data-testid': 'topbar-search-input' }}
-              placeholder={searchPlaceholder}
+              placeholder={placeholder}
               placeholderTextColor={colors.mutedForeground}
               value={searchValue}
               onChangeText={onChangeSearch}

--- a/packages/ui-screens/jest.setup.ts
+++ b/packages/ui-screens/jest.setup.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom';
+import '@hum/i18n';

--- a/packages/ui-screens/package.json
+++ b/packages/ui-screens/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@hum/ui-components": "file:../ui-components",
-    "@testing-library/jest-dom": "6.8.0"
+    "@testing-library/jest-dom": "6.8.0",
+    "react-i18next": "^13.2.2"
   }
 }

--- a/packages/ui-screens/src/ChatScreen.tsx
+++ b/packages/ui-screens/src/ChatScreen.tsx
@@ -11,6 +11,7 @@ import {
   TopBar,
   ContactInline,
 } from '@hum/ui-components';
+import { useTranslation } from 'react-i18next';
 
 export interface ChatMessage extends MessageBubbleProps {
   id: string;
@@ -32,6 +33,7 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
   const { colors, spacing, radius } = useTheme();
   const insets = useSafeAreaInsets();
   const [value, setValue] = useState('');
+  const { t } = useTranslation();
 
   return (
     <View
@@ -50,7 +52,7 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
               <Avatar size={40}>
                 <AvatarImage
                   source={{ uri: chatAvatar }}
-                  accessibilityLabel={`${chatName} avatar`}
+                  accessibilityLabel={t('labels.avatar', { name: chatName })}
                 />
               </Avatar>
             ),
@@ -62,19 +64,19 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
             type: 'icon',
             name: 'camera-video',
             onPress: () => {},
-            a11yLabel: 'Video call',
+            a11yLabel: t('actions.video_call'),
           },
           {
             type: 'icon',
             name: 'telephone',
             onPress: () => {},
-            a11yLabel: 'Voice call',
+            a11yLabel: t('actions.voice_call'),
           },
           {
             type: 'text',
             label: '⋮',
             onPress: () => {},
-            a11yLabel: 'More options',
+            a11yLabel: t('actions.more_options'),
           },
         ]}
       />
@@ -129,12 +131,12 @@ export const ChatScreen: React.FC<ChatScreenProps> = ({
           >
             <TextInput
               style={[styles.textInput, { color: colors.foreground }]}
-              placeholder="Type a message..."
+              placeholder={t('placeholders.type_message')}
               placeholderTextColor={colors.mutedForeground}
               value={value}
               onChangeText={setValue}
               accessible
-              accessibilityLabel="Message input"
+              accessibilityLabel={t('labels.message_input')}
             />
             <Icon name="emoji-smile" size={20} color={colors.mutedForeground} />
           </View>

--- a/packages/ui-screens/src/ChatsScreen.test.tsx
+++ b/packages/ui-screens/src/ChatsScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react-native';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-native/extend-expect';
 import { ChatsScreen, type ChatsScreenProps } from './ChatsScreen';
 import { ThemeProvider } from '@hum/ui-components';
 

--- a/packages/ui-screens/src/ChatsScreen.tsx
+++ b/packages/ui-screens/src/ChatsScreen.tsx
@@ -9,6 +9,7 @@ import {
   TopBar,
   ChatItem,
 } from '@hum/ui-components';
+import { useTranslation } from 'react-i18next';
 
 export interface Chat {
   id: string;
@@ -58,6 +59,7 @@ const ChatsScreenInner: React.FC<InnerProps> = ({
   const { colors, spacing } = useTheme();
   const insets = useSafeAreaInsets();
   const [query, setQuery] = React.useState<string>('');
+  const { t } = useTranslation();
 
   const renderItem: ListRenderItem<Chat> = ({ item }) => (
     <ChatItem
@@ -85,20 +87,25 @@ const ChatsScreenInner: React.FC<InnerProps> = ({
       ]}
     >
       <TopBar
-        title="Chats"
+        title={t('nav.chats')}
         leftItems={[
-          { type: 'text', label: '⋯', onPress: () => {}, a11yLabel: 'Menu' },
+          {
+            type: 'text',
+            label: '⋯',
+            onPress: () => {},
+            a11yLabel: t('actions.menu'),
+          },
         ]}
         rightItems={[
           {
             type: 'icon',
             name: 'camera',
             onPress: () => {},
-            a11yLabel: 'Open camera',
+            a11yLabel: t('actions.open_camera'),
           },
         ]}
         showSearch={showSearch}
-        searchPlaceholder="Search"
+        searchPlaceholder={t('placeholders.search')}
         searchValue={query}
         onChangeSearch={setQuery}
         onSubmitSearch={() => {}}
@@ -106,8 +113,8 @@ const ChatsScreenInner: React.FC<InnerProps> = ({
 
       <ListRow
         icon={<Icon name="archive" size={24} color={colors.mutedForeground} />}
-        label="Archiviert"
-        rightText="5"
+        label={t('labels.archived')}
+        rightText={String(5)}
         onPress={() => {}}
       />
 
@@ -120,7 +127,7 @@ const ChatsScreenInner: React.FC<InnerProps> = ({
 
       <Button
         size="icon"
-        accessibilityLabel="Add"
+        accessibilityLabel={t('actions.add')}
         style={[
           styles.fab,
           {

--- a/packages/ui-screens/src/LightningScreen.tsx
+++ b/packages/ui-screens/src/LightningScreen.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   TopBar,
 } from '@hum/ui-components';
+import { useTranslation } from 'react-i18next';
 
 export interface LightningScreenProps {
   onBack?: () => void;
@@ -16,64 +17,50 @@ export interface LightningScreenProps {
 export const LightningScreen: React.FC<LightningScreenProps> = ({ onBack }) => {
   const { colors, spacing, type, radius } = useTheme();
   const insets = useSafeAreaInsets();
+  const { t } = useTranslation();
   const iconColor = colors.humPrimaryForeground;
   const heroSize = spacing.xl * 4;
 
   const features = [
     {
       icon: <Icon name="wallet" size={24} color={iconColor} />,
-      title: 'Lightning Wallet',
-      description:
-        'Manage your Lightning Bitcoin balance and make instant payments',
+      key: 'lightning.features.wallet',
     },
     {
       icon: <Icon name="qr-code" size={24} color={iconColor} />,
-      title: 'Send & Receive',
-      description:
-        'Scan QR codes or share payment links to send money instantly',
+      key: 'lightning.features.send_receive',
     },
     {
       icon: <Icon name="clock" size={24} color={iconColor} />,
-      title: 'Transaction History',
-      description: 'View all your Lightning payment history and receipts',
+      key: 'lightning.features.history',
     },
     {
       icon: <Icon name="credit-card" size={24} color={iconColor} />,
-      title: 'Payment Methods',
-      description:
-        'Connect your bank account or debit card to fund your wallet',
+      key: 'lightning.features.methods',
     },
     {
       icon: <Icon name="lightning" size={24} color={iconColor} />,
-      title: 'Instant Settlements',
-      description: 'Settle payments in milliseconds with low fees',
+      key: 'lightning.features.settlements',
     },
     {
       icon: <Icon name="arrow-left-right" size={24} color={iconColor} />,
-      title: 'Multi-Currency Support',
-      description: 'Support for Bitcoin, sats, and other Lightning currencies',
+      key: 'lightning.features.multicurrency',
     },
     {
       icon: <Icon name="receipt" size={24} color={iconColor} />,
-      title: 'Invoice Generation',
-      description: 'Create and share payment invoices with custom amounts',
+      key: 'lightning.features.invoice',
     },
     {
       icon: <Icon name="compass" size={24} color={iconColor} />,
-      title: 'Payment Routing',
-      description:
-        'Automatic routing through the Lightning Network for optimal fees',
+      key: 'lightning.features.routing',
     },
     {
       icon: <Icon name="broadcast" size={24} color={iconColor} />,
-      title: 'Channel Management',
-      description: 'Open and manage Lightning channels for better liquidity',
+      key: 'lightning.features.channel',
     },
     {
       icon: <Icon name="save" size={24} color={iconColor} />,
-      title: 'Backup & Recovery',
-      description:
-        'Secure backup and recovery options for your Lightning wallet',
+      key: 'lightning.features.backup',
     },
   ];
 
@@ -88,7 +75,7 @@ export const LightningScreen: React.FC<LightningScreenProps> = ({ onBack }) => {
       <TopBar
         backButton={!!onBack}
         onBackPress={onBack}
-        title="Lightning"
+        title={t('nav.lightning')}
         titleIconName="lightning"
       />
 
@@ -122,12 +109,12 @@ export const LightningScreen: React.FC<LightningScreenProps> = ({ onBack }) => {
                 marginBottom: spacing.sm,
               }}
             >
-              Lightning Payments
+              {t('lightning.hero.title')}
             </Text>
             <Text
               style={{ color: colors.mutedForeground, fontSize: type.size.sm }}
             >
-              Fast, cheap Bitcoin payments for everyone
+              {t('lightning.hero.subtitle')}
             </Text>
           </View>
 
@@ -136,11 +123,11 @@ export const LightningScreen: React.FC<LightningScreenProps> = ({ onBack }) => {
               marginBottom: idx === features.length - 1 ? 0 : spacing.lg,
             };
             return (
-              <View key={f.title} style={[styles.cardWrapper, wrapperStyle]}>
+              <View key={f.key} style={[styles.cardWrapper, wrapperStyle]}>
                 <FeatureCard
                   icon={f.icon}
-                  title={f.title}
-                  description={f.description}
+                  title={t(`${f.key}.title`)}
+                  description={t(`${f.key}.description`)}
                 />
               </View>
             );
@@ -166,13 +153,12 @@ export const LightningScreen: React.FC<LightningScreenProps> = ({ onBack }) => {
                 marginBottom: spacing.sm,
               }}
             >
-              Coming Soon
+              {t('lightning.coming.title')}
             </Text>
             <Text
               style={{ color: colors.mutedForeground, fontSize: type.size.sm }}
             >
-              Lightning payments will be available in a future update. Stay
-              tuned for instant Bitcoin transactions!
+              {t('lightning.coming.description')}
             </Text>
           </View>
 
@@ -196,49 +182,27 @@ export const LightningScreen: React.FC<LightningScreenProps> = ({ onBack }) => {
                 marginBottom: spacing.md,
               }}
             >
-              Why Lightning?
+              {t('lightning.why.title')}
             </Text>
             <View style={{ gap: spacing.sm }}>
-              <Text
-                style={{
-                  color: colors.mutedForeground,
-                  fontSize: type.size.sm,
-                }}
-              >
-                • Lightning Network enables instant Bitcoin payments
-              </Text>
-              <Text
-                style={{
-                  color: colors.mutedForeground,
-                  fontSize: type.size.sm,
-                }}
-              >
-                • Extremely low fees, often less than a penny
-              </Text>
-              <Text
-                style={{
-                  color: colors.mutedForeground,
-                  fontSize: type.size.sm,
-                }}
-              >
-                • Built on Bitcoin&apos;s secure infrastructure
-              </Text>
-              <Text
-                style={{
-                  color: colors.mutedForeground,
-                  fontSize: type.size.sm,
-                }}
-              >
-                • Perfect for microtransactions and everyday payments
-              </Text>
-              <Text
-                style={{
-                  color: colors.mutedForeground,
-                  fontSize: type.size.sm,
-                }}
-              >
-                • Global reach with 24/7 availability
-              </Text>
+              {[
+                t('lightning.why.bullets.instant'),
+                t('lightning.why.bullets.low_fees'),
+                t('lightning.why.bullets.secure'),
+                t('lightning.why.bullets.micro'),
+                t('lightning.why.bullets.global'),
+              ].map((b) => (
+                <Text
+                  key={b}
+                  style={{
+                    color: colors.mutedForeground,
+                    fontSize: type.size.sm,
+                  }}
+                >
+                  {'• '}
+                  {b}
+                </Text>
+              ))}
             </View>
           </View>
 
@@ -256,7 +220,7 @@ export const LightningScreen: React.FC<LightningScreenProps> = ({ onBack }) => {
                 marginBottom: spacing.sm,
               }}
             >
-              Get Early Access
+              {t('lightning.beta.title')}
             </Text>
             <Text
               style={[
@@ -268,10 +232,10 @@ export const LightningScreen: React.FC<LightningScreenProps> = ({ onBack }) => {
                 },
               ]}
             >
-              Be among the first to try Lightning payments when they launch.
+              {t('lightning.beta.message')}
             </Text>
-            <Button accessibilityLabel="Join beta waitlist">
-              <Text>Join Beta Waitlist</Text>
+            <Button accessibilityLabel={t('lightning.beta.button')}>
+              <Text>{t('lightning.beta.button')}</Text>
             </Button>
           </View>
         </View>

--- a/packages/ui-screens/src/SettingsScreen.tsx
+++ b/packages/ui-screens/src/SettingsScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme, Icon, TopBar } from '@hum/ui-components';
+import { useTranslation } from 'react-i18next';
 
 export interface SettingsScreenProps {
   onBack?: () => void;
@@ -21,13 +22,16 @@ export interface SettingsScreenProps {
 export const SettingsScreen: React.FC<SettingsScreenProps> = ({
   onBack,
   children,
-  profileName = 'Your Name',
-  profileStatus = 'Hey there! I am using Hum.',
+  profileName,
+  profileStatus,
   profileImageUri = 'https://picsum.photos/200/200',
 }) => {
   const { colors, spacing, radius, type } = useTheme();
   const insets = useSafeAreaInsets();
   const [search, setSearch] = React.useState('');
+  const { t } = useTranslation();
+  const pName = profileName ?? t('labels.your_name');
+  const pStatus = profileStatus ?? t('labels.profile_status_default');
 
   return (
     <View
@@ -36,7 +40,11 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
         { backgroundColor: colors.background, paddingBottom: insets.bottom },
       ]}
     >
-      <TopBar backButton={!!onBack} onBackPress={onBack} title="Settings" />
+      <TopBar
+        backButton={!!onBack}
+        onBackPress={onBack}
+        title={t('nav.settings')}
+      />
 
       <ScrollView
         style={styles.scroll}
@@ -62,7 +70,7 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
             <TextInput
               value={search}
               onChangeText={setSearch}
-              placeholder="Search"
+              placeholder={t('placeholders.search')}
               placeholderTextColor={colors.mutedForeground}
               style={[
                 styles.searchInput,
@@ -72,7 +80,7 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
                   paddingVertical: spacing.sm,
                 },
               ]}
-              accessibilityLabel="Search"
+              accessibilityLabel={t('actions.search')}
               accessibilityRole="search"
             />
           </View>
@@ -89,7 +97,7 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
               <Image
                 source={{ uri: profileImageUri }}
                 style={styles.profileImage}
-                accessibilityLabel="Profile"
+                accessibilityLabel={t('labels.profile')}
               />
               <View style={{ marginLeft: spacing.md }}>
                 <Text
@@ -99,7 +107,7 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
                     fontWeight: type.weight.medium,
                   }}
                 >
-                  {profileName}
+                  {pName}
                 </Text>
                 <Text
                   style={{
@@ -107,7 +115,7 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
                     fontSize: type.size.sm,
                   }}
                 >
-                  {profileStatus}
+                  {pStatus}
                 </Text>
               </View>
             </View>

--- a/scripts/gen-build-info.cjs
+++ b/scripts/gen-build-info.cjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 /* eslint-env node */
 
-/* eslint-disable no-undef */
 const path = require('path');
 const fs = require('fs');
 const {

--- a/scripts/i18n-missing.cjs
+++ b/scripts/i18n-missing.cjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const enPath = path.join(
+  __dirname,
+  '..',
+  'packages',
+  'i18n',
+  'src',
+  'locales',
+  'en',
+  'common.json',
+);
+const dePath = path.join(
+  __dirname,
+  '..',
+  'packages',
+  'i18n',
+  'src',
+  'locales',
+  'de',
+  'common.json',
+);
+
+const en = JSON.parse(fs.readFileSync(enPath, 'utf8'));
+const de = JSON.parse(fs.readFileSync(dePath, 'utf8'));
+
+function collect(obj, prefix = '') {
+  return Object.entries(obj).flatMap(([k, v]) => {
+    const key = prefix ? `${prefix}.${k}` : k;
+    return typeof v === 'object' && !Array.isArray(v) ? collect(v, key) : key;
+  });
+}
+
+const enKeys = collect(en);
+const deKeys = collect(de);
+
+const missingInDe = enKeys.filter((k) => !deKeys.includes(k));
+const missingInEn = deKeys.filter((k) => !enKeys.includes(k));
+
+if (missingInDe.length || missingInEn.length) {
+  console.log('Missing translations:');
+  if (missingInDe.length) console.log('  de missing:', missingInDe.join(', '));
+  if (missingInEn.length) console.log('  en missing:', missingInEn.join(', '));
+  process.exit(1);
+} else {
+  console.log('All locales in sync');
+}

--- a/scripts/sync-version.cjs
+++ b/scripts/sync-version.cjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 /* eslint-env node */
 
-/* eslint-disable no-undef */
 const path = require('path');
 const {
   getLatestTag,

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,0 +1,3 @@
+import '@testing-library/jest-dom';
+import '@testing-library/jest-native/extend-expect';
+import '@hum/i18n';

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,3 +1,2 @@
 import '@testing-library/jest-dom';
-import '@testing-library/jest-native/extend-expect';
 import '@hum/i18n';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "module": "commonjs",
     "moduleResolution": "node",
     "strict": true,
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
+    "resolveJsonModule": true,
     "paths": {
       "@apps/*": ["apps/*/src"],
       "@packages/*": ["packages/*/src"],


### PR DESCRIPTION
## Summary
- add reusable i18n package with English and German resources
- wire translations into mobile app and UI components
- document how to extend locales and check for missing keys

## Testing
- `npm run i18n:missing`
- `npm run lint`
- `npm test` *(fails: toHaveStyle expectations and missing elements)*

------
https://chatgpt.com/codex/tasks/task_e_68c8059f2914832fa7a99caf2a511a12