### PR TITLE
test(ui-components): improve ListRow coverage

### DIFF
--- a/packages/ui-components/src/list-row.test.tsx
+++ b/packages/ui-components/src/list-row.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import renderer, { act } from 'react-test-renderer';
 
 import { ListRow, type ListRowProps } from './list-row';
 import { ThemeProvider } from './theme/theme-provider';
 import { Icon } from './theme/icon';
 import { colors } from './theme/colors';
+import { spacing } from './theme/spacing';
+import { type as typography } from './theme/typography';
 
 const baseProps: ListRowProps = {
   label: 'Archiviert',
@@ -31,7 +34,9 @@ describe('ListRow', () => {
   it('fires onPress when pressed', () => {
     const onPress = jest.fn();
     const { getByLabelText } = renderRow('light', { onPress });
-    fireEvent.press(getByLabelText('Archiviert'));
+    const pressable = getByLabelText('Archiviert');
+    expect(pressable.props.role).toBe('button');
+    fireEvent.press(pressable);
     expect(onPress).toHaveBeenCalled();
   });
 
@@ -48,5 +53,95 @@ describe('ListRow', () => {
     const darkStyle = UNSAFE_getByProps({ children: 'Archiviert' }).props
       .style as Record<string, unknown>;
     expect(darkStyle).toMatchObject({ color: colors.dark.foreground });
+  });
+
+  it('renders spacing and background colors based on press state', async () => {
+    let tree: ReturnType<typeof renderer.create> | undefined;
+    await act(async () => {
+      tree = renderer.create(
+        <ThemeProvider forcedScheme="light">
+          <ListRow {...baseProps} />
+        </ThemeProvider>,
+      );
+    });
+
+    const pressable = tree!.root.findByProps({
+      accessibilityLabel: 'Archiviert',
+    });
+    const styleFn = pressable.props.style as (state: {
+      pressed: boolean;
+    }) => Array<Record<string, unknown> | number>;
+
+    const unpressed = styleFn({ pressed: false });
+    expect(unpressed[1]).toMatchObject({
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      backgroundColor: 'transparent',
+    });
+
+    const pressed = styleFn({ pressed: true });
+    expect(pressed[1]).toMatchObject({
+      backgroundColor: colors.light.muted,
+    });
+
+    await act(async () => {
+      tree!.unmount();
+    });
+  });
+
+  it('omits optional elements when they are not provided', async () => {
+    let tree: ReturnType<typeof renderer.create> | undefined;
+    await act(async () => {
+      tree = renderer.create(
+        <ThemeProvider forcedScheme="light">
+          <ListRow label="Archiviert" />
+        </ThemeProvider>,
+      );
+    });
+
+    const pressable = tree!.root.findByProps({
+      accessibilityLabel: 'Archiviert',
+    });
+    const children = React.Children.toArray(pressable.props.children);
+    expect(children).toHaveLength(1);
+
+    const left = children[0] as React.ReactElement<{
+      children?: React.ReactNode;
+    }>;
+    const leftChildren = React.Children.toArray(left.props.children);
+    expect(leftChildren).toHaveLength(1);
+
+    await act(async () => {
+      tree!.unmount();
+    });
+  });
+
+  it('applies theme typography to the right text when provided', async () => {
+    let tree: ReturnType<typeof renderer.create> | undefined;
+    await act(async () => {
+      tree = renderer.create(
+        <ThemeProvider forcedScheme="light">
+          <ListRow {...baseProps} />
+        </ThemeProvider>,
+      );
+    });
+
+    const pressable = tree!.root.findByProps({
+      accessibilityLabel: 'Archiviert',
+    });
+    const children = React.Children.toArray(
+      pressable.props.children,
+    ) as React.ReactElement[];
+    const rightText = children[1] as React.ReactElement<{
+      style: Record<string, unknown>;
+    }>;
+    expect(rightText.props.style).toMatchObject({
+      color: colors.light.mutedForeground,
+      fontSize: typography.size.sm,
+    });
+
+    await act(async () => {
+      tree!.unmount();
+    });
   });
 });

--- a/packages/ui-components/src/list-row.test.tsx
+++ b/packages/ui-components/src/list-row.test.tsx
@@ -1,6 +1,31 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import renderer, { act } from 'react-test-renderer';
+
+const pressableStyles: Array<
+  (state: { pressed: boolean }) => Array<Record<string, unknown> | number>
+> = [];
+
+jest.mock('react-native', () => {
+  const actual =
+    jest.requireActual<typeof import('react-native')>('react-native');
+  type PressableProps = React.ComponentProps<typeof actual.Pressable>;
+
+  const CapturingPressable = React.forwardRef<unknown, PressableProps>(
+    ({ style, ...rest }, ref) => {
+      if (typeof style === 'function') {
+        pressableStyles.push(style);
+      }
+
+      return <actual.Pressable ref={ref} style={style} {...rest} />;
+    },
+  );
+  CapturingPressable.displayName = 'CapturingPressable';
+
+  return {
+    ...actual,
+    Pressable: CapturingPressable,
+  };
+});
 
 import { ListRow, type ListRowProps } from './list-row';
 import { ThemeProvider } from './theme/theme-provider';
@@ -26,6 +51,10 @@ function renderRow(scheme: Scheme = 'light', props?: Partial<ListRowProps>) {
 }
 
 describe('ListRow', () => {
+  beforeEach(() => {
+    pressableStyles.length = 0;
+  });
+
   it('renders and matches snapshot', () => {
     const { toJSON } = renderRow();
     expect(toJSON()).toMatchSnapshot();
@@ -55,22 +84,11 @@ describe('ListRow', () => {
     expect(darkStyle).toMatchObject({ color: colors.dark.foreground });
   });
 
-  it('renders spacing and background colors based on press state', async () => {
-    let tree: ReturnType<typeof renderer.create> | undefined;
-    await act(async () => {
-      tree = renderer.create(
-        <ThemeProvider forcedScheme="light">
-          <ListRow {...baseProps} />
-        </ThemeProvider>,
-      );
-    });
 
-    const pressable = tree!.root.findByProps({
-      accessibilityLabel: 'Archiviert',
-    });
-    const styleFn = pressable.props.style as (state: {
-      pressed: boolean;
-    }) => Array<Record<string, unknown> | number>;
+  it('renders spacing and background colors based on press state', () => {
+    renderRow();
+    expect(pressableStyles).toHaveLength(1);
+    const styleFn = pressableStyles[0]!;
 
     const unpressed = styleFn({ pressed: false });
     expect(unpressed[1]).toMatchObject({
@@ -83,25 +101,14 @@ describe('ListRow', () => {
     expect(pressed[1]).toMatchObject({
       backgroundColor: colors.light.muted,
     });
-
-    await act(async () => {
-      tree!.unmount();
-    });
   });
 
-  it('omits optional elements when they are not provided', async () => {
-    let tree: ReturnType<typeof renderer.create> | undefined;
-    await act(async () => {
-      tree = renderer.create(
-        <ThemeProvider forcedScheme="light">
-          <ListRow label="Archiviert" />
-        </ThemeProvider>,
-      );
+  it('omits optional elements when they are not provided', () => {
+    const { getByLabelText } = renderRow('light', {
+      icon: undefined,
+      rightText: undefined,
     });
-
-    const pressable = tree!.root.findByProps({
-      accessibilityLabel: 'Archiviert',
-    });
+    const pressable = getByLabelText('Archiviert');
     const children = React.Children.toArray(pressable.props.children);
     expect(children).toHaveLength(1);
 
@@ -110,25 +117,11 @@ describe('ListRow', () => {
     }>;
     const leftChildren = React.Children.toArray(left.props.children);
     expect(leftChildren).toHaveLength(1);
-
-    await act(async () => {
-      tree!.unmount();
-    });
   });
 
-  it('applies theme typography to the right text when provided', async () => {
-    let tree: ReturnType<typeof renderer.create> | undefined;
-    await act(async () => {
-      tree = renderer.create(
-        <ThemeProvider forcedScheme="light">
-          <ListRow {...baseProps} />
-        </ThemeProvider>,
-      );
-    });
-
-    const pressable = tree!.root.findByProps({
-      accessibilityLabel: 'Archiviert',
-    });
+  it('applies theme typography to the right text when provided', () => {
+    const { getByLabelText } = renderRow();
+    const pressable = getByLabelText('Archiviert');
     const children = React.Children.toArray(
       pressable.props.children,
     ) as React.ReactElement[];
@@ -138,10 +131,6 @@ describe('ListRow', () => {
     expect(rightText.props.style).toMatchObject({
       color: colors.light.mutedForeground,
       fontSize: typography.size.sm,
-    });
-
-    await act(async () => {
-      tree!.unmount();
     });
   });
 });


### PR DESCRIPTION
## Summary
- add focused tests for `ListRow` covering onPress accessibility role and theme-driven spacing/background styles
- verify optional icon/rightText branches and trailing typography using `react-test-renderer`

## Testing
- npm test -- list-row.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc1fd04780832fb017efad9d38c6d3