### PR TITLE
test: increase coverage for HumError conversions

### DIFF
--- a/native/rust/crates/core/src/error.rs
+++ b/native/rust/crates/core/src/error.rs
@@ -71,4 +71,75 @@ mod tests {
             _ => panic!("wrong variant"),
         }
     }
+
+    #[test]
+    fn convert_matrix_sdk_error() {
+        let hum: HumError = matrix_sdk::Error::AuthenticationRequired.into();
+        match hum {
+            HumError::Matrix(inner) => match *inner {
+                matrix_sdk::Error::AuthenticationRequired => {}
+                _ => panic!("unexpected matrix error variant"),
+            },
+            _ => panic!("expected matrix error"),
+        }
+    }
+
+    #[test]
+    fn convert_client_build_error() {
+        let hum: HumError = matrix_sdk::ClientBuildError::MissingHomeserver.into();
+        match hum {
+            HumError::Other(msg) => {
+                assert_eq!(msg, "no homeserver or user ID was configured");
+            }
+            _ => panic!("expected stringified client build error"),
+        }
+    }
+
+    #[test]
+    fn convert_http_error() {
+        let hum: HumError = matrix_sdk::HttpError::NotClientRequest.into();
+        match hum {
+            HumError::Other(msg) => {
+                assert_eq!(msg, "the queried endpoint is not meant for clients");
+            }
+            _ => panic!("expected http error string"),
+        }
+    }
+
+    #[test]
+    fn convert_id_parse_error() {
+        let hum: HumError = matrix_sdk::IdParseError::MissingLeadingSigil.into();
+        match hum {
+            HumError::Other(msg) => {
+                assert_eq!(msg, "leading sigil is incorrect or missing");
+            }
+            _ => panic!("expected id parse error string"),
+        }
+    }
+
+    #[test]
+    fn convert_crypto_store_error() {
+        let hum: HumError = matrix_sdk::encryption::CryptoStoreError::AccountUnset.into();
+        match hum {
+            HumError::Other(msg) => {
+                assert!(msg.contains("can't save/load sessions"));
+            }
+            _ => panic!("expected crypto store error string"),
+        }
+    }
+
+    #[test]
+    fn convert_secret_storage_error() {
+        let hum: HumError =
+            matrix_sdk::encryption::secret_storage::SecretStorageError::MissingKeyInfo {
+                key_id: Some("key".to_owned()),
+            }
+            .into();
+        match hum {
+            HumError::Other(msg) => {
+                assert!(msg.contains("secret key could not have been found"));
+            }
+            _ => panic!("expected secret storage error string"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add unit tests covering HumError conversions from matrix-sdk and anyhow errors

## Testing
- cargo test -p hum-matrix-core

------
https://chatgpt.com/codex/tasks/task_e_68cc1fa8e860832f8500aafbaf841bff