### PR TITLE
Add coverage tests for payments flow

### DIFF
--- a/packages/breeze-payment-client/src/__tests__/client.test.ts
+++ b/packages/breeze-payment-client/src/__tests__/client.test.ts
@@ -1,0 +1,219 @@
+import type { PaymentEvent } from '@hum/payment-client';
+import { PaymentError } from '@hum/payment-client';
+import type {
+  Payment as BreezPayment,
+  PreparePayOnchainResponse,
+  RecommendedFees,
+  SdkEvent,
+  SendPaymentResponse,
+} from '@breeztech/react-native-breez-sdk-liquid';
+
+const mockSdk = {
+  defaultConfig: jest.fn<Promise<{ base: string }>, [string, string]>(),
+  connect: jest.fn<Promise<void>, [Record<string, unknown>]>(),
+  disconnect: jest.fn<Promise<void>, []>(),
+  addEventListener: jest.fn<Promise<string>, [(event: SdkEvent) => void]>(),
+  removeEventListener: jest.fn<Promise<void>, [string]>(),
+  setLogger: jest.fn<
+    Promise<{ remove: () => void }>,
+    [((entry: { level: string; line: string }) => void) | undefined]
+  >(),
+  getInfo: jest.fn<
+    Promise<{
+      walletInfo: {
+        balanceSat: number;
+        pendingReceiveSat: number;
+        pendingSendSat: number;
+        assetBalances: Array<{
+          assetId?: string;
+          ticker?: string;
+          balanceSat: number;
+        }>;
+        pubkey: string;
+      };
+    }>,
+    []
+  >(),
+  prepareReceivePayment: jest.fn(),
+  receivePayment: jest.fn(),
+  prepareSendPayment: jest.fn(),
+  sendPayment: jest.fn(),
+  preparePayOnchain: jest.fn<Promise<PreparePayOnchainResponse>, [unknown]>(),
+  payOnchain: jest.fn<Promise<SendPaymentResponse>, [unknown]>(),
+  recommendedFees: jest.fn<Promise<RecommendedFees>, []>(),
+  listPayments: jest.fn<Promise<BreezPayment[]>, [unknown]>(),
+  parseInvoice: jest.fn(),
+};
+
+jest.mock('@breeztech/react-native-breez-sdk-liquid', () => mockSdk, {
+  virtual: true,
+});
+
+const resetSdkMocks = () => {
+  for (const value of Object.values(mockSdk)) {
+    if ('mockReset' in value) {
+      value.mockReset();
+    }
+  }
+};
+
+const loadModule = async (nativeModules: Record<string, unknown>) => {
+  jest.resetModules();
+  jest.doMock('react-native', () => ({
+    __esModule: true,
+    ...jest.requireActual('react-native'),
+    NativeModules: nativeModules,
+  }));
+  return import('../client');
+};
+
+describe('BreezePaymentClient', () => {
+  beforeEach(() => {
+    resetSdkMocks();
+    delete (global as { __turboModuleProxy?: unknown }).__turboModuleProxy;
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('throws when the Breez native module is missing', async () => {
+    const { createBreezePaymentClient } = await loadModule({});
+    expect(() =>
+      createBreezePaymentClient({ apiKey: 'key', mnemonic: 'seed words' }),
+    ).toThrow(
+      new PaymentError(
+        'UNSUPPORTED',
+        'Breez payments require a custom native build. Run the app from a dev build or standalone build to enable payments.',
+      ),
+    );
+  });
+
+  it('initializes, fetches data, handles events, and tears down cleanly', async () => {
+    const events: PaymentEvent[] = [];
+    const { BreezePaymentClientImpl } = await loadModule({
+      RNBreezSDKLiquid: {},
+    });
+
+    mockSdk.defaultConfig.mockResolvedValue({ base: 'config' });
+    mockSdk.connect.mockResolvedValue(undefined);
+    mockSdk.disconnect.mockResolvedValue(undefined);
+    mockSdk.setLogger.mockResolvedValue({ remove: jest.fn() });
+    let eventHandler: ((ev: SdkEvent) => void) | undefined;
+    mockSdk.addEventListener.mockImplementation(
+      async (handler: (ev: SdkEvent) => void) => {
+        eventHandler = handler;
+        return 'listener-id';
+      },
+    );
+    mockSdk.removeEventListener.mockResolvedValue(undefined);
+    mockSdk.getInfo.mockResolvedValue({
+      walletInfo: {
+        balanceSat: 1_000,
+        pendingReceiveSat: 25,
+        pendingSendSat: 5,
+        assetBalances: [
+          { assetId: 'USDt', balanceSat: 200 },
+          { ticker: 'EURx', balanceSat: 50 },
+        ],
+        pubkey: 'pub',
+      },
+    });
+    const breezPayment: BreezPayment = {
+      amountSat: 500,
+      feesSat: 0,
+      paymentType: 'receive',
+      status: 'complete',
+      timestamp: 100,
+      details: {
+        type: 'lightning',
+        swapId: 'swap-1',
+        description: 'invoice',
+        invoice: 'lnbc',
+        paymentHash: 'hash',
+      },
+      txId: 'p1',
+    };
+    mockSdk.listPayments.mockResolvedValue([breezPayment]);
+    mockSdk.recommendedFees.mockResolvedValue({
+      fastestFee: 3.4,
+      halfHourFee: 2.2,
+      hourFee: 1.1,
+      economyFee: 0.9,
+      minimumFee: 0.5,
+    });
+    mockSdk.preparePayOnchain.mockResolvedValue({
+      receiverAmountSat: 10,
+      claimFeesSat: 1,
+      totalFeesSat: 1,
+    });
+    mockSdk.payOnchain.mockResolvedValue({
+      payment: {
+        amountSat: 10,
+        feesSat: 1,
+        paymentType: 'send',
+        status: 'complete',
+        timestamp: Date.now(),
+        txId: 'tx123',
+        details: {
+          type: 'bitcoin',
+          swapId: 'swap-2',
+          bitcoinAddress: 'addr',
+          description: 'withdrawal',
+        },
+      },
+    });
+
+    const client = new BreezePaymentClientImpl({
+      apiKey: 'key',
+      mnemonic: 'seed words',
+    });
+    const unsubscribe = client.on((event) => events.push(event));
+
+    await client.init({ network: 'testnet', logger: jest.fn() });
+
+    expect(mockSdk.defaultConfig).toHaveBeenCalledWith('testnet', 'key');
+    expect(mockSdk.connect).toHaveBeenCalled();
+
+    const balances = await client.getBalances();
+    expect(balances).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ asset: 'L-BTC', spendable: 1_000n }),
+        expect.objectContaining({ asset: 'USDt', spendable: 200n }),
+      ]),
+    );
+
+    const history = await client.listPayments({
+      limit: 1,
+      status: ['SUCCEEDED'],
+    });
+    expect(mockSdk.listPayments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 1,
+        states: expect.arrayContaining(['complete']),
+      }),
+    );
+    expect(history.items).toHaveLength(1);
+
+    const fees = await client.estimateFees('withdraw', {
+      sats: 10n,
+      asset: 'L-BTC',
+    });
+    expect(fees.fast).toBe(3n);
+
+    const tx = await client.withdrawOnchain({
+      address: 'addr',
+      amount: { sats: 10n, asset: 'L-BTC' },
+    });
+    expect(tx).toEqual({ txid: 'tx123' });
+
+    await eventHandler?.({ type: 'synced' });
+    await eventHandler?.({ type: 'paymentSucceeded', details: breezPayment });
+    expect(events.some((ev) => ev.type === 'CONNECTIVITY')).toBe(true);
+    expect(events.some((ev) => ev.type === 'PAYMENT_UPDATED')).toBe(true);
+
+    await client.destroy();
+    unsubscribe();
+    expect(mockSdk.disconnect).toHaveBeenCalled();
+  });
+});

