### PR TITLE
refactor: use theme styles on payment screens

### DIFF
--- a/packages/ui-screens/src/ActivatePaymentScreen.tsx
+++ b/packages/ui-screens/src/ActivatePaymentScreen.tsx
@@ -95,6 +95,12 @@ export const ActivatePaymentScreen: React.FC<ActivatePaymentScreenProps> = ({
       wordBadge: {
         gap: spacing.xs,
       } satisfies ViewStyle,
+      wordContent: {
+        backgroundColor: colors.muted,
+        paddingVertical: spacing.sm,
+        paddingHorizontal: spacing.md,
+        borderRadius: radius.lg,
+      } satisfies ViewStyle,
       wordIndex: {
         color: colors.mutedForeground,
         fontSize: type.size.sm,
@@ -129,6 +135,11 @@ export const ActivatePaymentScreen: React.FC<ActivatePaymentScreenProps> = ({
         backgroundColor: colors.background,
         marginBottom: BOTTOM_BAR_HEIGHT,
       } satisfies ViewStyle,
+      buttonLabel: {
+        color: colors.humPrimaryForeground,
+        fontSize: type.size.base,
+        fontWeight: type.weight.bold,
+      } satisfies TextStyle,
     }),
     [colors, insets.bottom, radius, spacing, type],
   );
@@ -215,7 +226,7 @@ export const ActivatePaymentScreen: React.FC<ActivatePaymentScreenProps> = ({
                     <Text style={themedStyles.wordIndex}>
                       {(index + 1).toString().padStart(2, '0')}
                     </Text>
-                    <View style={styles.wordContent}>
+                    <View style={themedStyles.wordContent}>
                       <Text style={themedStyles.wordValue}>{word}</Text>
                     </View>
                   </View>
@@ -261,7 +272,7 @@ export const ActivatePaymentScreen: React.FC<ActivatePaymentScreenProps> = ({
               )}
               onPress={handleContinue}
             >
-              <Text style={styles.buttonLabel}>
+              <Text style={themedStyles.buttonLabel}>
                 {t('payments.activate.actions.confirm_written')}
               </Text>
             </Button>
@@ -284,16 +295,6 @@ const styles = StyleSheet.create({
   flex: { flex: 1 },
   wordBadge: {
     minWidth: 110,
-  },
-  wordContent: {
-    backgroundColor: 'rgba(255,255,255,0.04)',
-    paddingVertical: 8,
-    paddingHorizontal: 12,
-    borderRadius: 12,
-  },
-  buttonLabel: {
-    color: '#FFFFFF',
-    fontWeight: '600',
   },
 });
 

--- a/packages/ui-screens/src/ConfirmMnemonicScreen.tsx
+++ b/packages/ui-screens/src/ConfirmMnemonicScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ScrollView,
-  StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
@@ -167,6 +166,11 @@ export const ConfirmMnemonicScreen: React.FC<ConfirmMnemonicScreenProps> = ({
         backgroundColor: colors.background,
         marginBottom: keyboardVisible ? 0 : bottomOffset,
       } satisfies ViewStyle,
+      buttonLabel: {
+        color: colors.humPrimaryForeground,
+        fontSize: type.size.base,
+        fontWeight: type.weight.bold,
+      } satisfies TextStyle,
     }),
     [
       bottomOffset,
@@ -424,7 +428,7 @@ export const ConfirmMnemonicScreen: React.FC<ConfirmMnemonicScreenProps> = ({
           onPress={onComplete}
           testID="activate-wallet"
         >
-          <Text style={styles.buttonLabel}>
+          <Text style={themedStyles.buttonLabel}>
             {t('payments.activate.actions.finish')}
           </Text>
         </Button>
@@ -432,12 +436,5 @@ export const ConfirmMnemonicScreen: React.FC<ConfirmMnemonicScreenProps> = ({
     </View>
   );
 };
-
-const styles = StyleSheet.create({
-  buttonLabel: {
-    color: '#FFFFFF',
-    fontWeight: '600',
-  },
-});
 
 export default ConfirmMnemonicScreen;

--- a/packages/ui-screens/src/PaymentScreen.tsx
+++ b/packages/ui-screens/src/PaymentScreen.tsx
@@ -188,6 +188,11 @@ export const PaymentScreen: React.FC<PaymentScreenProps> = ({
       counterparty: {
         color: colors.mutedForeground,
       } satisfies TextStyle,
+      buttonLabel: {
+        color: colors.humPrimaryForeground,
+        fontSize: type.size.base,
+        fontWeight: type.weight.bold,
+      } satisfies TextStyle,
     }),
     [colors, insets.bottom, radius, spacing, type],
   );
@@ -426,7 +431,9 @@ export const PaymentScreen: React.FC<PaymentScreenProps> = ({
             }}
             testID="activate-payments"
           >
-            <Text style={styles.buttonLabel}>{t('payments.activate.cta')}</Text>
+            <Text style={themedStyles.buttonLabel}>
+              {t('payments.activate.cta')}
+            </Text>
           </Button>
         </View>
       )}
@@ -442,7 +449,9 @@ export const PaymentScreen: React.FC<PaymentScreenProps> = ({
             accessibilityLabel={t('payments.errors.retry')}
             onPress={handleRetry}
           >
-            <Text style={styles.buttonLabel}>{t('payments.errors.retry')}</Text>
+            <Text style={themedStyles.buttonLabel}>
+              {t('payments.errors.retry')}
+            </Text>
           </Button>
         </View>
       )}
@@ -593,10 +602,6 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingHorizontal: 24,
     gap: 16,
-  },
-  buttonLabel: {
-    color: '#FFFFFF',
-    fontWeight: '600',
   },
   cardBase: {
     borderWidth: 1,


### PR DESCRIPTION
## Summary
- replace the mnemonic badge background with theme-aware colors in the activation flow
- switch payment-related button labels to use theme typography and colors for better contrast consistency

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68da3b0e4000832fad08635cb1aca280