### PR TITLE
Increase message bubble test coverage

### DIFF
--- a/packages/ui-components/src/message-bubble.test.tsx
+++ b/packages/ui-components/src/message-bubble.test.tsx
@@ -34,6 +34,11 @@ describe('MessageBubble', () => {
     expect(UNSAFE_getByProps({ children: '✓✓' })).toBeTruthy();
   });
 
+  it('hides read indicator when message is unread', () => {
+    const { queryByText } = renderBubble('light', { isRead: false });
+    expect(queryByText('✓✓')).toBeNull();
+  });
+
   it('applies theme colors', () => {
     const { getByLabelText, rerender } = renderBubble('light');
     expect(getByLabelText('Outgoing message')).toHaveStyle({
@@ -47,5 +52,26 @@ describe('MessageBubble', () => {
     expect(getByLabelText('Outgoing message')).toHaveStyle({
       backgroundColor: 'rgba(254,202,26,1.00)',
     });
+  });
+
+  it('renders incoming messages with correct styles and accessibility', () => {
+    const { getByLabelText } = renderBubble('light', {
+      isOutgoing: false,
+      isRead: false,
+    });
+
+    const bubble = getByLabelText('Incoming message');
+    expect(bubble).toBeTruthy();
+    expect(bubble).toHaveStyle({
+      backgroundColor: 'rgba(236,236,240,1.00)',
+    });
+    const messageText = bubble.findByProps({ children: baseProps.text });
+    expect(messageText.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ color: '#0A0A0A' })]),
+    );
+    const timeText = bubble.findByProps({ children: baseProps.time });
+    expect(timeText.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ color: '#717182' })]),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add tests covering unread outgoing message indicator
- verify incoming message bubble styling and accessibility to exercise alternate theme branches

## Testing
- npm test -- message-bubble --coverage

------
https://chatgpt.com/codex/tasks/task_e_68cc1fd42ea4832f8d462f1093f99780