### PR TITLE
Fix ActivatePaymentScreen build and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "native/*"
       ],
       "dependencies": {
+        "expo-clipboard": "^6.0.3",
         "jest-fixed-jsdom": "^0.0.10"
       },
       "devDependencies": {
@@ -65,6 +66,7 @@
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/slider": "4.5.4",
         "expo": "54.0.7",
+        "expo-clipboard": "^6.0.3",
         "react": "19.1.0",
         "react-native": "0.81.4",
         "react-native-gesture-handler": "~2.28.0",
@@ -12884,6 +12886,15 @@
         "semver": "^7.6.0",
         "temp-dir": "~2.0.0",
         "unique-string": "~2.0.0"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-6.0.3.tgz",
+      "integrity": "sha512-RIKDsuHkYfaspifbFpVC8sBVFKR05L7Pj7mU2/XkbrW9m01OBNvdpGraXEMsTFCx97xMGsZpEw9pPquL4j4xVg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/packages/ui-screens/src/ActivatePaymentScreen.tsx
+++ b/packages/ui-screens/src/ActivatePaymentScreen.tsx
@@ -43,11 +43,15 @@ export const ActivatePaymentScreen: React.FC<ActivatePaymentScreenProps> = ({
   const [step, setStep] = useState<Step>('display');
   const [mnemonic, setMnemonic] = useState(() => generateMnemonic());
   const words = useMemo(() => mnemonic.split(' '), [mnemonic]);
+  const dictionary = useMemo(
+    () => (Array.isArray(WORDLIST) ? WORDLIST : []),
+    [],
+  );
   const [confirmedWords, setConfirmedWords] = useState<string[]>([]);
   const [currentInput, setCurrentInput] = useState('');
   const [inputError, setInputError] = useState<string | null>(null);
   const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
-  const copyTimer = useRef<NodeJS.Timeout | null>(null);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const expectedWord = words[confirmedWords.length] ?? null;
 
@@ -289,7 +293,7 @@ export const ActivatePaymentScreen: React.FC<ActivatePaymentScreenProps> = ({
     if (!prefix) {
       return [expectedWord];
     }
-    const matches = WORDLIST.filter((word) => word.startsWith(prefix));
+    const matches = dictionary.filter((word) => word.startsWith(prefix));
     const ordered = [expectedWord, ...matches];
     const unique: string[] = [];
     for (const word of ordered) {
@@ -299,7 +303,7 @@ export const ActivatePaymentScreen: React.FC<ActivatePaymentScreenProps> = ({
       if (unique.length >= 8) break;
     }
     return unique;
-  }, [currentInput, expectedWord]);
+  }, [currentInput, dictionary, expectedWord]);
 
   const isConfirmationValid = useMemo(
     () =>

--- a/packages/ui-screens/src/types/expo-clipboard.d.ts
+++ b/packages/ui-screens/src/types/expo-clipboard.d.ts
@@ -1,0 +1,3 @@
+declare module 'expo-clipboard' {
+  export function setStringAsync(text: string): Promise<void>;
+}

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -2,6 +2,10 @@ import '@testing-library/react-native';
 import '@hum/i18n';
 (globalThis as any).__DEV__ = true;
 
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
 const originalConsoleError = console.error;
 
 console.error = (...args: unknown[]) => {

--- a/tests/react-native.d.ts
+++ b/tests/react-native.d.ts
@@ -5,6 +5,7 @@ declare module 'react-native' {
   export const Text: React.FC<any>;
   export const Image: React.FC<any>;
   export const Pressable: React.FC<any>;
+  export const TouchableOpacity: React.FC<any>;
   export const KeyboardAvoidingView: React.FC<any>;
   export const Modal: React.FC<any>;
   export const ScrollView: React.FC<any>;
@@ -34,6 +35,7 @@ declare module 'react-native' {
     style?: any;
     [key: string]: any;
   }
+  export interface TouchableOpacityProps extends PressableProps {}
   export const Platform: {
     OS: 'ios' | 'android';
   };


### PR DESCRIPTION
## Summary
- guard ActivatePaymentScreen suggestions against missing mnemonic word lists and use a platform-safe timeout handle
- add a local expo-clipboard type declaration and mock so TypeScript and Jest handle the dependency
- extend the React Native test typings to expose TouchableOpacity used by the screen

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a1db5040832fa1dfabeacf2186d6