### PR TITLE
Fix Storybook build for Expo clipboard and modules

### DIFF
--- a/apps/storybook/src/polyfills/expoEnsureNativeModulesAreInstalled.ts
+++ b/apps/storybook/src/polyfills/expoEnsureNativeModulesAreInstalled.ts
@@ -1,0 +1,4 @@
+export function ensureNativeModulesAreInstalled(): void {
+  // Expo modules are not available in Storybook's web runtime.
+  // The native module installation step is therefore a no-op.
+}

--- a/apps/storybook/src/polyfills/react-native-web.ts
+++ b/apps/storybook/src/polyfills/react-native-web.ts
@@ -1,0 +1,8 @@
+export * from 'react-native-web';
+export { default } from 'react-native-web';
+
+export const TurboModuleRegistry = {
+  get() {
+    return null;
+  },
+};

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -16,14 +16,67 @@ export default defineConfig({
   plugins: [
     svgr({ include: '**/*.svg', svgrOptions: { exportType: 'default' } }),
     react(),
+    {
+      name: 'expo-clipboard-paste-button-jsx-fix',
+      enforce: 'pre',
+      transform(code, id) {
+        if (
+          id.includes(
+            'node_modules/expo-clipboard/build/ClipboardPasteButton.js',
+          )
+        ) {
+          return {
+            code: code.replace(
+              'return <ExpoClipboardPasteButton onPastePressed={onPastePressed} {...restProps}/>;',
+              'return React.createElement(ExpoClipboardPasteButton, { onPastePressed, ...restProps });',
+            ),
+            map: null,
+          };
+        }
+        return null;
+      },
+    },
+    {
+      name: 'expo-ensure-native-modules-polyfill',
+      enforce: 'pre',
+      transform(code, id) {
+        if (
+          id.includes('node_modules/expo-modules-core/src/') &&
+          code.includes("import { TurboModuleRegistry } from 'react-native';")
+        ) {
+          return {
+            code: code.replace(
+              "import { TurboModuleRegistry } from 'react-native';",
+              'const TurboModuleRegistry = { get: () => null };',
+            ),
+            map: null,
+          };
+        }
+        return null;
+      },
+    },
   ],
   resolve: {
     alias: {
-      'react-native': 'react-native-web',
+      'react-native': r('./src/polyfills/react-native-web.ts'),
       '@hum/ui-components': r('../../packages/ui-components/src'),
       '@hum/ui-components/': r('../../packages/ui-components/src/'),
       '@hum/ui-screens': r('../../packages/ui-screens'),
       '@hum/ui-screens/': r('../../packages/ui-screens/'),
+      '@hum/breeze-payment-client': r(
+        '../../packages/breeze-payment-client/index.ts',
+      ),
+      '@hum/breeze-payment-client/': r(
+        '../../packages/breeze-payment-client/src/',
+      ),
+      '@hum/payment-client': r('../../packages/payment-client/index.ts'),
+      '@hum/payment-client/': r('../../packages/payment-client/src/'),
+      'expo-modules-core/src/ensureNativeModulesAreInstalled': r(
+        './src/polyfills/expoEnsureNativeModulesAreInstalled.ts',
+      ),
+      'expo-modules-core/build/ensureNativeModulesAreInstalled': r(
+        './src/polyfills/expoEnsureNativeModulesAreInstalled.ts',
+      ),
       'react-native-safe-area-context': r(
         './react-native-safe-area-context.tsx',
       ),

--- a/types/react-native-web.d.ts
+++ b/types/react-native-web.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-native-web';


### PR DESCRIPTION
## Summary
- add vite transforms and aliases so Storybook can bundle Expo clipboard and payment client dependencies
- polyfill Expo native module installation calls and react-native TurboModuleRegistry for the Storybook web runtime
- add a react-native-web module declaration to satisfy TypeScript

## Testing
- npm run build --workspace @hum/storybook
- npm run typecheck
- npm run lint
- cargo check --manifest-path native/rust/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68d7acac7350832faf10dcf7593a4079