### PR TITLE
test: expand HumClient coverage

### DIFF
--- a/native/rust/crates/core/src/client.rs
+++ b/native/rust/crates/core/src/client.rs
@@ -125,7 +125,43 @@ mod tests {
     use super::*;
     use httpmock::prelude::*;
     use serde_json::json;
+    use std::time::Duration;
     use tempfile::tempdir;
+    use tokio::time::sleep;
+
+    use matrix_sdk::{
+        SessionMeta, SessionTokens,
+        authentication::matrix::MatrixSession,
+        ruma::{device_id, user_id},
+    };
+
+    fn sample_session() -> MatrixSession {
+        MatrixSession {
+            meta: SessionMeta {
+                user_id: user_id!("@example:localhost").to_owned(),
+                device_id: device_id!("DEVICE").to_owned(),
+            },
+            tokens: SessionTokens {
+                access_token: "token".into(),
+                refresh_token: None,
+            },
+        }
+    }
+
+    async fn mocked_client() -> (MockServer, tempfile::TempDir, HumClient) {
+        let dir = tempdir().unwrap();
+
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/_matrix/client/versions");
+            then.status(200)
+                .json_body(json!({ "versions": ["v1.8"], "unstable_features": {} }));
+        });
+
+        let cfg = ClientConfig::new(server.base_url(), dir.path().to_path_buf());
+        let client = HumClient::new(cfg).await.unwrap();
+        (server, dir, client)
+    }
 
     #[tokio::test]
     async fn create_client() {
@@ -149,5 +185,153 @@ mod tests {
                 .contains(&server.base_url())
         );
         // Some SDK versions may not call /versions on build; skip strict assertion.
+    }
+
+    #[tokio::test]
+    async fn config_accessors_reflect_input() {
+        let (server, dir, client) = mocked_client().await;
+
+        assert_eq!(client.config().homeserver_url, server.base_url());
+        assert_eq!(client.config().store_path, dir.path());
+
+        let homeserver = client.inner().homeserver().clone();
+        let base_url = server.base_url();
+        let actual = homeserver.as_str().trim_end_matches('/');
+        let expected = base_url.trim_end_matches('/');
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn from_store_creates_equivalent_client() {
+        let dir = tempdir().unwrap();
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/_matrix/client/versions");
+            then.status(200)
+                .json_body(json!({ "versions": ["v1.8"], "unstable_features": {} }));
+        });
+
+        let store_path = dir.path().to_path_buf();
+        let client = HumClient::from_store(server.base_url(), store_path.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(client.config().homeserver_url, server.base_url());
+        assert_eq!(client.config().store_path, store_path);
+    }
+
+    #[tokio::test]
+    async fn session_restoration_updates_auth_state() {
+        let (_server, _dir, client) = mocked_client().await;
+
+        assert!(!client.is_authenticated());
+        assert!(!client.verify_recovery_ready().await.unwrap());
+
+        client
+            .inner()
+            .restore_session(sample_session())
+            .await
+            .unwrap();
+
+        assert!(client.is_authenticated());
+        assert!(client.verify_recovery_ready().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn export_recovery_key_returns_expected_error() {
+        let (_server, _dir, client) = mocked_client().await;
+
+        let err = client.export_recovery_key().await.unwrap_err();
+        match err {
+            HumError::Other(message) => {
+                assert!(message.contains("not implemented"));
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn sync_helpers_issue_requests() {
+        let dir = tempdir().unwrap();
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/_matrix/client/versions");
+            then.status(200)
+                .json_body(json!({ "versions": ["v1.8"], "unstable_features": {} }));
+        });
+
+        let sync_mock = server.mock(|when, then| {
+            when.method(GET).path("/_matrix/client/v3/sync");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "next_batch": "test",
+                    "rooms": { "join": {} },
+                    "presence": { "events": [] },
+                    "account_data": { "events": [] },
+                    "to_device": { "events": [] }
+                }));
+        });
+
+        let cfg = ClientConfig::new(server.base_url(), dir.path().to_path_buf());
+        let client = HumClient::new(cfg).await.unwrap();
+
+        client
+            .inner()
+            .restore_session(sample_session())
+            .await
+            .unwrap();
+
+        let sync_cfg = SyncConfig::new(false, Some(10));
+        client.sync_once(&sync_cfg).await.unwrap();
+        client.initial_sync().await.unwrap();
+
+        sync_mock.assert_hits(2);
+    }
+
+    #[tokio::test]
+    async fn start_and_stop_sync_loop_manage_task() {
+        let dir = tempdir().unwrap();
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/_matrix/client/versions");
+            then.status(200)
+                .json_body(json!({ "versions": ["v1.8"], "unstable_features": {} }));
+        });
+
+        let sync_mock = server.mock(|when, then| {
+            when.method(GET).path("/_matrix/client/v3/sync");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "next_batch": "token",
+                    "rooms": { "join": {} },
+                    "presence": { "events": [] },
+                    "account_data": { "events": [] },
+                    "to_device": { "events": [] }
+                }));
+        });
+
+        let cfg = ClientConfig::new(server.base_url(), dir.path().to_path_buf());
+        let client = HumClient::new(cfg).await.unwrap();
+        client
+            .inner()
+            .restore_session(sample_session())
+            .await
+            .unwrap();
+
+        let sync_cfg = SyncConfig::default();
+
+        client.start_sync_loop(&sync_cfg).await.unwrap();
+        sleep(Duration::from_millis(200)).await;
+        // Starting again should be a no-op when already running.
+        client.start_sync_loop(&sync_cfg).await.unwrap();
+
+        sleep(Duration::from_millis(100)).await;
+        client.stop_sync_loop().await.unwrap();
+        // Stopping again should also be a no-op.
+        client.stop_sync_loop().await.unwrap();
+
+        assert!(sync_mock.hits() > 0);
     }
 }


### PR DESCRIPTION
## Summary
- add helper utilities for constructing mock clients and sessions in HumClient tests
- cover configuration accessors, session restoration, sync helpers, and loop controls with new async tests
- assert export error path and ensure mock sync endpoints are exercised to raise coverage

## Testing
- cargo test -p hum-matrix-core

------
https://chatgpt.com/codex/tasks/task_e_68cc1fa56394832fb40092d258b97fc1