### PR TITLE
feat: improve chat input bar usability

### DIFF
--- a/packages/ui-components/src/chat-input-bar.test.tsx
+++ b/packages/ui-components/src/chat-input-bar.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
+import { spacing } from './theme/spacing';
 import { ThemeProvider } from './theme/theme-provider';
 import { ChatInputBar } from './chat-input-bar';
 
@@ -27,6 +29,37 @@ describe('ChatInputBar', () => {
     fireEvent.changeText(getByLabelText('Message input'), 'Hello');
 
     expect(handleChange).toHaveBeenCalledWith('Hello');
+  });
+
+  it('uses a multiline text input that grows with content', () => {
+    const { getByLabelText } = renderComponent();
+    const minHeight = spacing.lg * 2;
+    const maxHeight = spacing.xl * 6;
+
+    const textInput = getByLabelText('Message input');
+
+    fireEvent(textInput, 'contentSizeChange', {
+      nativeEvent: { contentSize: { height: 10 } },
+    });
+
+    let flattened = StyleSheet.flatten(
+      getByLabelText('Message input').props.style,
+    );
+    const compactHeight =
+      typeof flattened.height === 'string'
+        ? parseFloat(flattened.height)
+        : flattened.height;
+    expect(compactHeight).toBe(minHeight);
+    fireEvent(textInput, 'contentSizeChange', {
+      nativeEvent: { contentSize: { height: 300 } },
+    });
+
+    flattened = StyleSheet.flatten(getByLabelText('Message input').props.style);
+    const expandedHeight =
+      typeof flattened.height === 'string'
+        ? parseFloat(flattened.height)
+        : flattened.height;
+    expect(expandedHeight).toBe(maxHeight);
   });
 
   it('invokes action handlers when provided', () => {

--- a/packages/ui-components/src/chat-input-bar.tsx
+++ b/packages/ui-components/src/chat-input-bar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { Icon } from './theme/icon';
 import { useTheme } from './theme/theme-provider';
@@ -33,6 +33,10 @@ export const ChatInputBar: React.FC<ChatInputBarProps> = ({
   micAccessibilityLabel,
 }) => {
   const { colors, spacing, radius } = useTheme();
+  const minInputHeight = spacing.lg * 2;
+  const maxInputHeight = spacing.xl * 6;
+  const [inputHeight, setInputHeight] = useState(minInputHeight);
+  const [isScrollable, setIsScrollable] = useState(false);
   const themedStyles = useMemo(
     () => ({
       container: {
@@ -51,9 +55,11 @@ export const ChatInputBar: React.FC<ChatInputBarProps> = ({
         borderRadius: radius.xl,
         paddingHorizontal: spacing.md,
         paddingVertical: spacing.xs,
+        overflow: 'hidden' as const,
       },
       textInput: {
         color: colors.foreground,
+        textAlignVertical: 'top' as const,
       },
       emojiButton: {
         marginLeft: spacing.xs,
@@ -73,6 +79,32 @@ export const ChatInputBar: React.FC<ChatInputBarProps> = ({
       spacing.xs,
     ],
   );
+
+  const handleContentSizeChange = useCallback(
+    (event: {
+      nativeEvent: {
+        contentSize: {
+          height: number;
+        };
+      };
+    }) => {
+      const contentHeight = event.nativeEvent.contentSize.height;
+      const clampedHeight = Math.min(
+        Math.max(contentHeight, minInputHeight),
+        maxInputHeight,
+      );
+      setInputHeight(clampedHeight);
+      setIsScrollable(contentHeight > maxInputHeight);
+    },
+    [maxInputHeight, minInputHeight],
+  );
+
+  useEffect(() => {
+    if (value.length === 0) {
+      setInputHeight(minInputHeight);
+      setIsScrollable(false);
+    }
+  }, [minInputHeight, value]);
 
   return (
     <View style={[styles.container, themedStyles.container]}>
@@ -101,13 +133,26 @@ export const ChatInputBar: React.FC<ChatInputBarProps> = ({
 
         <View style={[styles.textInputContainer, themedStyles.inputContainer]}>
           <TextInput
-            style={[styles.textInput, themedStyles.textInput]}
+            style={[
+              styles.textInput,
+              themedStyles.textInput,
+              {
+                minHeight: minInputHeight,
+                maxHeight: maxInputHeight,
+                height: inputHeight,
+              },
+            ]}
             placeholder={placeholder}
             placeholderTextColor={colors.mutedForeground}
             value={value}
             onChangeText={onChangeText}
             accessible
             accessibilityLabel={inputAccessibilityLabel}
+            multiline
+            onContentSizeChange={handleContentSizeChange}
+            scrollEnabled={isScrollable}
+            blurOnSubmit={false}
+            testID="chat-input-bar-text-input"
           />
           <Pressable
             accessibilityRole={onEmojiPress ? 'button' : undefined}


### PR DESCRIPTION
## Summary
- make the chat input multiline, auto-growing, and clamped to a maximum height for better ergonomics
- align the input text to the top, handle scrollability, and reset sizing when the value is cleared
- cover the dynamic sizing behaviour with dedicated unit tests

## Testing
- npm test -- packages/ui-components/src/chat-input-bar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ce73f86f40832f8d52b105e150144c