### PR TITLE
test: cover push token placeholders

### DIFF
--- a/native/rust/crates/core/src/push.rs
+++ b/native/rust/crates/core/src/push.rs
@@ -18,3 +18,61 @@ impl HumClient {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ClientConfig;
+    use httpmock::prelude::*;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    async fn build_client() -> HumClient {
+        let dir = tempdir().unwrap();
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/_matrix/client/versions");
+            then.status(200)
+                .json_body(json!({ "versions": ["v1.8"], "unstable_features": {} }));
+        });
+
+        HumClient::new(ClientConfig::new(
+            server.base_url(),
+            dir.path().to_path_buf(),
+        ))
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn register_push_token_returns_placeholder_error() {
+        let client = build_client().await;
+        let err = client
+            .register_push_token("token", "ios")
+            .await
+            .expect_err("register should error");
+
+        match err {
+            HumError::Other(msg) => {
+                assert_eq!(msg, "register_push_token not implemented");
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unregister_push_token_returns_placeholder_error() {
+        let client = build_client().await;
+        let err = client
+            .unregister_push_token("token")
+            .await
+            .expect_err("unregister should error");
+
+        match err {
+            HumError::Other(msg) => {
+                assert_eq!(msg, "unregister_push_token not implemented");
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add async unit tests that exercise the push token registration helpers
- confirm the placeholder implementations currently return the expected errors

## Testing
- cargo test -p hum-matrix-core

------
https://chatgpt.com/codex/tasks/task_e_68cc1fb93ef0832f8fdfa6e223186cc8