### PR TITLE
Increase MockClient test coverage

### DIFF
--- a/tests/MockClient.test.ts
+++ b/tests/MockClient.test.ts
@@ -1,6 +1,19 @@
+import { PresenceState } from '@hum/hum-matrix-native';
+
 import { MockClient } from '../apps/mobile/src/hum/MockClient';
 
 describe('MockClient', () => {
+  const BASE_TS = 1_700_000_000_000;
+  let nowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(() => {
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(BASE_TS);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('seeds multiple rooms with avatars and timelines', async () => {
     const c = new MockClient('hs', 'store');
     const rooms = await c.getRooms();
@@ -20,5 +33,115 @@ describe('MockClient', () => {
     msgs[0]!.body = 'changed';
     const fresh = await c.getMessages(sample.id);
     expect(fresh[0]!.body).not.toBe('changed');
+  });
+
+  it('tracks authentication state and presence', async () => {
+    const c = new MockClient('hs', 'store');
+
+    await expect(c.isAuthenticated()).resolves.toBe(false);
+
+    await c.login('user', 'pass');
+    await expect(c.isAuthenticated()).resolves.toBe(true);
+
+    await c.logout();
+    await expect(c.isAuthenticated()).resolves.toBe(false);
+
+    await c.setPresence(PresenceState.DoNotDisturb);
+    await expect(c.getPresence('me')).resolves.toBe(PresenceState.DoNotDisturb);
+    await expect(c.getPresence('@nobody:mock')).resolves.toBe(
+      PresenceState.Online,
+    );
+
+    await expect(c.searchUsers('alice')).resolves.toEqual([]);
+    await expect(c.getDevices()).resolves.toEqual([]);
+  });
+
+  it('appends outgoing messages and updates room summaries', async () => {
+    const c = new MockClient('hs', 'store');
+    const rooms = await c.getRooms();
+    expect(rooms.length).toBeGreaterThan(1);
+
+    const target = rooms[1] ?? rooms[0];
+
+    nowSpy.mockReturnValue(BASE_TS + 60_000);
+    await c.sendText(target.id, 'Hello there');
+
+    const timeline = await c.getMessages(target.id);
+    const last = timeline[timeline.length - 1]!;
+    expect(last.body).toBe('Hello there');
+    expect(last.isOutgoing).toBe(true);
+    expect(last.ts).toBe(BASE_TS + 60_000);
+
+    const updatedRooms = await c.getRooms();
+    expect(updatedRooms[0]!.id).toBe(target.id);
+    expect(updatedRooms[0]!.lastMessage).toBe('Hello there');
+    expect(updatedRooms[0]!.unreadCount).toBe(0);
+  });
+
+  it('creates rooms on demand when sending to unknown rooms', async () => {
+    const c = new MockClient('hs', 'store');
+    const newRoomId = '!brand-new:mock';
+
+    nowSpy.mockReturnValue(BASE_TS + 120_000);
+    await c.sendText(newRoomId, 'First!');
+
+    const rooms = await c.getRooms();
+    const created = rooms.find((room) => room.id === newRoomId);
+    expect(created).toBeDefined();
+    expect(created!.name).toBe(newRoomId);
+    expect(created!.lastMessage).toBe('First!');
+    expect(created!.lastMessageTs).toBe(BASE_TS + 120_000);
+
+    const msgs = await c.getMessages(newRoomId);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.isOutgoing).toBe(true);
+  });
+
+  it('creates, joins, and leaves rooms', async () => {
+    const c = new MockClient('hs', 'store');
+
+    nowSpy.mockReturnValue(BASE_TS + 240_000);
+    const id = await c.createRoom({ name: 'Test Room' });
+
+    const roomsAfterCreate = await c.getRooms();
+    const created = roomsAfterCreate.find((room) => room.id === id);
+    expect(created).toBeDefined();
+    expect(created!.name).toBe('Test Room');
+    expect(created!.lastMessage).toBe('');
+    expect(created!.avatarUrl).toContain('https://');
+
+    const timeline = await c.getMessages(id);
+    expect(timeline).toEqual([]);
+
+    await expect(c.joinRoom(id)).resolves.toBe(id);
+
+    await c.leaveRoom(id);
+    const roomsAfterLeave = await c.getRooms();
+    expect(roomsAfterLeave.some((room) => room.id === id)).toBe(false);
+    await expect(c.getMessages(id)).resolves.toEqual([]);
+  });
+
+  it('handles miscellaneous operations without throwing', async () => {
+    const c = new MockClient('hs', 'store');
+
+    await expect(
+      c.sendReaction('room', 'event', '👍'),
+    ).resolves.toBeUndefined();
+    await expect(c.redact('room', 'event')).resolves.toBeUndefined();
+    await expect(c.sendReadReceipt('room', 'event')).resolves.toBeUndefined();
+    await expect(c.setTyping('room', true, 5_000)).resolves.toBeUndefined();
+    await expect(c.startSyncLoop(10_000)).resolves.toBeUndefined();
+    await expect(c.stopSyncLoop()).resolves.toBeUndefined();
+    await expect(c.syncOnce(15_000)).resolves.toBeUndefined();
+    await expect(c.dispose()).resolves.toBeUndefined();
+    await expect(c.importRecoveryKey('key')).resolves.toBeUndefined();
+    await expect(c.renameDevice('device', 'name')).resolves.toBeUndefined();
+    await expect(c.deleteDevice('device')).resolves.toBeUndefined();
+
+    const upload = await c.uploadMedia(new Uint8Array([1, 2, 3]), 'image/png');
+    expect(upload).toBe('mxc://mock');
+    const download = await c.downloadMedia(upload);
+    expect(download).toBeInstanceOf(Uint8Array);
+    expect(download.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- extend MockClient unit tests to cover authentication, messaging, room management, and presence behaviors
- verify auxiliary client utilities such as media helpers and lifecycle no-ops

## Testing
- `npm test -- MockClient`


------
https://chatgpt.com/codex/tasks/task_e_68cc0c9b46e8832fa9613d02d4c01e84