### PR TITLE
Add reusable slide transition and integrate into mobile app

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -6,6 +6,7 @@ import {
   BottomNavigation,
   ThemeProvider,
   OverlayProvider,
+  SlideTransition,
 } from '@hum/ui-components';
 import Constants from 'expo-constants';
 import {
@@ -26,6 +27,9 @@ import i18n from '@hum/i18n';
 function AppInner() {
   const [activeTab, setActiveTab] = useState('chats');
   const [selectedChat, setSelectedChat] = useState<Chat | null>(null);
+  const [chatTransitionDirection, setChatTransitionDirection] = useState<
+    'forward' | 'backward'
+  >('forward');
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const [showDev, setShowDev] = useState(false);
   const enableDev = useMemo(() => {
@@ -38,6 +42,8 @@ function AppInner() {
   }, []);
   const [theme, setTheme] = useState<'light' | 'dark' | 'auto'>('auto');
   const [settingsView, setSettingsView] = useState<'main' | 'theme'>('main');
+  const [settingsTransitionDirection, setSettingsTransitionDirection] =
+    useState<'forward' | 'backward'>('forward');
   const systemScheme = useColorScheme() ?? 'light';
   const resolvedScheme = theme === 'auto' ? systemScheme : theme;
   const { i18n: i18next } = useTranslation();
@@ -57,25 +63,52 @@ function AppInner() {
     };
   }, [selectedChat, getMessages]);
 
+  const handleNavigateToChat = (chat: Chat) => {
+    setChatTransitionDirection('forward');
+    setSelectedChat(chat);
+  };
+
+  const handleChatBack = () => {
+    setChatTransitionDirection('backward');
+    setSelectedChat(null);
+  };
+
+  const handleNavigateToTheme = () => {
+    setSettingsTransitionDirection('forward');
+    setSettingsView('theme');
+  };
+
+  const handleThemeBack = () => {
+    setSettingsTransitionDirection('backward');
+    setSettingsView('main');
+  };
+
   const renderCurrentScreen = () => {
     if (showDev) {
       return <DevNativeBridgeScreen onBack={() => setShowDev(false)} />;
     }
 
-    if (selectedChat) {
-      return (
-        <ChatScreen
-          chatName={selectedChat.name}
-          chatAvatar={selectedChat.avatar}
-          messages={chatMessages}
-          onBack={() => setSelectedChat(null)}
-        />
-      );
-    }
-
     switch (activeTab) {
       case 'chats':
-        return <ChatsFromProvider onNavigateToChat={setSelectedChat} />;
+        return (
+          <SlideTransition
+            activeKey={selectedChat ? 'chat' : 'list'}
+            direction={chatTransitionDirection}
+            scenes={{
+              list: (
+                <ChatsFromProvider onNavigateToChat={handleNavigateToChat} />
+              ),
+              chat: selectedChat ? (
+                <ChatScreen
+                  chatName={selectedChat.name}
+                  chatAvatar={selectedChat.avatar}
+                  messages={chatMessages}
+                  onBack={handleChatBack}
+                />
+              ) : null,
+            }}
+          />
+        );
       case 'calls':
         return <CallsScreen />;
       case 'payments':
@@ -83,16 +116,25 @@ function AppInner() {
         return <LightningScreen />;
       case 'settings':
       default:
-        return settingsView === 'theme' ? (
-          <ThemeSettingsScreen
-            theme={theme}
-            onBack={() => setSettingsView('main')}
-            onSelectTheme={setTheme}
-          />
-        ) : (
-          <MainSettingsScreen
-            theme={theme}
-            onNavigateToTheme={() => setSettingsView('theme')}
+        return (
+          <SlideTransition
+            activeKey={settingsView === 'theme' ? 'theme' : 'main'}
+            direction={settingsTransitionDirection}
+            scenes={{
+              main: (
+                <MainSettingsScreen
+                  theme={theme}
+                  onNavigateToTheme={handleNavigateToTheme}
+                />
+              ),
+              theme: (
+                <ThemeSettingsScreen
+                  theme={theme}
+                  onBack={handleThemeBack}
+                  onSelectTheme={setTheme}
+                />
+              ),
+            }}
           />
         );
     }

--- a/packages/ui-components/index.ts
+++ b/packages/ui-components/index.ts
@@ -19,6 +19,8 @@ export { SettingsItem } from './src/settings-item';
 export type { SettingsItemProps } from './src/settings-item';
 export { BottomNavigation } from './src/bottom-navigation';
 export type { BottomNavigationProps } from './src/bottom-navigation';
+export { SlideTransition } from './src/slide-transition';
+export type { SlideTransitionProps } from './src/slide-transition';
 export { ChatItem } from './src/chat-item';
 export type { ChatItemProps } from './src/chat-item';
 export { CallItem } from './src/call-item';

--- a/packages/ui-components/src/slide-transition.test.tsx
+++ b/packages/ui-components/src/slide-transition.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { View } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { SlideTransition } from './slide-transition';
+
+describe('SlideTransition', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const scenes = {
+    list: <View testID="scene-list" />,
+    detail: <View testID="scene-detail" />,
+  } as const;
+
+  it('renders the active scene without animating initially', () => {
+    const screen = render(
+      <SlideTransition
+        activeKey="list"
+        scenes={scenes}
+        testID="transition"
+        initialWidth={200}
+      />,
+    );
+
+    const staticView = screen.UNSAFE_root.findAllByProps({
+      testID: 'slide-transition-static',
+    })[0];
+    expect(staticView.props.children).toEqual(
+      expect.objectContaining({
+        props: expect.objectContaining({ testID: 'scene-list' }),
+      }),
+    );
+  });
+
+  it('keeps the previous scene visible while transitioning forward', () => {
+    const screen = render(
+      <SlideTransition
+        activeKey="list"
+        scenes={scenes}
+        direction="forward"
+        testID="transition"
+        initialWidth={200}
+      />,
+    );
+
+    screen.rerender(
+      <SlideTransition
+        activeKey="detail"
+        scenes={scenes}
+        direction="forward"
+        testID="transition"
+        initialWidth={200}
+      />,
+    );
+
+    jest.runAllTimers();
+
+    const findByScene = (id: string) =>
+      screen.UNSAFE_root.findAllByProps({ testID: id });
+    expect(findByScene('scene-list')).toHaveLength(0);
+    expect(findByScene('scene-detail')).toHaveLength(1);
+  });
+
+  it('keeps the previous scene visible while transitioning backward', () => {
+    const screen = render(
+      <SlideTransition
+        activeKey="detail"
+        scenes={scenes}
+        direction="forward"
+        testID="transition"
+        initialWidth={160}
+      />,
+    );
+
+    screen.rerender(
+      <SlideTransition
+        activeKey="list"
+        scenes={scenes}
+        direction="backward"
+        testID="transition"
+        initialWidth={160}
+      />,
+    );
+
+    jest.runAllTimers();
+
+    const findByScene = (id: string) =>
+      screen.UNSAFE_root.findAllByProps({ testID: id });
+    expect(findByScene('scene-detail')).toHaveLength(0);
+    expect(findByScene('scene-list')).toHaveLength(1);
+  });
+});

--- a/packages/ui-components/src/slide-transition.tsx
+++ b/packages/ui-components/src/slide-transition.tsx
@@ -1,0 +1,209 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Animated,
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+
+export type SlideDirection = 'forward' | 'backward';
+
+export interface SlideTransitionProps<K extends string = string> {
+  /**
+   * Key of the currently active scene.
+   */
+  activeKey: K;
+  /**
+   * Scenes to render for each key. The component re-renders the corresponding
+   * node whenever `scenes` changes, so the caller can pass freshly created
+   * elements each render.
+   */
+  scenes: Record<K, React.ReactNode>;
+  /**
+   * Direction of the transition. `forward` slides the next scene from the
+   * right, while `backward` slides it in from the left.
+   */
+  direction?: SlideDirection;
+  /**
+   * Duration of the slide animation in milliseconds.
+   */
+  duration?: number;
+  style?: StyleProp<ViewStyle>;
+  /**
+   * Optional test identifier applied to the container.
+   */
+  testID?: string;
+  /**
+   * Optional initial width used before the first layout event. Useful for tests.
+   */
+  initialWidth?: number;
+}
+
+const DEFAULT_DURATION = 220;
+
+export function SlideTransition<K extends string>({
+  activeKey,
+  scenes,
+  direction = 'forward',
+  duration = DEFAULT_DURATION,
+  style,
+  testID,
+  initialWidth = 0,
+}: SlideTransitionProps<K>) {
+  const animationProgress = useRef(new Animated.Value(0)).current;
+  const [containerWidth, setContainerWidth] = useState(initialWidth);
+  const [displayedKey, setDisplayedKey] = useState<K>(activeKey);
+  const [transitionKey, setTransitionKey] = useState<K | null>(null);
+  const [activeDirection, setActiveDirection] =
+    useState<SlideDirection>(direction);
+  const scenesRef = useRef(scenes);
+  if (scenesRef.current !== scenes) {
+    const mergedScenes: Record<K, React.ReactNode> = { ...scenesRef.current };
+    (Object.keys(scenes) as K[]).forEach((key) => {
+      const scene = scenes[key];
+      if (scene !== null && scene !== undefined) {
+        mergedScenes[key] = scene;
+      }
+    });
+    scenesRef.current = mergedScenes;
+  }
+
+  useEffect(() => {
+    if (activeKey === displayedKey) {
+      return;
+    }
+
+    if (containerWidth === 0) {
+      setDisplayedKey(activeKey);
+      setTransitionKey(null);
+      animationProgress.stopAnimation();
+      return;
+    }
+
+    animationProgress.stopAnimation();
+    animationProgress.setValue(0);
+    setActiveDirection(direction);
+    setTransitionKey(activeKey);
+
+    const animation = Animated.timing(animationProgress, {
+      toValue: 1,
+      duration,
+      useNativeDriver: true,
+    });
+
+    animation.start(({ finished }: { finished?: boolean }) => {
+      if (finished) {
+        setDisplayedKey(activeKey);
+        setTransitionKey(null);
+        animationProgress.setValue(0);
+      }
+    });
+
+    return () => {
+      animation.stop();
+    };
+  }, [
+    activeKey,
+    direction,
+    containerWidth,
+    animationProgress,
+    displayedKey,
+    duration,
+  ]);
+
+  type LayoutEvent = {
+    nativeEvent: {
+      layout: {
+        width: number;
+      };
+    };
+  };
+
+  const handleLayout = (event: LayoutEvent) => {
+    const width = Math.round(event.nativeEvent.layout.width);
+    if (width !== containerWidth) {
+      setContainerWidth(width);
+    }
+  };
+
+  const { currentScene, nextScene } = useMemo(() => {
+    const currentScene = scenesRef.current[displayedKey];
+    const nextScene = transitionKey ? scenesRef.current[transitionKey] : null;
+    return { currentScene, nextScene };
+  }, [displayedKey, transitionKey]);
+
+  const { currentStyles, nextStyles } = useMemo(() => {
+    if (!transitionKey || containerWidth === 0) {
+      return {
+        currentStyles: styles.absoluteFill,
+        nextStyles: styles.absoluteFill,
+      };
+    }
+
+    const offset = containerWidth;
+    const forward = activeDirection === 'forward';
+
+    const nextFrom = forward ? offset : -offset;
+    const currentTo = forward ? -offset : offset;
+
+    const nextTranslate = animationProgress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [nextFrom, 0],
+    });
+
+    const currentTranslate = animationProgress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, currentTo],
+    });
+
+    return {
+      currentStyles: [
+        styles.absoluteFill,
+        { transform: [{ translateX: currentTranslate }] },
+      ],
+      nextStyles: [
+        styles.absoluteFill,
+        { transform: [{ translateX: nextTranslate }] },
+      ],
+    };
+  }, [activeDirection, animationProgress, containerWidth, transitionKey]);
+
+  return (
+    <View
+      style={[styles.container, style]}
+      onLayout={handleLayout}
+      testID={testID}
+    >
+      {transitionKey ? (
+        <React.Fragment>
+          <Animated.View
+            testID="slide-transition-current"
+            style={currentStyles}
+          >
+            {currentScene}
+          </Animated.View>
+          <Animated.View testID="slide-transition-next" style={nextStyles}>
+            {nextScene}
+          </Animated.View>
+        </React.Fragment>
+      ) : (
+        <View testID="slide-transition-static" style={styles.absoluteFill}>
+          {currentScene}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    overflow: 'hidden',
+  },
+  absoluteFill: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});
+
+export default SlideTransition;

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -76,6 +76,13 @@ jest.mock('@hum/ui-components', () => {
       {children}
     </TouchableOpacity>
   );
+  const SlideTransition = ({
+    activeKey,
+    scenes,
+  }: {
+    activeKey: string;
+    scenes: Record<string, React.ReactNode>;
+  }) => <View testID={`slide-${activeKey}`}>{scenes[activeKey]}</View>;
   const BottomNavigation = ({
     onTabChange,
     activeTab,
@@ -111,6 +118,7 @@ jest.mock('@hum/ui-components', () => {
     ThemeProvider,
     OverlayProvider,
     Button,
+    SlideTransition,
     __themeState: themeState,
   };
 });


### PR DESCRIPTION
## Summary
- add a reusable SlideTransition component for animated scene swaps
- wrap the chat and settings flows in the mobile app with slide transitions
- update tests and mocks to cover the new transition behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce73f37304832f97a8beefc14f8278