### PR TITLE
feat: add top bar action for new chats

### DIFF
--- a/packages/ui-screens/src/ChatsScreen.test.tsx
+++ b/packages/ui-screens/src/ChatsScreen.test.tsx
@@ -53,6 +53,7 @@ describe('ChatsScreen', () => {
     const { getByLabelText } = renderScreen();
     expect(getByLabelText('Menu')).toBeOnTheScreen();
     expect(getByLabelText('Open camera')).toBeOnTheScreen();
+    expect(getByLabelText('Add')).toBeOnTheScreen();
   });
 
   it('smoke presses actions', () => {
@@ -90,7 +91,7 @@ describe('ChatsScreen', () => {
     expect(onNavigate).toHaveBeenCalledWith(chat);
   });
 
-  it('opens the new chat overlay from the floating action button', () => {
+  it('opens the new chat overlay from the top bar action', () => {
     const open = jest.fn();
     const close = jest.fn();
     useOverlaySpy.mockReturnValue({
@@ -98,11 +99,7 @@ describe('ChatsScreen', () => {
       close,
     });
 
-    const { getByLabelText } = render(
-      <ThemeProvider forcedScheme="dark">
-        <ChatsScreen chats={[]} />
-      </ThemeProvider>,
-    );
+    const { getByLabelText } = renderScreen({ chats: [] });
 
     fireEvent.press(getByLabelText('Add'));
     expect(open).toHaveBeenCalledTimes(1);

--- a/packages/ui-screens/src/ChatsScreen.tsx
+++ b/packages/ui-screens/src/ChatsScreen.tsx
@@ -57,7 +57,7 @@ const ChatsScreenInner: React.FC<InnerProps> = ({
   onNavigateToChat,
   showSearch,
 }) => {
-  const { colors, spacing, type } = useTheme();
+  const { colors, spacing } = useTheme();
   const insets = useSafeAreaInsets();
   const { open } = useOverlay();
   const [query, setQuery] = React.useState<string>('');

--- a/packages/ui-screens/src/ChatsScreen.tsx
+++ b/packages/ui-screens/src/ChatsScreen.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { View, Text, StyleSheet, FlatList, ListRenderItem } from 'react-native';
+import { View, StyleSheet, FlatList, ListRenderItem } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   useTheme,
-  Button,
   ListRow,
   Icon,
   TopBar,
@@ -106,6 +105,12 @@ const ChatsScreenInner: React.FC<InnerProps> = ({
             onPress: () => {},
             a11yLabel: t('actions.open_camera'),
           },
+          {
+            type: 'text',
+            label: '+',
+            onPress: () => open(<NewChatScreen />),
+            a11yLabel: t('actions.add'),
+          },
         ]}
         showSearch={showSearch}
         searchPlaceholder={t('placeholders.search')}
@@ -127,24 +132,6 @@ const ChatsScreenInner: React.FC<InnerProps> = ({
         renderItem={renderItem}
         contentContainerStyle={{ paddingBottom: spacing.xl * 4 }}
       />
-
-      <Button
-        size="icon"
-        accessibilityLabel={t('actions.add')}
-        style={[
-          styles.fab,
-          {
-            backgroundColor: colors.humPrimary,
-            right: spacing.lg,
-            bottom: spacing.lg + insets.bottom,
-          },
-        ]}
-        onPress={() => open(<NewChatScreen />)}
-      >
-        <Text style={[styles.plusText, { color: colors.humPrimaryForeground }]}>
-          +
-        </Text>
-      </Button>
     </View>
   );
 };
@@ -152,17 +139,6 @@ const ChatsScreenInner: React.FC<InnerProps> = ({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  fab: {
-    position: 'absolute',
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  plusText: {
-    fontSize: 24,
   },
 });
 


### PR DESCRIPTION
## Summary
- add a + action to the Chats top bar that opens the NewChat overlay
- remove the floating action button and adjust imports/styles accordingly
- update ChatsScreen tests to cover the new top bar control

## Testing
- npm test -- packages/ui-screens/src/ChatsScreen.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ce73fd25ec832f859dd1c6e9769268