--- a/packages/ui-screens/src/__tests__/ActivatePaymentScreen.test.tsx
+++ b/packages/ui-screens/src/__tests__/ActivatePaymentScreen.test.tsx
@@ -1,0 +1,265 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  waitFor,
+  type RenderAPI,
+} from '@testing-library/react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { ActivatePaymentScreen } from '../ActivatePaymentScreen';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+const translationMock = {
+  t: (key: string) => key,
+};
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => translationMock,
+}));
+
+type MockButtonProps = {
+  children: React.ReactNode;
+  onPress?: () => void;
+  disabled?: boolean;
+  testID?: string;
+  accessibilityLabel?: string;
+};
+
+type MockTopBarProps = {
+  title: string;
+};
+
+jest.mock('@hum/ui-components', () => ({
+  __esModule: true,
+  Button: ({
+    children,
+    onPress,
+    disabled,
+    testID,
+    accessibilityLabel,
+  }: MockButtonProps) => (
+    <TouchableOpacity
+      accessibilityLabel={accessibilityLabel}
+      disabled={disabled}
+      onPress={disabled ? undefined : onPress}
+      testID={testID}
+    >
+      <Text>{children}</Text>
+    </TouchableOpacity>
+  ),
+  Icon: ({ name }: { name: string }) => <Text>{name}</Text>,
+  TopBar: ({ title }: MockTopBarProps) => (
+    <View>
+      <Text>{title}</Text>
+    </View>
+  ),
+  useTheme: () => ({
+    colors: {
+      background: '#000',
+      foreground: '#fff',
+      mutedForeground: '#ccc',
+      muted: '#222',
+      card: '#111',
+      border: '#333',
+      humPrimary: '#f80',
+    },
+    spacing: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 },
+    radius: { lg: 12 },
+    type: {
+      size: { base: 14, sm: 12, md: 16, lg: 18, '2xl': 24 },
+      weight: { medium: '500' },
+    },
+  }),
+}));
+
+const confirmProps: {
+  onComplete?: () => void;
+  mnemonic?: string;
+  dictionary?: string[];
+  bottomOffset?: number;
+} = {};
+
+function ConfirmMock(props: {
+  mnemonic: string;
+  dictionary: string[];
+  onComplete: () => void;
+  bottomOffset: number;
+}) {
+  Object.assign(confirmProps, props);
+  return (
+    <View testID="confirm-mnemonic">
+      <Text>confirm</Text>
+      <TouchableOpacity testID="complete-confirm" onPress={props.onComplete}>
+        <Text>complete</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+jest.mock('../ConfirmMnemonicScreen', () => ({
+  __esModule: true,
+  ConfirmMnemonicScreen: ConfirmMock,
+  default: ConfirmMock,
+}));
+
+const clipboardMock = jest.fn();
+
+jest.mock('expo-clipboard', () => ({
+  __esModule: true,
+  setStringAsync: (...args: unknown[]) => clipboardMock(...args),
+}));
+
+const generateMnemonic = jest.fn();
+
+jest.mock('../utils/mnemonic', () => ({
+  __esModule: true,
+  WORDLIST: ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'nu', 'xi'],
+  generateMnemonic: () => generateMnemonic(),
+}));
+
+const extractText = (node: unknown): string => {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(extractText).join('');
+  }
+  if (typeof node === 'object' && 'props' in node) {
+    return extractText(
+      (node as { props?: { children?: unknown } }).props?.children,
+    );
+  }
+  return '';
+};
+
+const getTextContent = (element: { props?: { children?: unknown } }) =>
+  extractText(element.props?.children);
+
+const findByTextContent = async (api: RenderAPI, text: string) => {
+  await waitFor(() => {
+    expect(api.UNSAFE_queryAllByProps({ children: text })).not.toHaveLength(0);
+  });
+  return api.UNSAFE_getByProps({ children: text });
+};
+
+const getByTextContent = (api: RenderAPI, text: string) =>
+  api.UNSAFE_getByProps({ children: text });
+
+const findByTestID = async (api: RenderAPI, testID: string) => {
+  await waitFor(() => {
+    expect(api.UNSAFE_queryByProps({ testID })).not.toBeNull();
+  });
+  return api.UNSAFE_getByProps({ testID });
+};
+
+const getByTestID = (api: RenderAPI, testID: string) =>
+  api.UNSAFE_getByProps({ testID });
+
+describe('ActivatePaymentScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    confirmProps.onComplete = undefined;
+    confirmProps.mnemonic = undefined;
+    confirmProps.dictionary = undefined;
+    confirmProps.bottomOffset = undefined;
+    generateMnemonic.mockReset();
+    generateMnemonic
+      .mockReturnValueOnce(
+        'alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu',
+      )
+      .mockReturnValue(
+        'nu xi omicron pi rho sigma tau upsilon phi chi psi omega',
+      );
+  });
+
+  it('copies the mnemonic and resets the copy label after a timeout', async () => {
+    clipboardMock.mockResolvedValue(undefined);
+    const screen = render(<ActivatePaymentScreen onActivated={jest.fn()} />);
+
+    await act(async () => {
+      fireEvent.press(
+        getByTextContent(screen, 'payments.activate.actions.copy'),
+      );
+    });
+
+    expect(clipboardMock).toHaveBeenCalledWith(
+      'alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu',
+    );
+    await findByTextContent(screen, 'payments.activate.actions.copied');
+  });
+
+  it('regenerates the mnemonic and resets copy state', () => {
+    clipboardMock.mockResolvedValue(undefined);
+    const screen = render(<ActivatePaymentScreen onActivated={jest.fn()} />);
+
+    const firstWord = getTextContent(getByTestID(screen, 'mnemonic-word-1'));
+    expect(firstWord).toContain('alpha');
+
+    fireEvent.press(getByTextContent(screen, 'payments.activate.actions.copy'));
+    fireEvent.press(
+      getByTextContent(screen, 'payments.activate.actions.regenerate'),
+    );
+
+    const regeneratedWord = getTextContent(
+      getByTestID(screen, 'mnemonic-word-1'),
+    );
+    expect(regeneratedWord).toContain('nu');
+    expect(
+      getByTextContent(screen, 'payments.activate.actions.copy'),
+    ).toBeTruthy();
+  });
+
+  it('enters confirmation step and completes activation', async () => {
+    const onActivated = jest.fn();
+    const screen = render(<ActivatePaymentScreen onActivated={onActivated} />);
+
+    fireEvent.press(
+      getByTextContent(screen, 'payments.activate.actions.confirm_written'),
+    );
+
+    await findByTestID(screen, 'confirm-mnemonic');
+
+    expect(confirmProps.mnemonic).toBeDefined();
+    expect(confirmProps.dictionary).toEqual([
+      'alpha',
+      'beta',
+      'gamma',
+      'delta',
+      'epsilon',
+      'nu',
+      'xi',
+    ]);
+    expect(confirmProps.bottomOffset).toBe(72);
+
+    fireEvent.press(getByTestID(screen, 'complete-confirm'));
+    expect(onActivated).toHaveBeenCalledWith(
+      'alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu',
+    );
+  });
+
+  it('warns when copying fails', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    clipboardMock.mockRejectedValueOnce(new Error('boom'));
+
+    const screen = render(<ActivatePaymentScreen onActivated={jest.fn()} />);
+
+    fireEvent.press(getByTextContent(screen, 'payments.activate.actions.copy'));
+
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[ActivatePaymentScreen] copy failed',
+        expect.any(Error),
+      );
+      expect(
+        getByTextContent(screen, 'payments.activate.actions.copy'),
+      ).toBeTruthy();
+    });
+
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/ui-screens/src/__tests__/ConfirmMnemonicScreen.test.tsx
+++ b/packages/ui-screens/src/__tests__/ConfirmMnemonicScreen.test.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import { Text, TouchableOpacity } from 'react-native';
+import * as ReactNative from 'react-native';
+import { ConfirmMnemonicScreen } from '../ConfirmMnemonicScreen';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+const translationMock = {
+  t: (key: string, params?: Record<string, unknown>) =>
+    params && 'word' in params ? `${key}:${String(params.word)}` : key,
+};
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => translationMock,
+}));
+
+type MockButtonProps = {
+  children: React.ReactNode;
+  onPress?: () => void;
+  disabled?: boolean;
+  testID?: string;
+  accessibilityLabel?: string;
+};
+
+jest.mock('@hum/ui-components', () => ({
+  __esModule: true,
+  Button: ({
+    children,
+    onPress,
+    disabled,
+    testID,
+    accessibilityLabel,
+  }: MockButtonProps) => (
+    <TouchableOpacity
+      accessibilityLabel={accessibilityLabel}
+      accessibilityState={{ disabled: !!disabled }}
+      disabled={disabled}
+      onPress={disabled ? undefined : onPress}
+      testID={testID}
+    >
+      <Text>{children}</Text>
+    </TouchableOpacity>
+  ),
+  useTheme: () => ({
+    colors: {
+      background: '#000',
+      foreground: '#fff',
+      mutedForeground: '#ccc',
+      card: '#111',
+      border: '#222',
+      destructive: '#f00',
+    },
+    spacing: { xs: 2, sm: 4, md: 8, lg: 12, xl: 16 },
+    radius: { lg: 12 },
+    type: {
+      size: { base: 14, sm: 12 },
+      weight: { medium: '500' },
+    },
+  }),
+}));
+
+const dictionary = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'];
+
+const getTextContent = (
+  node: { props?: { children?: unknown } } | undefined,
+): string => {
+  const children = node?.props?.children;
+  if (children == null) return '';
+  if (typeof children === 'string' || typeof children === 'number') {
+    return String(children);
+  }
+  if (Array.isArray(children)) {
+    return children
+      .map((child) =>
+        getTextContent(
+          typeof child === 'object' && child != null
+            ? (child as { props?: { children?: unknown } })
+            : { props: { children: child } },
+        ),
+      )
+      .join('');
+  }
+  if (typeof children === 'object' && children != null) {
+    return getTextContent(children as { props?: { children?: unknown } });
+  }
+  return '';
+};
+
+describe('ConfirmMnemonicScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('commits words with whitespace-separated input and finishes successfully', () => {
+    const onComplete = jest.fn();
+    const screen = render(
+      <ConfirmMnemonicScreen
+        mnemonic="alpha beta gamma"
+        dictionary={dictionary}
+        onComplete={onComplete}
+      />,
+    );
+
+    const input = screen.getByLabelText(
+      'payments.activate.confirmation.placeholder',
+    );
+    fireEvent.changeText(input, 'alpha ');
+    let chips = screen.getAllByLabelText(
+      'payments.activate.confirmation.remove_word',
+    );
+    expect(chips).toHaveLength(1);
+    expect(getTextContent(chips[0])).toContain('alpha');
+
+    fireEvent.changeText(input, 'beta ');
+    chips = screen.getAllByLabelText(
+      'payments.activate.confirmation.remove_word',
+    );
+    expect(chips).toHaveLength(2);
+    expect(getTextContent(chips[1])).toContain('beta');
+
+    fireEvent.changeText(input, 'gamma');
+    fireEvent(input, 'submitEditing');
+    chips = screen.getAllByLabelText(
+      'payments.activate.confirmation.remove_word',
+    );
+    expect(chips).toHaveLength(3);
+    expect(getTextContent(chips[2])).toContain('gamma');
+
+    const finish = screen.UNSAFE_getByProps({
+      accessibilityLabel: 'payments.activate.actions.finish',
+    });
+    fireEvent.press(finish);
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it('shows validation errors and suggestion ordering', () => {
+    const screen = render(
+      <ConfirmMnemonicScreen
+        mnemonic="alpha beta gamma"
+        dictionary={[...dictionary, 'alphabet']}
+        onComplete={jest.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(
+      'payments.activate.confirmation.placeholder',
+    );
+    fireEvent.changeText(input, 'wrong ');
+    const error = screen.getByLabelText(
+      'payments.activate.confirmation.invalid_word:wrong',
+    );
+    expect(getTextContent(error)).toContain('wrong');
+
+    fireEvent.changeText(input, 'a');
+    expect(
+      screen.getByLabelText(
+        'payments.activate.confirmation.use_suggestion:alpha',
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByLabelText(
+        'payments.activate.confirmation.use_suggestion:alphabet',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('removes confirmed words on chip press', () => {
+    const screen = render(
+      <ConfirmMnemonicScreen
+        mnemonic="alpha beta"
+        dictionary={dictionary}
+        onComplete={jest.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(
+      'payments.activate.confirmation.placeholder',
+    );
+    fireEvent.changeText(input, 'alpha ');
+    fireEvent.changeText(input, 'beta ');
+
+    const [firstChip] = screen.getAllByLabelText(
+      'payments.activate.confirmation.remove_word',
+    );
+    fireEvent.press(firstChip);
+    expect(screen.queryByText('01 alpha')).toBeNull();
+    expect(
+      screen.getByLabelText('payments.activate.confirmation.placeholder').props
+        .value,
+    ).toBe('');
+  });
+
+  it('registers keyboard listeners when available', () => {
+    const removeShow = jest.fn();
+    const removeHide = jest.fn();
+    const addListener = jest
+      .fn()
+      .mockImplementation((event: string) =>
+        event === 'keyboardDidShow'
+          ? { remove: removeShow }
+          : { remove: removeHide },
+      );
+    const reactNativeModule = ReactNative as unknown as {
+      Keyboard?: { addListener: typeof addListener };
+    };
+    reactNativeModule.Keyboard = {
+      addListener,
+    };
+
+    const { unmount } = render(
+      <ConfirmMnemonicScreen
+        mnemonic="alpha beta"
+        dictionary={dictionary}
+        onComplete={jest.fn()}
+      />,
+    );
+
+    expect(addListener).toHaveBeenCalledWith(
+      'keyboardDidShow',
+      expect.any(Function),
+    );
+    expect(addListener).toHaveBeenCalledWith(
+      'keyboardDidHide',
+      expect.any(Function),
+    );
+
+    unmount();
+    expect(removeShow).toHaveBeenCalled();
+    expect(removeHide).toHaveBeenCalled();
+  });
+});

--- a/packages/ui-screens/src/__tests__/PaymentScreen.test.tsx
+++ b/packages/ui-screens/src/__tests__/PaymentScreen.test.tsx
@@ -1,0 +1,347 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  waitFor,
+  type RenderAPI,
+} from '@testing-library/react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import type { Payment, PaymentClient, PaymentEvent } from '@hum/payment-client';
+import { PaymentScreen } from '../PaymentScreen';
+
+const mockCreateClient = jest.fn();
+
+const textContent = (node: { props?: { children?: unknown } }): string => {
+  const children = node.props?.children;
+  if (Array.isArray(children)) {
+    return children.join('');
+  }
+  return children != null ? String(children) : '';
+};
+const findByTestID = async (api: RenderAPI, testID: string) => {
+  await waitFor(() => {
+    expect(api.UNSAFE_queryByProps({ testID })).not.toBeNull();
+  });
+  return api.UNSAFE_getByProps({ testID });
+};
+
+const getByTestID = (api: RenderAPI, testID: string) =>
+  api.UNSAFE_getByProps({ testID });
+
+const getAllByTestID = (api: RenderAPI, testID: string) =>
+  api.UNSAFE_getAllByProps({ testID });
+
+jest.mock('@hum/breeze-payment-client', () => ({
+  __esModule: true,
+  createBreezePaymentClient: (...args: unknown[]) => mockCreateClient(...args),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+const translationMock = {
+  t: (key: string, params?: Record<string, string | number>) => {
+    if (params) {
+      return `${key}:${Object.entries(params)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(',')}`;
+    }
+    return key;
+  },
+  i18n: { language: 'en' },
+};
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => translationMock,
+}));
+
+type MockButtonProps = {
+  children: React.ReactNode;
+  onPress?: () => void;
+  disabled?: boolean;
+  testID?: string;
+};
+
+type MockTopBarProps = {
+  title: string;
+  onBackPress?: () => void;
+};
+
+jest.mock('@hum/ui-components', () => ({
+  __esModule: true,
+  Button: ({ children, onPress, disabled, testID }: MockButtonProps) => (
+    <TouchableOpacity
+      accessibilityLabel={typeof children === 'string' ? children : undefined}
+      accessibilityState={{ disabled: !!disabled }}
+      disabled={disabled}
+      onPress={disabled ? undefined : onPress}
+      testID={testID}
+    >
+      <Text>{children}</Text>
+    </TouchableOpacity>
+  ),
+  Icon: ({ name }: { name: string }) => (
+    <Text testID={`icon-${name}`}>{name}</Text>
+  ),
+  TopBar: ({ title, onBackPress }: MockTopBarProps) => (
+    <View>
+      <Text>{title}</Text>
+      {onBackPress ? (
+        <TouchableOpacity testID="topbar-back" onPress={onBackPress}>
+          <Text>back</Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  ),
+  useTheme: () => ({
+    colors: {
+      background: '#000',
+      foreground: '#fff',
+      mutedForeground: '#ccc',
+      card: '#111',
+      border: '#222',
+      muted: '#333',
+      humPrimary: '#f80',
+      destructive: '#c00',
+    },
+    spacing: {
+      xs: 2,
+      sm: 4,
+      md: 8,
+      lg: 12,
+      xl: 16,
+    },
+    radius: {
+      lg: 12,
+    },
+    type: {
+      size: { sm: 12, base: 14, lg: 18 },
+      weight: { medium: '500' },
+    },
+  }),
+}));
+
+let lastActivateProps: {
+  onActivated?: (mnemonic: string) => void;
+  onBack?: () => void;
+} | null = null;
+
+jest.mock('../ActivatePaymentScreen', () => ({
+  __esModule: true,
+  default: (props: {
+    onActivated: (mnemonic: string) => void;
+    onBack: () => void;
+  }) => {
+    lastActivateProps = props;
+    return (
+      <View testID="mock-activate-screen">
+        <Text>activation</Text>
+        <TouchableOpacity
+          testID="mock-activation-complete"
+          onPress={() => props.onActivated('fresh mnemonic')}
+        >
+          <Text>complete</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  },
+}));
+
+interface MockClient extends PaymentClient {
+  __emit?: (event: PaymentEvent) => void;
+  __unsubscribe?: jest.Mock;
+}
+
+const createMockClient = (overrides: Partial<MockClient> = {}): MockClient => {
+  let listener: ((event: PaymentEvent) => void) | null = null;
+  const unsubscribe = jest.fn(() => {
+    listener = null;
+  });
+  const client: MockClient = {
+    init: jest.fn().mockResolvedValue(undefined),
+    destroy: jest.fn().mockResolvedValue(undefined),
+    getBalances: jest.fn().mockResolvedValue([]),
+    listPayments: jest.fn().mockResolvedValue({ items: [] }),
+    on: jest.fn((fn: (ev: PaymentEvent) => void) => {
+      listener = fn;
+      return unsubscribe;
+    }),
+    capabilities: jest.fn(() => new Set()),
+    createInvoice: jest.fn(),
+    decodeInvoice: jest.fn(),
+    getNodeInfo: jest.fn(),
+    isReady: jest.fn(() => true),
+    network: jest.fn(() => 'testnet'),
+    payInvoice: jest.fn(),
+    ...overrides,
+  } as unknown as MockClient;
+  client.__emit = (event: PaymentEvent) => {
+    listener?.(event);
+  };
+  client.__unsubscribe = unsubscribe;
+  return client;
+};
+
+describe('PaymentScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lastActivateProps = null;
+  });
+
+  it('shows an error when the API key is missing', async () => {
+    const storage = {
+      getItem: jest.fn().mockResolvedValue('secret'),
+      setItem: jest.fn(),
+    };
+    mockCreateClient.mockImplementation(() => createMockClient());
+
+    const screen = render(<PaymentScreen apiKey="   " storage={storage} />);
+
+    await waitFor(() => {
+      expect(
+        screen.UNSAFE_queryAllByProps({
+          children: 'payments.errors.missing_api_key',
+        }),
+      ).not.toHaveLength(0);
+    });
+    expect(storage.getItem).not.toHaveBeenCalled();
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it('loads balances and payments and updates after events', async () => {
+    const balances = [
+      { asset: 'L-BTC', spendable: 1_500n, pending: 0n },
+      { asset: 'USDt', spendable: 500n, pending: 0n },
+      { asset: 'L-BTC', spendable: 500n, pending: 0n },
+    ];
+    const payments: Payment[] = [
+      {
+        id: 'p-1',
+        amount: { sats: 1_000n, asset: 'L-BTC' },
+        asset: 'L-BTC',
+        counterparty: 'alice',
+        createdAt: 123,
+        updatedAt: 123,
+        description: 'first',
+        direction: 'INBOUND',
+        fee: undefined,
+        rail: 'lightning',
+        status: 'SUCCEEDED',
+        raw: {},
+      },
+    ];
+    const listPayments = jest
+      .fn()
+      .mockResolvedValueOnce({ items: payments })
+      .mockResolvedValueOnce({ items: payments })
+      .mockResolvedValue({ items: payments });
+    const client = createMockClient({
+      getBalances: jest.fn().mockResolvedValue(balances),
+      listPayments,
+    });
+    mockCreateClient.mockReturnValue(client);
+
+    const storage = {
+      getItem: jest.fn().mockResolvedValue('mnemonic words'),
+      setItem: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const screen = render(<PaymentScreen apiKey="api-123" storage={storage} />);
+
+    await findByTestID(screen, 'balance-amount-L-BTC');
+
+    expect(mockCreateClient).toHaveBeenCalledWith({
+      apiKey: 'api-123',
+      mnemonic: 'mnemonic words',
+      workingDir: undefined,
+    });
+    expect(client.init).toHaveBeenCalledWith(
+      expect.objectContaining({ network: 'testnet' }),
+    );
+
+    // Balances combine duplicate assets
+    expect(textContent(getByTestID(screen, 'balance-amount-L-BTC'))).toContain(
+      '2000',
+    );
+    expect(textContent(getByTestID(screen, 'balance-asset-L-BTC'))).toBe(
+      'L-BTC',
+    );
+    expect(textContent(getByTestID(screen, 'balance-amount-USDt'))).toContain(
+      '500',
+    );
+
+    // History renders rows
+    expect(getByTestID(screen, 'payment-row-p-1')).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('payments.history.refresh'));
+    await waitFor(() => {
+      expect(listPayments).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      client.__emit?.({
+        type: 'PAYMENT_UPDATED',
+        payment: {
+          ...payments[0],
+          id: 'p-2',
+          amount: { sats: 2_000n, asset: 'L-BTC' },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(getAllByTestID(screen, 'payment-row-p-1')).toHaveLength(1);
+      expect(getByTestID(screen, 'payment-row-p-2')).toBeTruthy();
+      expect(textContent(getByTestID(screen, 'payment-amount-p-2'))).toContain(
+        '2000',
+      );
+    });
+  });
+
+  it('allows activating payments when inactive', async () => {
+    const client = createMockClient({
+      getBalances: jest.fn().mockResolvedValue([]),
+      listPayments: jest.fn().mockResolvedValue({ items: [] }),
+    });
+    mockCreateClient.mockReturnValue(client);
+
+    const storage = {
+      getItem: jest
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue('fresh mnemonic'),
+      setItem: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const screenInactive = render(
+      <PaymentScreen apiKey="secret" storage={storage} onBack={jest.fn()} />,
+    );
+
+    await findByTestID(screenInactive, 'activate-payments');
+
+    fireEvent.press(getByTestID(screenInactive, 'activate-payments'));
+
+    await findByTestID(screenInactive, 'mock-activate-screen');
+
+    expect(lastActivateProps).not.toBeNull();
+    act(() => {
+      lastActivateProps?.onActivated?.('fresh mnemonic');
+    });
+
+    await waitFor(() => {
+      expect(client.init).toHaveBeenCalled();
+    });
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'payments.mnemonic',
+      'fresh mnemonic',
+    );
+
+    screenInactive.unmount();
+    await waitFor(() => {
+      expect(client.destroy).toHaveBeenCalled();
+    });
+    expect(client.__unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/packages/ui-screens/src/__tests__/SettingsScreen.test.tsx
+++ b/packages/ui-screens/src/__tests__/SettingsScreen.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
+import { SettingsScreen } from '../SettingsScreen';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+const translationMock = {
+  t: (key: string, params?: Record<string, string>) =>
+    params?.defaultValue ?? key,
+};
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => translationMock,
+}));
+
+type MockButtonProps = {
+  children: React.ReactNode;
+  onPress?: () => void;
+  testID?: string;
+  accessibilityLabel?: string;
+};
+
+jest.mock('@hum/ui-components', () => ({
+  __esModule: true,
+  Button: ({
+    children,
+    onPress,
+    testID,
+    accessibilityLabel,
+  }: MockButtonProps) => (
+    <TouchableOpacity
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      testID={testID}
+    >
+      <Text>{children}</Text>
+    </TouchableOpacity>
+  ),
+  Icon: ({ name }: { name: string }) => (
+    <Text testID={`icon-${name}`}>{name}</Text>
+  ),
+  TopBar: ({ title }: { title: string }) => (
+    <View>
+      <Text>{title}</Text>
+    </View>
+  ),
+  useTheme: () => ({
+    colors: {
+      background: '#000',
+      foreground: '#fff',
+      mutedForeground: '#ccc',
+      muted: '#111',
+      border: '#222',
+    },
+    spacing: { sm: 4, md: 8, lg: 12, xl: 16 },
+    radius: { lg: 12 },
+    type: {
+      size: { md: 16, lg: 20, sm: 12 },
+      weight: { medium: '500' },
+    },
+  }),
+  Avatar: ({ children }: { children: React.ReactNode }) => (
+    <View testID="avatar">{children}</View>
+  ),
+  AvatarImage: ({ source }: { source: { uri: string } }) => (
+    <Text testID="avatar-image">{source.uri}</Text>
+  ),
+  AvatarFallback: ({ children }: { children: React.ReactNode }) => (
+    <Text testID="avatar-fallback">{children}</Text>
+  ),
+}));
+
+describe('SettingsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders profile details and handles search input', () => {
+    const screen = render(
+      <SettingsScreen
+        profileName="Alice Bob"
+        profileStatus="Available"
+        profileImageUri="https://example.com/avatar.png"
+      />,
+    );
+
+    expect(screen.UNSAFE_getByProps({ children: 'Alice Bob' })).toBeTruthy();
+    expect(screen.UNSAFE_getByProps({ children: 'Available' })).toBeTruthy();
+    expect(
+      screen.UNSAFE_getByProps({ children: 'https://example.com/avatar.png' }),
+    ).toBeTruthy();
+    expect(screen.UNSAFE_getByProps({ children: 'AB' })).toBeTruthy();
+
+    const search = screen.getByLabelText('actions.search');
+    fireEvent.changeText(search, 'bitcoin');
+    expect(search.props.value).toBe('bitcoin');
+  });
+
+  it('invokes clear storage handler and logs errors', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const successClear = jest.fn().mockResolvedValue(undefined);
+    const failingClear = jest.fn().mockRejectedValue(new Error('nope'));
+
+    const screen = render(<SettingsScreen onClearStorage={successClear} />);
+
+    fireEvent.press(screen.getByLabelText('settings.actions.clear_storage'));
+    await waitFor(() => {
+      expect(successClear).toHaveBeenCalled();
+    });
+
+    screen.rerender(<SettingsScreen onClearStorage={failingClear} />);
+    fireEvent.press(screen.getByLabelText('settings.actions.clear_storage'));
+    await waitFor(() => {
+      expect(failingClear).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[SettingsScreen] clear storage failed',
+        expect.any(Error),
+      );
+    });
+
+    screen.rerender(<SettingsScreen />);
+    expect(() => screen.getByText('Clear payments data')).toThrow();
+
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to initials when profile data missing', () => {
+    const screen = render(<SettingsScreen />);
+
+    expect(
+      screen.UNSAFE_getByProps({ children: 'labels.your_name' }),
+    ).toBeTruthy();
+    expect(
+      screen.UNSAFE_getByProps({ children: 'labels.profile_status_default' }),
+    ).toBeTruthy();
+    expect(screen.UNSAFE_getByProps({ children: 'L' })).toBeTruthy();
+  });
+});

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import type { Chat } from '@hum/ui-screens';
 
 const constantsMock = {
@@ -39,11 +39,27 @@ jest.mock('react-native-gesture-handler', () => {
   };
 });
 
+const asyncStorageMock = {
+  getItem: jest.fn<Promise<string | null>, [string]>(async () => null),
+  setItem: jest.fn<Promise<void>, [string, string]>(async () => undefined),
+  removeItem: jest.fn<Promise<void>, [string]>(async () => undefined),
+};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: asyncStorageMock,
+}));
+
 jest.mock('@hum/ui-components', () => {
   const React = require('react');
   const { View, Text, TouchableOpacity } = require('react-native');
   const themeState = {
     forcedScheme: undefined as 'light' | 'dark' | undefined,
+  };
+  const typographyState = {
+    onScaleIndexChange: undefined as
+      | ((index: number, option: unknown) => void)
+      | undefined,
   };
   const ThemeProvider = ({
     children,
@@ -64,7 +80,9 @@ jest.mock('@hum/ui-components', () => {
     <View>{children}</View>
   );
   const TYPOGRAPHY_SCALE_OPTIONS = [
+    { id: 'sm', multiplier: 0.9, labelKey: 'text_size.small' },
     { id: 'md', multiplier: 1, labelKey: 'text_size.default' },
+    { id: 'lg', multiplier: 1.1, labelKey: 'text_size.large' },
   ] as const;
   const TypographyProvider = ({
     children,
@@ -86,6 +104,7 @@ jest.mock('@hum/ui-components', () => {
         );
         onScaleIndexChange(clamped, TYPOGRAPHY_SCALE_OPTIONS[clamped]);
       }
+      typographyState.onScaleIndexChange = onScaleIndexChange as any;
     }, [initialScaleIndex, onScaleIndexChange]);
     return <>{children}</>;
   };
@@ -140,6 +159,7 @@ jest.mock('@hum/ui-components', () => {
     TypographyProvider,
     TYPOGRAPHY_SCALE_OPTIONS,
     __themeState: themeState,
+    __typographyState: typographyState,
   };
 });
 
@@ -274,15 +294,17 @@ const i18nModule = {
   changeLanguage: jest.fn(),
 };
 
+const translationMock = {
+  t: (key: string) => key,
+  i18n: i18nModule,
+};
+
 jest.mock('react-i18next', () => ({
   __esModule: true,
   I18nextProvider: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
-  useTranslation: () => ({
-    t: (key: string) => key,
-    i18n: i18nModule,
-  }),
+  useTranslation: () => translationMock,
   __mockI18n: i18nModule,
 }));
 
@@ -358,9 +380,20 @@ describe('App', () => {
         getMessages: jest.Mock<Promise<unknown[]>, [string]>;
       };
     };
-  const { __themeState } = require('@hum/ui-components') as {
-    __themeState: { forcedScheme: 'light' | 'dark' | undefined };
-  };
+  const { __themeState, __typographyState, TYPOGRAPHY_SCALE_OPTIONS } =
+    require('@hum/ui-components') as {
+      __themeState: { forcedScheme: 'light' | 'dark' | undefined };
+      __typographyState: {
+        onScaleIndexChange?: (index: number, option: unknown) => void;
+      };
+      TYPOGRAPHY_SCALE_OPTIONS: readonly {
+        id: string;
+        multiplier: number;
+        labelKey: string;
+      }[];
+    };
+  const asyncStorage = (require('@react-native-async-storage/async-storage')
+    .default ?? asyncStorageMock) as typeof asyncStorageMock;
   const { __mockI18n } = require('react-i18next') as {
     __mockI18n: { changeLanguage: jest.Mock };
   };
@@ -376,6 +409,10 @@ describe('App', () => {
     });
     __themeState.forcedScheme = undefined;
     __mockI18n.changeLanguage.mockReset();
+    asyncStorage.getItem.mockResolvedValue(null);
+    asyncStorage.setItem.mockResolvedValue(undefined);
+    asyncStorage.removeItem.mockResolvedValue(undefined);
+    __typographyState.onScaleIndexChange = undefined;
   });
 
   afterAll(() => {
@@ -500,5 +537,72 @@ describe('App', () => {
     fireEvent.press(getByTestId('dev-back'));
     await waitFor(() => expect(queryByTestId('dev-screen')).toBeNull());
     expect(getByTestId('bottom-nav')).toBeTruthy();
+  });
+
+  it('restores and persists typography scale changes', async () => {
+    asyncStorage.getItem.mockResolvedValueOnce('7');
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(asyncStorage.getItem).toHaveBeenCalledWith(
+        'settings.typography.scaleIndex',
+      ),
+    );
+
+    const change = __typographyState.onScaleIndexChange;
+    expect(change).toBeDefined();
+
+    await act(async () => {
+      change?.(0, TYPOGRAPHY_SCALE_OPTIONS[0]);
+    });
+    await waitFor(() =>
+      expect(asyncStorage.setItem).toHaveBeenCalledWith(
+        'settings.typography.scaleIndex',
+        '0',
+      ),
+    );
+
+    await act(async () => {
+      change?.(999, TYPOGRAPHY_SCALE_OPTIONS[2] ?? TYPOGRAPHY_SCALE_OPTIONS[0]);
+    });
+    await waitFor(() =>
+      expect(asyncStorage.setItem).toHaveBeenCalledWith(
+        'settings.typography.scaleIndex',
+        '2',
+      ),
+    );
+  });
+
+  it('clears payments storage and handles failures', async () => {
+    const screen = render(<App />);
+    const getByTestId = (id: string) =>
+      screen.UNSAFE_getByProps({ testID: id });
+
+    fireEvent.press(getByTestId('tab-settings'));
+    const clearButton = await waitFor(() =>
+      screen.UNSAFE_getByProps({ testID: 'clear-storage' }),
+    );
+    fireEvent.press(clearButton);
+
+    await waitFor(() =>
+      expect(asyncStorage.removeItem).toHaveBeenCalledWith('payments.mnemonic'),
+    );
+    await waitFor(() =>
+      expect(getByTestId('active-tab').props.children).toBe('payments'),
+    );
+
+    asyncStorage.removeItem.mockRejectedValueOnce(new Error('fail'));
+    fireEvent.press(getByTestId('tab-settings'));
+    const retryButton = await waitFor(() =>
+      screen.UNSAFE_getByProps({ testID: 'clear-storage' }),
+    );
+    fireEvent.press(retryButton);
+    await waitFor(() =>
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[App] clear payments storage failed',
+        expect.any(Error),
+      ),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add comprehensive tests for the payments screen covering initialization, balance rendering, refresh handling, and activation flow
- exercise activate/confirm mnemonic and settings screens for clipboard actions, validation, search, and storage clearing behaviors
- add Breez client integration tests plus extend the mobile app test to cover typography persistence and payments storage clearing

## Testing
- npm run lint -- --max-warnings=0
- npm test -- --runInBand --runTestsByPath packages/ui-screens/src/__tests__/PaymentScreen.test.tsx packages/ui-screens/src/__tests__/ActivatePaymentScreen.test.tsx packages/ui-screens/src/__tests__/ConfirmMnemonicScreen.test.tsx packages/ui-screens/src/__tests__/SettingsScreen.test.tsx packages/breeze-payment-client/src/__tests__/client.test.ts tests/App.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68d7c697f294832f89efe7301dccd3a6