### PR TITLE
Increase ChatsScreen test coverage

### DIFF
--- a/packages/ui-screens/src/ChatsScreen.test.tsx
+++ b/packages/ui-screens/src/ChatsScreen.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { ChatsScreen, type ChatsScreenProps } from './ChatsScreen';
-import { ThemeProvider, OverlayProvider } from '@hum/ui-components';
+import * as UIComponents from '@hum/ui-components';
+import { ThemeProvider } from '@hum/ui-components';
 import * as RNNS from 'react-native';
+import { TextInput } from 'react-native';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
@@ -29,14 +31,24 @@ afterAll(() => {
 function renderScreen(props?: Partial<ChatsScreenProps>) {
   return render(
     <ThemeProvider forcedScheme="dark">
-      <OverlayProvider>
-        <ChatsScreen {...props} chats={props?.chats ?? []} />
-      </OverlayProvider>
+      <ChatsScreen {...props} chats={props?.chats ?? []} />
     </ThemeProvider>,
   );
 }
 
 describe('ChatsScreen', () => {
+  let useOverlaySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    useOverlaySpy = jest
+      .spyOn(UIComponents, 'useOverlay')
+      .mockReturnValue({ open: jest.fn(), close: jest.fn() });
+  });
+
+  afterEach(() => {
+    useOverlaySpy.mockRestore();
+  });
+
   it('renders top bar', () => {
     const { getByLabelText } = renderScreen();
     expect(getByLabelText('Menu')).toBeOnTheScreen();
@@ -48,5 +60,51 @@ describe('ChatsScreen', () => {
     fireEvent.press(getByLabelText('Menu'));
     fireEvent.press(getByLabelText('Open camera'));
     fireEvent.press(getByLabelText('Add'));
+  });
+
+  it('shows and updates the search input when enabled', () => {
+    const { UNSAFE_getByType } = renderScreen({ showSearch: true });
+    const searchInput = UNSAFE_getByType(TextInput);
+    expect(searchInput.props.value).toBe('');
+    fireEvent.changeText(searchInput, 'Boba Fett');
+    expect(UNSAFE_getByType(TextInput).props.value).toBe('Boba Fett');
+  });
+
+  it('renders chats and navigates when a chat is pressed', () => {
+    const onNavigate = jest.fn();
+    const chat = {
+      id: '1',
+      name: 'Leia Organa',
+      message: 'Help me, Obi-Wan Kenobi',
+      time: '08:00',
+      avatar: 'https://example.com/leia.png',
+      unreadCount: 3,
+    };
+    const { getByLabelText } = renderScreen({
+      onNavigateToChat: onNavigate,
+      chats: [chat],
+    });
+
+    expect(getByLabelText('Archived')).toBeOnTheScreen();
+    fireEvent.press(getByLabelText(`Chat with ${chat.name}`));
+    expect(onNavigate).toHaveBeenCalledWith(chat);
+  });
+
+  it('opens the new chat overlay from the floating action button', () => {
+    const open = jest.fn();
+    const close = jest.fn();
+    useOverlaySpy.mockReturnValue({
+      open,
+      close,
+    });
+
+    const { getByLabelText } = render(
+      <ThemeProvider forcedScheme="dark">
+        <ChatsScreen chats={[]} />
+      </ThemeProvider>,
+    );
+
+    fireEvent.press(getByLabelText('Add'));
+    expect(open).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- expand ChatsScreen test suite to exercise search interaction, chat navigation, and overlay launch logic
- mock overlay hook usage to isolate tests from provider behavior while keeping modal handling predictable

## Testing
- npm test -- --coverage packages/ui-screens/src/ChatsScreen.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc1fd8d7a8832f8bdb9a182fad95d2