### PR TITLE
test(ui-components): avoid react-test-renderer in ListRow tests

### DIFF
--- a/packages/ui-components/src/list-row.test.tsx
+++ b/packages/ui-components/src/list-row.test.tsx
@@ -1,10 +1,38 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 
+const pressableStyles: Array<
+  (state: { pressed: boolean }) => Array<Record<string, unknown> | number>
+> = [];
+
+jest.mock('react-native', () => {
+  const actual =
+    jest.requireActual<typeof import('react-native')>('react-native');
+  type PressableProps = React.ComponentProps<typeof actual.Pressable>;
+
+  const CapturingPressable = React.forwardRef<unknown, PressableProps>(
+    ({ style, ...rest }, ref) => {
+      if (typeof style === 'function') {
+        pressableStyles.push(style);
+      }
+
+      return <actual.Pressable ref={ref} style={style} {...rest} />;
+    },
+  );
+  CapturingPressable.displayName = 'CapturingPressable';
+
+  return {
+    ...actual,
+    Pressable: CapturingPressable,
+  };
+});
+
 import { ListRow, type ListRowProps } from './list-row';
 import { ThemeProvider } from './theme/theme-provider';
 import { Icon } from './theme/icon';
 import { colors } from './theme/colors';
+import { spacing } from './theme/spacing';
+import { type as typography } from './theme/typography';
 
 const baseProps: ListRowProps = {
   label: 'Archiviert',
@@ -23,6 +51,10 @@ function renderRow(scheme: Scheme = 'light', props?: Partial<ListRowProps>) {
 }
 
 describe('ListRow', () => {
+  beforeEach(() => {
+    pressableStyles.length = 0;
+  });
+
   it('renders and matches snapshot', () => {
     const { toJSON } = renderRow();
     expect(toJSON()).toMatchSnapshot();
@@ -31,7 +63,9 @@ describe('ListRow', () => {
   it('fires onPress when pressed', () => {
     const onPress = jest.fn();
     const { getByLabelText } = renderRow('light', { onPress });
-    fireEvent.press(getByLabelText('Archiviert'));
+    const pressable = getByLabelText('Archiviert');
+    expect(pressable.props.role).toBe('button');
+    fireEvent.press(pressable);
     expect(onPress).toHaveBeenCalled();
   });
 
@@ -48,5 +82,54 @@ describe('ListRow', () => {
     const darkStyle = UNSAFE_getByProps({ children: 'Archiviert' }).props
       .style as Record<string, unknown>;
     expect(darkStyle).toMatchObject({ color: colors.dark.foreground });
+  });
+
+  it('renders spacing and background colors based on press state', () => {
+    renderRow();
+    expect(pressableStyles).toHaveLength(1);
+    const styleFn = pressableStyles[0]!;
+
+    const unpressed = styleFn({ pressed: false });
+    expect(unpressed[1]).toMatchObject({
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      backgroundColor: 'transparent',
+    });
+
+    const pressed = styleFn({ pressed: true });
+    expect(pressed[1]).toMatchObject({
+      backgroundColor: colors.light.muted,
+    });
+  });
+
+  it('omits optional elements when they are not provided', () => {
+    const { getByLabelText } = renderRow('light', {
+      icon: undefined,
+      rightText: undefined,
+    });
+    const pressable = getByLabelText('Archiviert');
+    const children = React.Children.toArray(pressable.props.children);
+    expect(children).toHaveLength(1);
+
+    const left = children[0] as React.ReactElement<{
+      children?: React.ReactNode;
+    }>;
+    const leftChildren = React.Children.toArray(left.props.children);
+    expect(leftChildren).toHaveLength(1);
+  });
+
+  it('applies theme typography to the right text when provided', () => {
+    const { getByLabelText } = renderRow();
+    const pressable = getByLabelText('Archiviert');
+    const children = React.Children.toArray(
+      pressable.props.children,
+    ) as React.ReactElement[];
+    const rightText = children[1] as React.ReactElement<{
+      style: Record<string, unknown>;
+    }>;
+    expect(rightText.props.style).toMatchObject({
+      color: colors.light.mutedForeground,
+      fontSize: typography.size.sm,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- capture the ListRow pressable style function through a lightweight jest mock so tests can exercise pressed/unpressed branches without react-test-renderer
- refactor the ListRow spec to rely solely on @testing-library/react-native while still verifying theme spacing, typography, and optional children

## Testing
- npm test -- list-row.test.tsx
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc1fd04780832fb017efad9d38c6d3